### PR TITLE
added configuration parameter to specify drush binary path

### DIFF
--- a/src/Drupal/Driver/DrushDriver.php
+++ b/src/Drupal/Driver/DrushDriver.php
@@ -23,6 +23,11 @@ class DrushDriver extends BaseDriver {
   public $root = FALSE;
 
   /**
+   * Store the path to drush binary.
+   */
+  public $binary = FALSE;
+
+  /**
    * Track bootstrapping.
    */
   private $bootstrapped = FALSE;
@@ -34,13 +39,15 @@ class DrushDriver extends BaseDriver {
    *   A drush alias
    * @param string $root_path
    *   The root path of the Drupal install. This is an alternative to using aliases.
+   * @param string $binary
+   *   The path to the drush binary.
    */
-  public function __construct($alias = NULL, $root_path = NULL) {
+  public function __construct($alias = NULL, $root_path = NULL, $binary = 'drush') {
     if ($alias) {
-    // Trim off the '@' symbol if it has been added.
-    $alias = ltrim($alias, '@');
+      // Trim off the '@' symbol if it has been added.
+      $alias = ltrim($alias, '@');
 
-    $this->alias = $alias;
+      $this->alias = $alias;
     }
     elseif ($root_path) {
       $this->root = realpath($root_path);
@@ -48,6 +55,8 @@ class DrushDriver extends BaseDriver {
     else {
       throw new \BootstrapException('A drush alias or root path is required.');
     }
+
+    $this->binary = $binary;
   }
 
   /**
@@ -145,7 +154,7 @@ class DrushDriver extends BaseDriver {
 
     $alias = $this->alias ? "@{$this->alias}" : '--root=' . $this->root;
 
-    $process = new Process("drush {$alias} {$command} {$string_options} {$arguments}");
+    $process = new Process("{$this->binary} {$alias} {$command} {$string_options} {$arguments}");
     $process->setTimeout(3600);
     $process->run();
 

--- a/src/Drupal/DrupalExtension/Extension.php
+++ b/src/Drupal/DrupalExtension/Extension.php
@@ -51,6 +51,9 @@ class Extension implements ExtensionInterface {
       $config['drush']['alias'] = isset($config['drush']['alias']) ? $config['drush']['alias'] : FALSE;
       $container->setParameter('drupal.driver.drush.alias', $config['drush']['alias']);
 
+      $config['drush']['binary'] = isset($config['drush']['binary']) ? $config['drush']['binary'] : 'drush';
+      $container->setParameter('drupal.driver.drush.binary', $config['drush']['binary']);
+
       $config['drush']['root'] = isset($config['drush']['root']) ? $config['drush']['root'] : FALSE;
       $container->setParameter('drupal.driver.drush.root', $config['drush']['root']);
     }
@@ -120,6 +123,7 @@ class Extension implements ExtensionInterface {
         arrayNode('drush')->
           children()->
             scalarNode('alias')->end()->
+            scalarNode('binary')->defaultValue('drush')->end()->
             scalarNode('root')->end()->
           end()->
         end()->

--- a/src/Drupal/DrupalExtension/config/drivers/drush.yml
+++ b/src/Drupal/DrupalExtension/config/drivers/drush.yml
@@ -7,5 +7,6 @@ services:
     arguments:
       - %drupal.driver.drush.alias%
       - %drupal.driver.drush.root%
+      - %drupal.driver.drush.binary%
     tags:
       - { name: drupal.driver, alias: drush }


### PR DESCRIPTION
Introduces a configuration parameter to specify Drush binary path. It's useful in those situations where drush is not available system-wide because it's installed through other means, such as Composer.
