### PR TITLE
Update assertSelectRadioById

### DIFF
--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -508,7 +508,7 @@ class MinkContext extends MinkExtension implements TranslatableContext {
    */
   public function assertSelectRadioById($label, $id = '') {
     $element = $this->getSession()->getPage();
-    $radiobutton = $id ? $element->findById($id) : $element->find('named', array('radio', $this->getSession()->getSelectorsHandler()->xpathLiteral($label)));
+    $radiobutton = $id ? $element->findById($id) : $element->find('named', array('radio', $label));
     if ($radiobutton === NULL) {
       throw new \Exception(sprintf('The radio button with "%s" was not found on the page %s', $id ? $id : $label, $this->getSession()->getCurrentUrl()));
     }


### PR DESCRIPTION
In order to fix "I select the radio button" step in Behat version 2+ we should replace "$this->getSession()->getSelectorsHandler()->xpathLiteral($label)" with "$label". Otherwise I receive the following error:
6384: The Behat\Mink\Selector\SelectorsHandler::xpathLiteral method is deprecated as of 1.7 and will be removed in 2.0. Use \Behat\Mink\Selector\Xpath\Escaper::escapeLiteral instead when building Xpath or pass the unescaped value when using the named selector. in vendor/behat/mink/src/Selector/SelectorsHandler.php line 131