### PR TITLE
[WIP] Document settings through "behat --config-reference"

### DIFF
--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -114,11 +114,23 @@ class DrupalExtension implements ExtensionInterface {
           defaultValue('drush')->
         end()->
         arrayNode('region_map')->
+          info("Targeting content in specific regions can be accomplished once those regions have been defined." . PHP_EOL
+            . '  My region: "#css-selector"' . PHP_EOL
+            . '  Content: "#main .region-content"'. PHP_EOL
+            . '  Right sidebar: "#sidebar-second"'. PHP_EOL
+          )->
           useAttributeAsKey('key')->
           prototype('variable')->
           end()->
         end()->
         arrayNode('text')->
+          info(
+              'Text strings, such as Log out or the Username field can be altered via behat.yml if they vary from the default values.' . PHP_EOL
+            . '  log_out: "Sign out"' . PHP_EOL
+            . '  log_in: "Sign in"' . PHP_EOL
+            . '  password_field: "Enter your password"' . PHP_EOL
+            . '  username_field: "Nickname"'
+          )->
           addDefaultsIfNotSet()->
           children()->
             scalarNode('log_in')->
@@ -160,9 +172,19 @@ class DrupalExtension implements ExtensionInterface {
         end()->
         // Subcontext paths.
         arrayNode('subcontexts')->
+          info(
+              'The Drupal Extension is capable of discovering additional step-definitions provided by subcontexts.' . PHP_EOL
+            . 'Module authors can provide these in files following the naming convention of foo.behat.inc. Once that module is enabled, the Drupal Extension will load these.' . PHP_EOL
+            . PHP_EOL
+            . 'Additional subcontexts can be loaded by either placing them in the bootstrap directory (typically features/bootstrap) or by adding them to behat.yml.'
+          )->
           addDefaultsIfNotSet()->
           children()->
             arrayNode('paths')->
+              info(
+                '- /path/to/additional/subcontexts' . PHP_EOL
+              . '- /another/path'
+              )->
               useAttributeAsKey('key')->
               prototype('variable')->end()->
             end()->


### PR DESCRIPTION
As my learning curve still is steep it would be great to have the config documented and learn people to use

``` bash
behat --config-reference
```
- [ ] document all other options

Please comment on all settings so I can work on their documentation.

``` bash
$ vendor/bin/behat --config-reference
...
    drupal:
        basic_auth:
            username:             ~
            password:             ~

        # Use "blackbox" to test remote site. See "api_driver" for easier integration.
        default_driver:       blackbox

        # Bootstraps drupal through "drupal8" or "drush".
        api_driver:           drush
        drush_driver:         drush
        region_map:

            # Prototype
            key:                  ~
        text:
            log_in:               'Log in'
            log_out:              'Log out'
            password_field:       Password
            username_field:       Username
        selectors:
            message_selector:     ~
            error_message_selector:  ~
            success_message_selector:  ~
            warning_message_selector:  ~
        blackbox:             []
        drupal:
            drupal_root:          ~
        drush:
            alias:                ~
            binary:               drush
            root:                 ~
        subcontexts:
            paths:

                # Prototype
                key:                  ~
            autoload:             true
```
