### PR TITLE
Upgrade Behat to 2.5.*@stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "behat/mink": "1.5.*@stable",
     "behat/mink-goutte-driver": "*",
     "behat/mink-selenium2-driver": "*",
-    "behat/behat": "2.4.*@stable",
+    "behat/behat": "2.5.*@stable",
     "behat/mink-extension": "*"
   },
   "require-dev": {


### PR DESCRIPTION
Although this project uses the requirement specified in the [Behat documentation](http://docs.behat.org/quick_intro.html#method-1-composer), it would be great to upgrade to the `2.5.*@stable` point releases so that we can use environment variables to modify configurations.

To highlight where this is useful, [Solr Integration Testing](https://github.com/cpliakas/drupal-solrtest) uses the environment variables to set the URL that tests should be run against. This allows us to have a `behat.yml` file that can be used as is without having the modify the `base_url` according to your environment.

Thanks if advance for you consideration to this pull request,
Chris
