### PR TITLE
Move building the extension list to the core driver

### DIFF
--- a/src/Drupal/Driver/Cores/CoreInterface.php
+++ b/src/Drupal/Driver/Cores/CoreInterface.php
@@ -27,6 +27,14 @@ interface CoreInterface {
   public function bootstrap();
 
   /**
+   * Returns a list of extensions paths.
+   *
+   * @return string[]
+   *   List of paths to modules/themes/...
+   */
+  public function getExtensionPathList();
+
+  /**
    * Clear caches.
    */
   public function clearCache();

--- a/src/Drupal/Driver/Cores/Drupal6.php
+++ b/src/Drupal/Driver/Cores/Drupal6.php
@@ -62,6 +62,27 @@ class Drupal6 implements CoreInterface {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  public function getExtensionPathList() {
+    $paths = array();
+
+    // Get enabled modules.
+    $modules = \module_list();
+    foreach ($modules as $module) {
+      $paths[] = $this->drupalRoot . DIRECTORY_SEPARATOR . \drupal_get_path('module', $module);
+    }
+
+    // Themes.
+    // @todo
+
+    // Active profile
+    // @todo
+
+    return $paths;
+  }
+
+  /**
    * Implements CoreInterface::clearCache().
    */
   public function clearCache() {

--- a/src/Drupal/Driver/Cores/Drupal7.php
+++ b/src/Drupal/Driver/Cores/Drupal7.php
@@ -64,6 +64,27 @@ class Drupal7 implements CoreInterface {
   /**
    * {@inheritDoc}
    */
+  public function getExtensionPathList() {
+    $paths = array();
+
+    // Get enabled modules.
+    $modules = \module_list();
+    foreach ($modules as $module) {
+      $paths[] = $this->drupalRoot . DIRECTORY_SEPARATOR . \drupal_get_path('module', $module);
+    }
+
+    // Themes.
+    // @todo
+
+    // Active profile
+    // @todo
+
+    return $paths;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   public function clearCache() {
     // Need to change into the Drupal root directory or the registry explodes.
     $current_path = getcwd();

--- a/src/Drupal/Driver/Cores/Drupal8.php
+++ b/src/Drupal/Driver/Cores/Drupal8.php
@@ -68,6 +68,26 @@ class Drupal8 implements CoreInterface {
   /**
    * {@inheritDoc}
    */
+  public function getExtensionPathList() {
+    $paths = array();
+
+    // Get enabled modules.
+    foreach (\Drupal::moduleHandler()->getModuleList() as $module) {
+      $paths[] = $this->drupalRoot . DIRECTORY_SEPARATOR . $module->getPath();
+    }
+
+    // Themes.
+    // @todo
+
+    // Active profile
+    // @todo
+
+    return $paths;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   public function clearCache() {
     // Need to change into the Drupal root directory or the registry explodes.
     $current_path = getcwd();

--- a/src/Drupal/Driver/DrupalDriver.php
+++ b/src/Drupal/Driver/DrupalDriver.php
@@ -120,22 +120,7 @@ class DrupalDriver implements DriverInterface, DrupalSubContextFinderInterface {
       $this->bootstrap();
     }
 
-    $paths = array();
-
-    // Get enabled modules.
-    $modules = \module_list();
-    $paths = array();
-    foreach ($modules as $module) {
-      $paths[] = $this->drupalRoot . DIRECTORY_SEPARATOR . \drupal_get_path('module', $module);
-    }
-
-    // Themes.
-    // @todo
-
-    // Active profile
-    // @todo
-
-    return $paths;
+    return $this->getCore()->getExtensionPathList();
   }
 
   /**


### PR DESCRIPTION
I'm still on 1.0, didn't check if this is already fixed in 3.0.

module_list() has been removed in 8.x, so the whole thing now depends on the core version, I moved it into the core drivers and added a new method for it.