### PR TITLE
Add test coverage for user field handling in Drupal 8

### DIFF
--- a/features/field_handlers.feature
+++ b/features/field_handlers.feature
@@ -114,16 +114,13 @@ Feature: FieldHandlers
     And I am logged in as a user with the "administrator" role
     When I visit "admin/people"
     Then I should see the link "John Doe"
-
-# API actually works, but user view mode settings are not applied,
-# even though exported correctly
-#    And I click "John Doe"
-#    Then I should see "Tag one"
-#    And I should see "Tag two"
-#    But I should not see "Tag three"
-#    And I should see "Page one"
-#    And I should see "Page two"
-#    But I should not see "Page three"
+    And I click "John Doe"
+    Then I should see "Tag one"
+    And I should see "Tag two"
+    But I should not see "Tag three"
+    And I should see "Page one"
+    And I should see "Page two"
+    But I should not see "Page three"
 
 
 

--- a/fixtures/drupal8/modules/behat_test/behat_test.install
+++ b/fixtures/drupal8/modules/behat_test/behat_test.install
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Implements hook_install()
+ */
+function behat_test_install() {
+  $storage = \Drupal::service('behat_test.config.storage.install');
+  $config_names = array(
+    'core.entity_form_display.user.user.default',
+    'core.entity_view_display.user.user.default',
+  );
+
+  foreach ($config_names as $config_name) {
+    $data = $storage->read($config_name);
+    $config = \Drupal::configFactory()->getEditable($config_name);
+    $config->setData($data);
+    $config->save();
+  }
+}

--- a/fixtures/drupal8/modules/behat_test/behat_test.install
+++ b/fixtures/drupal8/modules/behat_test/behat_test.install
@@ -5,6 +5,8 @@
  */
 function behat_test_install() {
   $storage = \Drupal::service('behat_test.config.storage.install');
+
+  // Override Standard profile's user settings with our own.
   $config_names = array(
     'core.entity_form_display.user.user.default',
     'core.entity_view_display.user.user.default',
@@ -12,8 +14,6 @@ function behat_test_install() {
 
   foreach ($config_names as $config_name) {
     $data = $storage->read($config_name);
-    $config = \Drupal::configFactory()->getEditable($config_name);
-    $config->setData($data);
-    $config->save();
+    \Drupal::configFactory()->getEditable($config_name)->setData($data)->save();
   }
 }

--- a/fixtures/drupal8/modules/behat_test/behat_test.services.yml
+++ b/fixtures/drupal8/modules/behat_test/behat_test.services.yml
@@ -1,0 +1,5 @@
+services:
+  behat_test.config.storage.install:
+    class: Drupal\behat_test\Config\BehatTestExtensionInstallStorage
+    arguments: ['@config.storage', 'config/install']
+

--- a/fixtures/drupal8/modules/behat_test/src/Config/BehatTestExtensionInstallStorage.php
+++ b/fixtures/drupal8/modules/behat_test/src/Config/BehatTestExtensionInstallStorage.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\behat_test\Config\BehatTestExtensionInstallStorage
+ */
+
+namespace Drupal\behat_test\Config;
+
+use Drupal\Core\Config\ExtensionInstallStorage;
+
+class BehatTestExtensionInstallStorage extends ExtensionInstallStorage {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getAllFolders() {
+    if (!isset($this->folders)) {
+      $this->folders = $this->getComponentNames('module', array('behat_test'));
+    }
+    return $this->folders;
+  }
+}


### PR DESCRIPTION
The current pull request adds test coverage for user field handling in Drupal 8 by enforcing Behat Test module's user entity configuration in Drupal 8 installation, so that feature steps can be tested properly.