### PR TITLE
Use the same version of Guzzle as Drupal 8 core.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ sudo: false
 
 install:
   - composer self-update
+  # Use the example composer.json file for Drupal 8.
+  - test ${DRUPAL_VERSION} -eq 8 && cp doc/_static/composer.json.d8 ./composer.json || true
   - composer install
   - composer global require drush/drush:dev-master --prefer-source
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,11 @@ env:
 
 matrix:
   exclude:
-    - php: 5.3
-      env: DRUPAL_VERSION=8
     - php: 5.4
       env: DRUPAL_VERSION=8
     - php: 5.6
       env: DRUPAL_VERSION=6
     - php: 7.0
-      env: DRUPAL_VERSION=6
-    - php: hhvm
       env: DRUPAL_VERSION=6
   allow_failures:
     - php: 7.0

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -43,7 +43,7 @@ drupal6:
         tags: "@d6"
   extensions:
     Behat\MinkExtension:
-      base_url: http://localhost:8888
+      base_url: http://127.0.0.1:8888
     Drupal\DrupalExtension:
       api_driver: "drupal"
       drupal:
@@ -66,7 +66,7 @@ drupal7:
         tags: "@d7"
   extensions:
     Behat\MinkExtension:
-      base_url: http://localhost:8888
+      base_url: http://127.0.0.1:8888
     Drupal\DrupalExtension:
       api_driver: "drupal"
       drupal:
@@ -91,7 +91,7 @@ drush:
         tags: "@drushTest"
   extensions:
     Behat\MinkExtension:
-      base_url: http://localhost:8888
+      base_url: http://127.0.0.1:8888
     Drupal\DrupalExtension:
       api_driver: "drush"
       drush_driver: "drush"
@@ -114,7 +114,7 @@ drupal8:
         tags: "@d8&&~@d8wip"
   extensions:
     Behat\MinkExtension:
-      base_url: http://localhost:8888
+      base_url: http://127.0.0.1:8888
     Drupal\DrupalExtension:
       api_driver: "drupal"
       drupal:

--- a/doc/_static/composer.json.d8
+++ b/doc/_static/composer.json.d8
@@ -1,0 +1,40 @@
+{
+  "name": "drupal/drupal-extension",
+  "type": "behat-extension",
+  "description": "Drupal extension for Behat",
+  "keywords": ["drupal", "web", "test"],
+  "homepage": "http://drupal.org/project/drupalextension",
+  "license": "GPL-2.0+",
+  "authors": [
+     {
+       "name": "Jonathan Hedstrom",
+       "email": "jhedstrom@gmail.com"
+     }
+  ],
+  "require": {
+    "behat/mink": "~1.5",
+    "behat/mink-goutte-driver": "~1.0",
+    "behat/mink-selenium2-driver": "~1.1",
+    "behat/behat": "~3.0,>=3.0.5",
+    "behat/mink-extension": "~2.0",
+    "drupal/drupal-driver": "~1.0@dev",
+    "guzzlehttp/guzzle" : "^6.0@dev"
+  },
+  "require-dev": {
+    "phpspec/phpspec": "~2.0",
+    "phpunit/phpunit": "3.7.*",
+    "behat/mink-zombie-driver": "^1.2"
+  },
+  "autoload": {
+    "psr-0": {
+      "Drupal\\Drupal": "src/",
+      "Drupal\\Exception": "src/",
+      "Drupal\\DrupalExtension": "src/"
+    }
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "3.0.x-dev"
+    }
+  }
+}

--- a/doc/localinstall.rst
+++ b/doc/localinstall.rst
@@ -27,6 +27,12 @@ infrastructure. It also makes documentation consistent and reliable.
      :language: javascript 
      :linenos:
 
+  For Drupal 8, you'll need to specify the correct version of Guzzle:
+
+  .. literalinclude:: _static/snippets/composer.json.d8
+     : language: javascript
+     :linenos:
+
 4. Run the following command to install the Drupal Extension and all those
    dependencies. This takes a while before you start to see output::
 


### PR DESCRIPTION
This is a fix for issue #193. Adding the same version of Guzzle as Drupal 8 uses. This pulls in guzzle/psr7 version 1.2.0 as a dependency which contains a fix for the fatal error from #193.

This will still fail until https://www.drupal.org/node/2546272 is committed but that issue is RTBC and is on the brink of being committed. Awaiting this to be fixed upstream I'll create a fork of Drupal core with the patch applied to see whether we can get the tests green again.

Locally I had a test failure in the field handlers test, but that is probably unrelated to this issue.