### PR TITLE
Changed constraints to have an upper bound

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
      }
   ],
   "require": {
-    "behat/mink": "1.5.*@stable",
-    "behat/mink-goutte-driver": "*",
-    "behat/mink-selenium2-driver": "*",
+    "behat/mink": "~1.5",
+    "behat/mink-goutte-driver": "~1.0",
+    "behat/mink-selenium2-driver": "~1.1",
     "behat/behat": "~3.0,>=3.0.5",
-    "behat/mink-extension": "2.0.*@dev"
+    "behat/mink-extension": "~2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
This also makes usage of the semantic operator to allow using Mink 1.6 once released (or earlier if you allow dev versions)
