### PR TITLE
Add support for testing languages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "behat/mink-selenium2-driver": "~1.1",
     "behat/behat": "~3.0,>=3.0.5",
     "behat/mink-extension": "~2.0",
-    "drupal/drupal-driver": "dev-language"
+    "drupal/drupal-driver": "~1.0@dev"
   },
   "require-dev": {
     "phpspec/phpspec": "~2.0",
@@ -31,12 +31,6 @@
       "Drupal\\DrupalExtension": "src/"
     }
   },
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/pfrenssen/DrupalDriver"
-    }
-  ],
   "extra": {
     "branch-alias": {
       "dev-master": "3.0.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "behat/mink-selenium2-driver": "~1.1",
     "behat/behat": "~3.0,>=3.0.5",
     "behat/mink-extension": "~2.0",
-    "drupal/drupal-driver": "~1.0@dev"
+    "drupal/drupal-driver": "dev-language"
   },
   "require-dev": {
     "phpspec/phpspec": "~2.0",
@@ -31,6 +31,12 @@
       "Drupal\\DrupalExtension": "src/"
     }
   },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/pfrenssen/DrupalDriver"
+    }
+  ],
   "extra": {
     "branch-alias": {
       "dev-master": "3.0.x-dev"

--- a/features/language.feature
+++ b/features/language.feature
@@ -1,0 +1,21 @@
+@api @d7
+Feature: Language support
+  In order to demonstrate the language integration
+  As a developer for the Behat Extension
+  I need to provide test cases for the language support
+
+  # These test scenarios assume to have a clean installation of the "standard"
+  # profile and that the "behat_test" module from the "fixtures/" folder is
+  # enabled on the site.
+
+  Scenario: Enable multiple languages
+    Given the following languages are available:
+      | languages |
+      | en        |
+      | fr        |
+      | de        |
+    And I am logged in as a user with the 'administrator' role
+    When I go to "admin/config/regional/language"
+    Then I should see "English"
+    And I should see "French"
+    And I should see "German"

--- a/features/language.feature
+++ b/features/language.feature
@@ -1,4 +1,4 @@
-@api @d7
+@api @d7 @d8
 Feature: Language support
   In order to demonstrate the language integration
   As a developer for the Behat Extension

--- a/fixtures/drupal7/modules/behat_test/behat_test.info
+++ b/fixtures/drupal7/modules/behat_test/behat_test.info
@@ -7,6 +7,7 @@ dependencies[] = entityreference
 dependencies[] = features
 dependencies[] = link
 dependencies[] = list
+dependencies[] = locale
 dependencies[] = node
 dependencies[] = options
 dependencies[] = taxonomy

--- a/fixtures/drupal8/modules/behat_test/behat_test.info.yml
+++ b/fixtures/drupal8/modules/behat_test/behat_test.info.yml
@@ -5,3 +5,5 @@ package: Test
 version: '8.x-1.x-dev'
 core: '8.x'
 project: 'behat_test'
+dependencies:
+  - language

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -375,6 +375,26 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
   }
 
   /**
+   * Creates one or more languages.
+   *
+   * @Given the/these (following )languages are available:
+   *
+   * Provide language data in the following format:
+   *
+   * | langcode |
+   * | en       |
+   * | fr       |
+   *
+   * @param TableNode $langcodesTable
+   *   The table listing languages by their ISO code.
+   */
+  public function createLanguages(TableNode $langcodesTable) {
+    foreach ($langcodesTable->getHash() as $langcode) {
+      $this->languageCreate((object) $langcode);
+    }
+  }
+
+  /**
    * Pauses the scenario until the user presses a key. Useful when debugging a scenario.
    *
    * @Then (I )break

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -389,8 +389,11 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    *   The table listing languages by their ISO code.
    */
   public function createLanguages(TableNode $langcodesTable) {
-    foreach ($langcodesTable->getHash() as $langcode) {
-      $this->languageCreate((object) $langcode);
+    foreach ($langcodesTable->getHash() as $row) {
+      $language = (object) array(
+        'langcode' => $row['languages'],
+      );
+      $this->languageCreate($language);
     }
   }
 

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -322,12 +322,18 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    * @param \stdClass $language
    *   An object with the following properties:
    *   - langcode: the langcode of the language to create.
+   *
+   * @return object|FALSE
+   *   The created language, or FALSE if the language was already created.
    */
   public function languageCreate(\stdClass $language) {
     $this->dispatchHooks('BeforeLanguageCreateScope', $language);
-    $this->getDriver()->languageCreate($language);
-    $this->dispatchHooks('AfterLanguageCreateScope', $language);
-    $this->languages[$language->langcode] = $language;
+    $language = $this->getDriver()->languageCreate($language);
+    if ($language) {
+      $this->dispatchHooks('AfterLanguageCreateScope', $language);
+      $this->languages[$language->langcode] = $language;
+    }
+    return $language;
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -7,10 +7,12 @@ use Behat\Testwork\Hook\HookDispatcher;
 
 use Drupal\DrupalDriverManager;
 
+use Drupal\DrupalExtension\Hook\Scope\AfterLanguageEnableScope;
 use Drupal\DrupalExtension\Hook\Scope\AfterNodeCreateScope;
 use Drupal\DrupalExtension\Hook\Scope\AfterTermCreateScope;
 use Drupal\DrupalExtension\Hook\Scope\AfterUserCreateScope;
 use Drupal\DrupalExtension\Hook\Scope\BaseEntityScope;
+use Drupal\DrupalExtension\Hook\Scope\BeforeLanguageEnableScope;
 use Drupal\DrupalExtension\Hook\Scope\BeforeNodeCreateScope;
 use Drupal\DrupalExtension\Hook\Scope\BeforeUserCreateScope;
 use Drupal\DrupalExtension\Hook\Scope\BeforeTermCreateScope;
@@ -78,6 +80,13 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    * @var array
    */
   protected $roles = array();
+
+  /**
+   * Keep track of any languages that are created so they can easily be removed.
+   *
+   * @var array
+   */
+  protected $languages = array();
 
   /**
    * {@inheritDoc}
@@ -206,6 +215,19 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   }
 
   /**
+   * Remove any created languages.
+   *
+   * @AfterScenario
+   */
+  public function cleanLanguages() {
+    // Delete any languages that were created.
+    foreach ($this->languages as $language) {
+      $this->getDriver()->languageDelete($language);
+      unset($this->languages[$language->langcode]);
+    }
+  }
+
+  /**
    * Dispatch scope hooks.
    *
    * @param string $scope
@@ -292,6 +314,20 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
     $this->dispatchHooks('AfterTermCreateScope', $saved);
     $this->terms[] = $saved;
     return $saved;
+  }
+
+  /**
+   * Creates a language.
+   *
+   * @param \stdClass $language
+   *   An object with the following properties:
+   *   - langcode: the langcode of the language to create.
+   */
+  public function languageCreate(\stdClass $language) {
+    $this->dispatchHooks('BeforeLanguageCreateScope', $language);
+    $this->getDriver()->languageCreate($language);
+    $this->dispatchHooks('AfterLanguageCreateScope', $language);
+    $this->languages[$language->langcode] = $language;
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Hook/Scope/AfterLanguageCreateScope.php
+++ b/src/Drupal/DrupalExtension/Hook/Scope/AfterLanguageCreateScope.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\DrupalExtension\Hook\Scope\AfterLanguageCreateScope.
+ */
+namespace Drupal\DrupalExtension\Hook\Scope;
+
+/**
+ * Represents a language hook scope.
+ */
+final class AfterLanguageCreateScope extends LanguageScope {
+
+  /**
+   * Return the scope name.
+   *
+   * @return string
+   */
+  public function getName() {
+    return self::AFTER;
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Hook/Scope/BeforeLanguageCreateScope.php
+++ b/src/Drupal/DrupalExtension/Hook/Scope/BeforeLanguageCreateScope.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\DrupalExtension\Hook\Scope\BeforeLanguageCreateScope.
+ */
+namespace Drupal\DrupalExtension\Hook\Scope;
+
+/**
+ * Represents a language hook scope.
+ */
+final class BeforeLanguageCreateScope extends LanguageScope {
+
+  /**
+   * Return the scope name.
+   *
+   * @return string
+   */
+  public function getName() {
+    return self::BEFORE;
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Hook/Scope/BeforeLanguageCreateScope.php
+++ b/src/Drupal/DrupalExtension/Hook/Scope/BeforeLanguageCreateScope.php
@@ -12,7 +12,7 @@ namespace Drupal\DrupalExtension\Hook\Scope;
 final class BeforeLanguageCreateScope extends LanguageScope {
 
   /**
-   * Return the scope name.
+   * Returns the scope name.
    *
    * @return string
    */

--- a/src/Drupal/DrupalExtension/Hook/Scope/LanguageScope.php
+++ b/src/Drupal/DrupalExtension/Hook/Scope/LanguageScope.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\DrupalExtension\Hook\Scope\LanguageScope.
+ */
+namespace Drupal\DrupalExtension\Hook\Scope;
+
+/**
+ * Represents the LanguageScope object.
+ */
+abstract class LanguageScope extends BaseEntityScope {
+
+  const BEFORE = 'language.create.before';
+  const AFTER = 'language.create.after';
+
+}


### PR DESCRIPTION
It would be nice if we could add support for testing languages. I'm using Behat for an internal Drupal platform that is used in the European Commission, and we are currently supporting 24 languages :)

This pull requests adds a step definition for enabling additional languages in tests:

```
Given the following languages are available:
  | languages |
  | en        |
  | fr        |
  | de        |
```

This is currently depending on my fork of Drupal Driver that adds the respective functionality for creating and deleting languages. The sister pull request for Drupal Driver is here: https://github.com/jhedstrom/DrupalDriver/pull/45

In case this is accepted we would need to revert commit 55f03a4 before merging this in. That commit points the Drupal Driver dependency to my own fork.