### PR TITLE
remove drupal from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 *.phar
 composer.lock
 vendor
-drupal
+/drupal
 behat.yml


### PR DESCRIPTION
I was trying to incorporate drupalextension into another repo and every time I pull I would ask another user to pull the code, behat would fail. It would require a composer update for it to work. I narrowed it down to the files contained in src/Drupal/ missing from my repo. Git simply ignores them. This is because 'drupal' is listed in the .gitignore. I don't see a reason to have drupal in there (737f22a06c7dbd7425cedce221a30498ae8c0fcf).
