### PR TITLE
Provide a base class for subcontexts

### DIFF
--- a/doc/_static/snippets/subcontext.inc
+++ b/doc/_static/snippets/subcontext.inc
@@ -1,16 +1,23 @@
 <?php
+
+/**
+ * Contains \FooFoo.
+ */
+
 use Behat\Behat\Tester\Exception\PendingException;
+use Drupal\DrupalExtension\Context\DrupalSubContextBase;
 use Drupal\DrupalExtension\Context\DrupalSubContextInterface;
-use Drupal\DrupalDriverManager;
-  class FooFoo implements DrupalSubContextInterface {
-    private $drupal;
-    public function __construct(DrupalDriverManager $drupal) {
-      $this->drupal = $drupal;
-    }
-    /**
-      * @Then /^I should have a subcontext definition$/
-     */
-    public function assertSubContextDefinition() {
-      throw new PendingException();
-    }
+
+/**
+ * Example subcontext.
+ */
+class FooFoo extends DrupalSubContextBase implements DrupalSubContextInterface {
+
+  /**
+   * @Then /^I should have a subcontext definition$/
+   */
+  public function assertSubContextDefinition() {
+    throw new PendingException();
   }
+
+}

--- a/src/Drupal/DrupalExtension/Context/DrupalSubContextBase.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalSubContextBase.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\DrupalExtension\Context\DrupalSubContextBase.
+ */
+
+namespace Drupal\DrupalExtension\Context;
+
+use Behat\Behat\Context\Environment\InitializedContextEnvironment;
+use Drupal\DrupalDriverManager;
+
+/**
+ * Base class for subcontexts that use the Drupal API.
+ */
+abstract class DrupalSubContextBase extends RawDrupalContext implements DrupalSubContextInterface {
+
+  /**
+   * The Drupal Driver Manager.
+   *
+   * @var \Drupal\DrupalDriverManager $drupal
+   */
+  protected $drupal;
+
+  /**
+   * Constructs a DrupalSubContextBase object.
+   *
+   * @param \Drupal\DrupalDriverManager $drupal
+   *   The Drupal driver manager.
+   */
+  public function __construct(DrupalDriverManager $drupal) {
+    $this->drupal = $drupal;
+  }
+
+  /**
+   * Get the currently logged in user from DrupalContext.
+   */
+  protected function getUser() {
+    /** @var DrupalContext $context */
+    $context = $this->getContext('\Drupal\DrupalExtension\Context\DrupalContext');
+    if (empty($context->user)) {
+      throw new \Exception('No user is logged in.');
+    }
+
+    return $context->user;
+  }
+
+  /**
+   * Returns the Behat context that corresponds with the given class name.
+   *
+   * This is inspired by InitializedContextEnvironment::getContext() but also
+   * returns subclasses of the given class name. This allows us to retrieve for
+   * example DrupalContext even if it is overridden in a project.
+   *
+   * @param string $class
+   *   A fully namespaced class name.
+   *
+   * @return \Behat\Behat\Context\Context|false
+   *   The requested context, or FALSE if the context is not registered.
+   */
+  protected function getContext($class) {
+    /** @var InitializedContextEnvironment $environment */
+    $environment = $this->drupal->getEnvironment();
+    foreach ($environment->getContexts() as $context) {
+      if ($context instanceof $class) {
+        return $context;
+      }
+    }
+
+    return FALSE;
+  }
+
+}


### PR DESCRIPTION
It would be helpful if we provide a base class for subcontexts.

* Now all subcontexts have to implement the constructor but this is likely to be common for all subcontexts, causing code duplication.
* We can extend `RawDrupalContext` which would be a sane default for the most common case of subcontexts provided by contributed modules.
* If we have a base class we can also provide some helpful methods that can assist developers in building their subcontexts. As an example I have provided a method that allows the subcontext to get the currently logged in user from the DrupalContext class.
