### PR TITLE
Fixing session manager method name, node and role ID handling

### DIFF
--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -74,6 +74,7 @@ class Drupal8 implements CoreInterface {
    * Implements CoreInterface::nodeDelete().
    */
   public function nodeDelete($node) {
+    $node = $node instanceof NodeInterface ? $node : Node::load($node->nid);
     $node->delete();
   }
 


### PR DESCRIPTION
Not sure how the nid->value() code was tested, but that has to be a fatal error as value is a property, not a method. And assigning to ->nid doesn't change anything, it is still a FieldItemList object.

So, instead of that, using a similar pattern as we do for $user, keep $node as a stdClass object and just assign the nid.
