### PR TITLE
Add behat --init to the globalinstall documentation

### DIFF
--- a/doc/globalinstall.rst
+++ b/doc/globalinstall.rst
@@ -80,7 +80,12 @@ Set up tests
      :language: yaml 
      :linenos:
 
-3. This will generate a FeatureContext.php file that looks like:
+3. Initialize behat. This creates the features folder with some basic things to
+   get you started::
+
+    bin/behat --init
+
+4. This will generate a FeatureContext.php file that looks like:
 
   .. literalinclude:: _static/snippets/FeatureContext.php.inc
      :language: php 
@@ -91,7 +96,7 @@ Set up tests
   the Mink Extension, so you'll be able to take advantage of their drivers and
   step definitions and add your own custom step definitions here.
 
-4. To ensure everything is set up appropriately, type::
+5. To ensure everything is set up appropriately, type::
 
     behat -dl
 


### PR DESCRIPTION
I'm setting this up for the first time, and had to look around a bit to find out how to initialise behat since the globalinstall documentation doesn't specify that. We probably want to add that there.

The steps I followed were these: https://behat-drupal-extension.readthedocs.org/en/3.0/globalinstall.html