### PR TITLE
Make login more robust.

### DIFF
--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -118,16 +118,16 @@ class DrupalExtension implements ExtensionInterface {
           addDefaultsIfNotSet()->
           children()->
             scalarNode('log_in')->
-              defaultValue('Log in')->
+              defaultValue('edit-submit')->
             end()->
             scalarNode('log_out')->
               defaultValue('Log out')->
             end()->
             scalarNode('password_field')->
-              defaultValue('Password')->
+              defaultValue('edit-pass')->
             end()->
             scalarNode('username_field')->
-              defaultValue('Username')->
+              defaultValue('edit-user')->
             end()->
           end()->
         end()->


### PR DESCRIPTION
When logging in, I think it would be better to use field IDs rather than human-readable labels for two reasons:
1. i18n: this works out of the box on non-English sites. Even though these text overrides are documented, they can be hard to find the first time you set up a non-English site and wonder why logins are failing.
2. Collisions with other login forms: if you have a login form in your site header or sidebar, odds are good that it will have at least one field with the same name as a field on /user. For instance, both password fields might be labeled "Password". Behat will arbitrarily choose one to fill out. This race condition can cause very mysterious login failures.
