### PR TITLE
Fix to get assertNotLinkVisible to work using Selenium

### DIFF
--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -224,10 +224,6 @@ class MinkContext extends MinkExtension implements TranslatableContext {
       // this step is not being performed by a driver that supports javascript.
       // All other exceptions are valid.
     }
-
-    if ($result) {
-      throw new \Exception(sprintf("The link '%s' was present on the page %s and was not supposed to be", $link, $this->getSession()->getCurrentUrl()));
-    }
   }
 
   /**


### PR DESCRIPTION
Using
And I should not see the link "link name"
In a feature was giving false negatives and never passing, removing a few lines of code seems to have got it to work properly. As $result should always be populated it shouldn't fail if it's set, I think.
