### PR TITLE
Support 'authenticated' as role name for authenticated user role

### DIFF
--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -53,7 +53,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
       $roles = explode(',', $role);
       $roles = array_map('trim', $roles);
       foreach ($roles as $role) {
-        if ($role != 'authenticated user') {
+        if (!in_array(strtolower($role), ['authenticated', 'authenticated user'])) {
           // Only add roles other than 'authenticated user'.
           $this->getDriver()->userAddRole($user, $role);
         }


### PR DESCRIPTION
Drupal 8 now throws an exception when trying to assign this role, I have a lot of 'authenticated' in my tests as that is the machine name and other role machine names are supported too, so doing this is consistent I think.

Also lower cased it, because the actual role name is 'Authenticated user'.

Please also backport this to 1.0, as I'm still using that.
