### PR TITLE
Allow users without roles

### DIFF
--- a/features/d8.feature
+++ b/features/d8.feature
@@ -18,8 +18,9 @@ Feature: DrupalContext
 
   Scenario: Create users with roles
     Given users:
-    | name     | mail            | roles         |
-    | Joe User | joe@example.com | Administrator  |
+    | name     | mail             | roles          |
+    | Joe User | joe@example.com  | Administrator  |
+    | Jane Doe | jane@example.com |                |
     And I am logged in as a user with the "administrator" role
     When I visit "admin/people"
     Then I should see the text "Administrator" in the "Joe User" row

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -343,7 +343,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
       $roles = array();
       if (isset($userHash['roles'])) {
         $roles = explode(',', $userHash['roles']);
-        $roles = array_map('trim', $roles);
+        $roles = array_filter(array_map('trim', $roles));
         unset($userHash['roles']);
       }
 


### PR DESCRIPTION
I tried to create a user without any additional roles, but it did not work because we cast empty string to array.