### PR TITLE
Do not register abstract subcontext classes.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/Environment/Reader/Reader.php
+++ b/src/Drupal/DrupalExtension/Context/Environment/Reader/Reader.php
@@ -153,11 +153,11 @@ final class Reader implements EnvironmentReader {
         }
       }
 
-      // Find all subcontexts.
+      // Find all subcontexts, excluding abstract base classes.
       $classes = get_declared_classes();
       foreach ($classes as $class) {
         $reflect = new \ReflectionClass($class);
-        if ($reflect->implementsInterface('Drupal\DrupalExtension\Context\DrupalSubContextInterface')) {
+        if (!$reflect->isAbstract() && $reflect->implementsInterface('Drupal\DrupalExtension\Context\DrupalSubContextInterface')) {
           $class_names[] = $class;
         }
       }


### PR DESCRIPTION
This is a followup for [Provide a base class for subcontexts](https://github.com/jhedstrom/drupalextension/pull/141). When the list of subcontext classes is compiled we should ignore the abstract ones to avoid Behat from trying to register them.