### PR TITLE
Node create fails in Drupal 8

### DIFF
--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -10,6 +10,7 @@ use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Drupal\Drupal;
 use Drupal\DrupalExtension\Event\EntityEvent;
 use Drupal\DrupalExtension\Context\DrupalSubContextInterface;
+use Drupal\Core\Field\FieldItemList;
 
 use Symfony\Component\Process\Process;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -973,8 +974,15 @@ class DrupalContext extends MinkContext implements DrupalAwareInterface, Transla
     $this->dispatcher->dispatch('afterNodeCreate', new EntityEvent($this, $saved));
     $this->nodes[] = $saved;
 
-    // Set internal page on the new node.
-    $this->getSession()->visit($this->locatePath('/node/' . $saved->nid));
+    // Set internal page on the new node. The nid property is a scalar value in
+    // Drupal 6 and 7. In Drupal 8, this property is a FieldItemList object.
+    if ($saved->nid instanceof FieldItemList) {
+      $id = $saved->nid->value;
+    }
+    else {
+      $id = $saved->nid;
+    }
+    $this->getSession()->visit($this->locatePath('/node/' . $id));
   }
 
   /**


### PR DESCRIPTION
This is a port of the patch in https://drupal.org/node/2238731

The `nid` property of a node is Drupal 8 is a `FieldItemList` object, not a scalar. In order to support D8 and D6/D7, I had to put in an `if/else`.
