### PR TITLE
Add documentation for environment specific settings

### DIFF
--- a/doc/environment.rst
+++ b/doc/environment.rst
@@ -1,0 +1,42 @@
+Environment specific settings
+=============================
+
+Some of the settings in ``behat.yml`` are environment specific. For example the
+base URL may be ``http://mysite.localhost`` on your local development
+environment, while on a test server it might be ``http://127.0.0.1:8080``. Some
+other environment specific settings are the Drupal root path and the paths to
+search for subcontexts.
+
+If you intend to run your tests on different environments these settings should
+not be committed to ``behat.yml``. Instead they should be exported in an
+environment variable. Before running tests Behat will check the ``BEHAT_PARAMS``
+environment variable and add these settings to the ones that are present in
+``behat.yml``. This variable should contain a JSON object with your settings.
+
+Example JSON object:
+
+.. code-block:: json
+
+    {
+        "extensions": {
+            "Behat\\MinkExtension": {
+                "base_url": "http://myproject.localhost"
+            },
+            "Drupal\\DrupalExtension": {
+                "drupal": {
+                    "drupal_root": "/var/www/myproject"
+                }
+            }
+        }
+    }
+
+
+To export this into the ``BEHAT_PARAMS`` environment variable, squash the JSON
+object into a single line and surround with single quotes:
+
+.. code-block: bash
+
+    $ export BEHAT_PARAMS='{"extensions":{"Behat\\MinkExtension":{"base_url":"http://myproject.localhost"},"Drupal\\DrupalExtension":{"drupal":{"drupal_root":"/var/www/myproject"}}}}'
+
+There is also a `Drush extension <https://github.com/pfrenssen/drush-bde-env>`_
+that can help you generate these environment variables.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,6 +15,7 @@ Contents:
    requirements
    localinstall
    globalinstall
+   environment
    drivers
    blackbox
    drush


### PR DESCRIPTION
When running tests on different environments the environment specific settings need to be set in the `BEHAT_PARAMS` environment variable. This is not so straightforward so it would be nice to have documentation to help people with this.

This is my first foray into the wonders of the ReST text format and I have not yet found a good way of previewing this text so please forgive any formatting problems.

I have also rather shamelessly plugged my Drush extension that generates the environment variables automatically from the local environment.