### PR TITLE
Undesirable PHP Notice displayed when Exception thrown

### DIFF
--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -125,19 +125,22 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @Given I am logged in as a user with the :permissions permission(s)
    */
   public function assertLoggedInWithPermissions($permissions) {
+    // Create a temporary role with given permissions.
+    $permissions = explode(',', $permissions);
+    $role = $this->getDriver()->roleCreate($permissions);
+
     // Create user.
     $user = (object) array(
       'name' => $this->getRandom()->name(8),
       'pass' => $this->getRandom()->name(16),
+      'role' => $role,
     );
     $user->mail = "{$user->name}@example.com";
     $this->userCreate($user);
 
-    // Create and assign a temporary role with given permissions.
-    $permissions = explode(',', $permissions);
-    $rid = $this->getDriver()->roleCreate($permissions);
-    $this->getDriver()->userAddRole($user, $rid);
-    $this->roles[] = $rid;
+    // Assign the temporary role with given permissions.
+    $this->getDriver()->userAddRole($user, $role);
+    $this->roles[] = $role;
 
     // Login.
     $this->login();


### PR DESCRIPTION
If we don't set a role on the user object then if the following Exception is thrown:

https://github.com/jhedstrom/drupalextension/blob/master/src/Drupal/DrupalExtension/Context/RawDrupalContext.php#L365

when we are checking if a user is logged in then it will error with:

```
Notice: Undefined property: stdClass::$role in vendor/drupal/drupal-extension/src/Drupal/DrupalExtension/Context/RawDrupalContext.php line 365
```

I've changed $rid to $role because it is the role name that is being stored on not the rid value.
