### PR TITLE
Clean up DrupalSubContextInterface.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/DrupalSubContextInterface.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalSubContextInterface.php
@@ -1,19 +1,31 @@
 <?php
 
+/**
+ * Contains \Drupal\DrupalExtension\Context\DrupalSubContextInterface.
+ */
+
 namespace Drupal\DrupalExtension\Context;
 
 use Behat\Behat\Context\Context;
-
 use Drupal\DrupalDriverManager;
 
+/**
+ * Interface for subcontexts.
+ *
+ * Implement this interface if you want to provide custom Behat step definitions
+ * for your contributed modules. The class should be placed in a file named
+ * 'MYMODULE.behat.inc'.
+ *
+ * See the documentation on "Contributed module subcontexts".
+ */
 interface DrupalSubContextInterface extends Context {
+
   /**
    * Instantiates the subcontext.
    *
-   * @param \Drupal\Drupal
+   * @param \Drupal\DrupalDriverManager $context
    *   The Drupal Driver manager.
-   *
-   * @return string
    */
   public function __construct(DrupalDriverManager $context);
+
 }

--- a/src/Drupal/DrupalExtension/Context/DrupalSubContextInterface.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalSubContextInterface.php
@@ -23,9 +23,9 @@ interface DrupalSubContextInterface extends Context {
   /**
    * Instantiates the subcontext.
    *
-   * @param \Drupal\DrupalDriverManager $context
+   * @param \Drupal\DrupalDriverManager $drupal
    *   The Drupal Driver manager.
    */
-  public function __construct(DrupalDriverManager $context);
+  public function __construct(DrupalDriverManager $drupal);
 
 }


### PR DESCRIPTION
`DrupalSubContextInterface` could use a little love:

* The docblock for the constructor is not correct, it uses the wrong parameter type for `$context`.
* it states that the constructor returns a string but a constructor cannot return any value since it returns the object itself.
* We can also add some documentation to help people understand its purpose.