### PR TITLE
Provide a shorter alias for logging in as a user with a certain role.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -36,6 +36,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * Creates and authenticates a user with the given role(s).
    *
    * @Given I am logged in as a user with the :role role(s)
+   * @Given I am logged in as a/an :role
    */
   public function assertAuthenticatedByRole($role) {
     // Check if a user with this role is already logged in.


### PR DESCRIPTION
This is a very simple feature request. One of the most common actions is to log in as a user with a certain role:

```
@Given I am logged in as a user with the :role role(s)
```

I would love to have this shorter version available as an alias. This read and writes a bit more fluently :)
```
@Given I am logged in as a/an :role
```