### PR TITLE
Use Random.name instead of Random.string for node and taxonomy content.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -222,7 +222,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
     $node = (object) array(
       'title' => $title,
       'type' => $type,
-      'body' => $this->getRandom()->string(255),
+      'body' => $this->getRandom()->name(255),
     );
     $saved = $this->nodeCreate($node);
     // Set internal page on the new node.
@@ -242,7 +242,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
     $node = (object) array(
       'title' => $title,
       'type' => $type,
-      'body' => $this->getRandom()->string(255),
+      'body' => $this->getRandom()->name(255),
       'uid' => $this->user->uid,
     );
     $saved = $this->nodeCreate($node);
@@ -319,7 +319,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
     $term = (object) array(
       'name' => $name,
       'vocabulary_machine_name' => $vocabulary,
-      'description' => $this->getRandom()->string(255),
+      'description' => $this->getRandom()->name(255),
     );
     $saved = $this->termCreate($term);
 


### PR DESCRIPTION
The characters present in Random.string make the Pantheon security sniffer suspicious when they pass through the [Behat Drush Endpoint](https://github.com/drush-ops/behat-drush-endpoint).

Perhaps it would be sufficient to simplify here?  This change shouldn't affect the robustness of the tests; if users specifically want to test certain characters in node creation, they could always explicitly use them in their test data.

Hope this is okay.