### PR TITLE
assertRegionElementAttribute() only checks one element if it has a matching attribute

### DIFF
--- a/src/Drupal/DrupalExtension/Context/MarkupContext.php
+++ b/src/Drupal/DrupalExtension/Context/MarkupContext.php
@@ -107,11 +107,10 @@ class MarkupContext extends RawMinkContext {
       foreach ($elements as $element) {
         $attr = $element->getAttribute($attribute);
         if (!empty($attr)) {
-          $found = TRUE;
-          if (strpos($attr, "$value") === FALSE) {
-            throw new \Exception(sprintf('The "%s" attribute does not equal "%s" on the element "%s" in the "%s" region on the page %s', $attribute, $value, $tag, $region, $this->getSession()->getCurrentUrl()));
+          if (strpos($attr, "$value") !== FALSE) {
+            $found = TRUE;
+            break;
           }
-          break;
         }
       }
       if (!$found) {


### PR DESCRIPTION
The `MarkupContext` context `assertRegionElementAttribute()` gets a region, finds all of the elements that match a specified tag in that region and then loops through the elements to see if any of them have an attribute that matches a given value.

However, when it loops through all of the specified elements, it checks to see if the element has a given attribute and then automatically declares that a match has been found before checking to see if it has the proper value. It then throws an exception if it doesn't match the value. This means that if two or more elements have the same attribute (such as when searching for a `<div>` with a specific class) and the first `<div>` has a class but doesn't have the class you are looking for, the test will fail.

I believe that it should loop through all of the elements and only declare that a match has been found if a given element has the specified property and that property matches the specified value.

An exception should only be thrown once all of the elements have been examined and no match was found.
