### PR TITLE
Exceptions and no definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,12 @@ Drupal Extension 1.0 supports Behat 2.4, and Drupal 6 and 7 (with Drupal 8 suppo
 
   ```
   default:
-    paths:
-      features: 'features'
     extensions:
-      Behat\MinkExtension\Extension:
+      Behat\MinkExtension:
         goutte: ~
         selenium2: ~
         base_url: http://git6site.devdrupal.org/
-      Drupal\DrupalExtension\Extension:
+      Drupal\DrupalExtension:
         blackbox: ~
   ```
 


### PR DESCRIPTION
I need to change the behat.yml for master using behat 3
- path don't exists (anymore) for testwork. `[Symfony\Component\Config\Definition\Exception\InvalidConfigurationException]   Unrecognized options "paths" under "testwork"`
- extensions names are shortened.

After fixing those is still have an empty --definitions list :-( What is wrong?
