### PR TITLE
Allow entity titles that include a comma

### DIFF
--- a/features/api.feature
+++ b/features/api.feature
@@ -146,16 +146,16 @@ Feature: DrupalContext
     | name      |
     | Tag one   |
     | Tag two   |
-    | Tag three |
+    | Tag,three |
     | Tag four  |
     And "article" content:
-    | title           | body             | promote | field_tags                  |
-    | Article by Joe  | PLACEHOLDER BODY |       1 | Tag one, Tag two, Tag three |
-    | Article by Mike | PLACEHOLDER BODY |       1 | Tag four                    |
+    | title           | body             | promote | field_tags                    |
+    | Article by Joe  | PLACEHOLDER BODY |       1 | Tag one, Tag two, "Tag,three" |
+    | Article by Mike | PLACEHOLDER BODY |       1 | Tag four                      |
     When I am on the homepage
     Then I should see the link "Tag one"
     And I should see the link "Tag two"
-    And I should see the link "Tag three"
+    And I should see the link "Tag,three"
     And I should see the link "Tag four"
 
   Scenario: Readable created dates

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -275,7 +275,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
 
   /**
    * Parse multi-value fields. Possible formats:
-   *    A, B, C
+   *    A, B, "C, D"
    *    A - B, C - D, E - F
    *
    * @param string $entity_type
@@ -313,7 +313,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
       if ($this->getDriver()->isField($entity_type, $field_name)) {
         // Split up multiple values in multi-value fields.
         $values = array();
-        foreach (explode(', ', $field_value) as $key => $value) {
+        foreach (str_getcsv($field_value) as $key => $value) {
           $columns = $value;
           // Split up field columns if the ' - ' separator is present.
           if (strstr($value, ' - ') !== FALSE) {


### PR DESCRIPTION
Currently entity titles are just split on a comma+space, which means that any that contain a comma can't be referenced.

This changes `explode()` to `str_getcsv()`, which should cater for this. It will, however, be a BC break for anything using titles that around surrounded with double quotes (they would now need to be escaped).
