### PR TITLE
Use branch alias instead of branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "behat/mink-selenium2-driver": "~1.1",
     "behat/behat": "~3.0,>=3.0.5",
     "behat/mink-extension": "~2.0",
-    "drupal/drupal-driver": "dev-master"
+    "drupal/drupal-driver": "~1.0@dev"
   },
   "require-dev": {
     "phpspec/phpspec": "~2.0",


### PR DESCRIPTION
I try to use another version of ``drupal/drupal-driver`` but the hardcoded branch name makes it unnecessary complicated.