### PR TITLE
Keep translation of MinkContext

### DIFF
--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -124,7 +124,10 @@ class DrupalContext extends MinkContext implements DrupalAwareInterface, Transla
    * @return array
    */
   public function getTranslationResources() {
-    return glob(__DIR__ . '/../../../../i18n/*.xliff');
+      $translationFilesParent = parent::getTranslationResources();
+      $translationFilesDrupal = glob(__DIR__ . '/../../../../i18n/*.xliff');
+      $translationFilesCombined = array_merge($translationFilesParent, $translationFilesDrupal);
+      return $translationFilesCombined;
   }
 
   /**


### PR DESCRIPTION
Currently the translations of the steps provided by the MinkContext are not available when using the DrupalContext. This patch makes them available.
