### PR TITLE
Adding support for isVisible() method to link assertions.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -472,6 +472,18 @@ class DrupalContext extends MinkContext implements DrupalAwareInterface, Transla
   public function assertLinkVisible($link) {
     $element = $this->getSession()->getPage();
     $result = $element->findLink($link);
+
+    try {
+      if (!$result->isVisible()) {
+        throw new \Exception(sprintf("No link to '%s' on the page %s", $link, $this->getSession()->getCurrentUrl()));
+      }
+    }
+    catch (UnsupportedDriverActionException $e) {
+      // We catch the UnsupportedDriverActionException exception in case
+      // this step is not being performed by a driver that supports javascript.
+      // All other exceptions are valid.
+    }
+
     if (empty($result)) {
       throw new \Exception(sprintf("No link to '%s' on the page %s", $link, $this->getSession()->getCurrentUrl()));
     }
@@ -483,6 +495,18 @@ class DrupalContext extends MinkContext implements DrupalAwareInterface, Transla
   public function assertNotLinkVisible($link) {
     $element = $this->getSession()->getPage();
     $result = $element->findLink($link);
+
+    try {
+      if ($result->isVisible()) {
+        throw new \Exception(sprintf("The link '%s' was present on the page %s and was not supposed to be", $link, $this->getSession()->getCurrentUrl()));
+      }
+    }
+    catch (UnsupportedDriverActionException $e) {
+      // We catch the UnsupportedDriverActionException exception in case
+      // this step is not being performed by a driver that supports javascript.
+      // All other exceptions are valid.
+    }
+
     if ($result) {
       throw new \Exception(sprintf("The link '%s' was present on the page %s and was not supposed to be", $link, $this->getSession()->getCurrentUrl()));
     }


### PR DESCRIPTION
Currently, the assertLinkVisible() and assertNotLinkVisible() do not actually assert visibility-- they assert the presence of the link in markup. This modification will utilize the isVisible() method to verify that the link is both in markup and visible whenever a javascript session is being used.

It may be worthwhile to extend this fix to other similar methods that assert visibility.
