### PR TITLE
Remove custom php package installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ env:
 install:
   - composer self-update
   - composer install
-  - sudo apt-get update > /dev/null
-  - sudo apt-get --quiet=2 install php5-cli php5-cgi php5-curl php5-gd php5-mysql > /dev/null
   - composer global require drush/drush:dev-master --prefer-source
 
 before_script:

--- a/fixtures/drupal8/modules/behat_test/config/install/field.field.user.user.field_user_tags.yml
+++ b/fixtures/drupal8/modules/behat_test/config/install/field.field.user.user.field_user_tags.yml
@@ -5,6 +5,7 @@ dependencies:
     - field.storage.user.field_user_tags
   module:
     - taxonomy
+    - entity_reference
 id: user.user.field_user_tags
 field_name: field_user_tags
 entity_type: user
@@ -17,4 +18,10 @@ default_value: {  }
 default_value_callback: ''
 settings:
   handler: default
-field_type: taxonomy_term_reference
+  handler_settings:
+    target_bundles:
+      tags: tags
+    sort:
+      field: _none
+    auto_create: true
+field_type: entity_reference

--- a/fixtures/drupal8/modules/behat_test/config/install/field.storage.user.field_user_tags.yml
+++ b/fixtures/drupal8/modules/behat_test/config/install/field.storage.user.field_user_tags.yml
@@ -7,12 +7,8 @@ dependencies:
 id: user.field_user_tags
 field_name: field_user_tags
 entity_type: user
-type: taxonomy_term_reference
+type: entity_reference
 settings:
-  allowed_values:
-    -
-      vocabulary: tags
-      parent: 0
   target_type: taxonomy_term
   options_list_callback: null
   target_bundle: null
@@ -20,5 +16,4 @@ module: taxonomy
 locked: false
 cardinality: -1
 translatable: true
-indexes: {  }
 persist_with_no_fields: false

--- a/fixtures/drupal8/modules/behat_test/override_config/core.entity_view_display.user.user.default.yml
+++ b/fixtures/drupal8/modules/behat_test/override_config/core.entity_view_display.user.user.default.yml
@@ -27,9 +27,10 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_user_tags:
-    type: taxonomy_term_reference_link
+    type: entity_reference_label
     weight: 2
-    settings: {  }
+    settings:
+      link: true
     third_party_settings: {  }
     label: above
   field_user_reference:


### PR DESCRIPTION
Attempt to simplify travis builds. These packages are supposedly all in the normal CI build.