### PR TITLE
Issue #149: Revert "Temporary fix for Drupal 8 react/promise issue."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ before_script:
   - drush --yes --root=$PWD/drupal8 site-install --db-url=mysql://travis:@127.0.0.1/drupal8
   - cp -r fixtures/drupal8/modules/behat_test drupal8/modules
   - cd drupal8
-  # Temporary fix until https://www.drupal.org/node/2442411 lands.
-  composer update react/promise
   - drush --yes en behat_test
   - drush cr
   - drush runserver :8888 > ~/debug8.txt 2>&1 &


### PR DESCRIPTION
This reverts commit ad9f0039832d4acd6c5b477c698557f0ca4c5ffd.

A temporary fix was committed to update the react/promise package on Travis until this was fixed upstream. Unfortunately the fix introduced a violation against the YAML standard which broke testing on Travis.