### PR TITLE
Add support for Drupal autocomplete form elements.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -415,7 +415,7 @@ class DrupalContext extends MinkContext implements DrupalAwareInterface, Transla
    * @When /^(?:|I )press the "(?P<button>[^"]*)" button$/
    */
   public function pressButton($button) {
-    // Wait for any open autocomplete boxes to finish closint.  They block
+    // Wait for any open autocomplete boxes to finish closing.  They block
     // form-submission if they are still open.
     // Use a step 'I press the "Esc" key in the "LABEL" field' to close
     // autocomplete suggestion boxes with Mink.  "Click" events on the


### PR DESCRIPTION
Drupal's autocomplete is awfully incompatible with Mink.  While it is easy to open an autocomplete suggestion box with `setValue()` or '_I fill in "LABEL" with "VALUE"_', it is impossible to close the resulting autocomplete suggestion box without writing tricky custom code or something really ugly like '_Press "save", Wait for one second, Press "save"_'.

And if the autocomplete suggestion boxes are not closed, then form-submission fails, because they are blocked by Drupal's `autocomplete.js`.

This patch introduces two methods to improve the situation:
1.  `pressButton($button)` overrides `MinkExtension->pressButton()` to call `wait()` before passing execution back to `MinkExtension->pressButton()`.  `wait()` uses a javascript condition parameter that waits for any `#autocomplete` suggestion boxes to close.  If there are none open, Mink will not wait, so there is no performance impact for pages that don't ever open an autocomplete suggestion list.
   
   This new method duplicates the features of the existing method `assertPressButton()`, so I have deleted that one, and included the corresponding `@When` step definition in the new method.
2.  `pressKey($char, $field)` allows a key to be "pressed" on a field.  Special keys like escape, enter and tab are supported.  Support for other special keys would be useful.  This is necessary to allow autocomplete suggestion boxes to be closed.  If they are not closed, then the `wait()` in `pressButton()` will time out and corresponding form-submit will get blocked by Drupal's `autocomplete.js`.
   
   > NOTE once https://github.com/Behat/Mink/pull/345 is merged we can detect whether there are still any autocomplete boxes open by evaluating `wait()`'s return value.  We should do that and possibly even throw an exception or warning if there are boxes that are still open.
   
   The step definition for the new method is `/^(?:|I )press the "([^"]*)" key in the "([^"]*)" field$/`.  E.g.
   
   > And I press the "Esc" key in the "LABEL" field
