### PR TITLE
Update globalinstall.rst re `FeatureContext` not found error/

### DIFF
--- a/doc/globalinstall.rst
+++ b/doc/globalinstall.rst
@@ -94,7 +94,13 @@ Set up tests
 
   This will make your FeatureContext.php aware of both the Drupal Extension and
   the Mink Extension, so you'll be able to take advantage of their drivers and
-  step definitions and add your own custom step definitions here.
+  step definitions and add your own custom step definitions here. 
+  The FeatureContext.php file must be in the same directory as your behat.yml
+  file otherwise in step 5 you will get the following error:
+  
+    [Behat\Behat\Context\Exception\ContextNotFoundException]
+    `FeatureContext` context class not found and can not be used. 
+  
 
 5. To ensure everything is set up appropriately, type::
 


### PR DESCRIPTION
When following the global install instructions to the letter I encountered an error at the last step.
The following error was displayed when I ran the behat -dl command:
    
    [Behat\Behat\Context\Exception\ContextNotFoundException]
    `FeatureContext` context class not found and can not be used.

Moving the FeatureContext.php file from /behat-tests/features/bootstrap to /behat-tests fixed the issue for me.

Hopefully this will be helpful to others.