### PR TITLE
Drush tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,8 @@ before_script:
   - cp -r fixtures/drupal${DRUPAL_VERSION}/modules/behat_test ${MODULE_PATH}
   - cd drupal
   - drush --yes en behat_test
-  - mkdir drush; git clone https://github.com/drush-ops/behat-drush-endpoint.git drush/behat-drush-endpoint
+  - test ${DRUPAL_VERSION} -eq 8 || mkdir drush; git clone https://github.com/drush-ops/behat-drush-endpoint.git drush/behat-drush-endpoint
+  - test ${DRUPAL_VERSION} -ne 8 || composer require drush-ops/behat-drush-endpoint
   - drush cc drush
   - drush help behat
   # Only revert features on Drupal 7.

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_script:
   - cp -r fixtures/drupal${DRUPAL_VERSION}/modules/behat_test ${MODULE_PATH}
   - cd drupal
   - drush --yes en behat_test
-  - mkdir -p $PWD/drupal/drush; git clone https://github.com/drush-ops/behat-drush-endpoint.git $PWD/drupal/drush/behat-drush-endpoint
+  - mkdir -p drupal/drush; cd drupal/drush && git clone https://github.com/drush-ops/behat-drush-endpoint.git
   - drush cc drush
   - drush help behat
   # Only revert features on Drupal 7.

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,8 @@ script:
   - vendor/bin/phpspec run -f pretty --no-interaction
   - vendor/bin/behat -fprogress --strict
   - vendor/bin/behat -fprogress --profile=drupal${DRUPAL_VERSION} --strict
-  # Only test the Drush profile if Drupal 7 was installed.
-  - test \! ${DRUPAL_VERSION} -eq 7 || vendor/bin/behat -fprogress --profile=drush --strict
+  # Do not test the Drush profile if Drupal 6 was installed.
+  - test ${DRUPAL_VERSION} -eq 6 || vendor/bin/behat -fprogress --profile=drush --strict
 
 after_failure:
   - cat ~/debug.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,8 @@ script:
   - vendor/bin/phpspec run -f pretty --no-interaction
   - vendor/bin/behat -fprogress --strict
   - vendor/bin/behat -fprogress --profile=drupal${DRUPAL_VERSION} --strict
-  # Do not test the Drush profile if Drupal 6 was installed.
-  - test ${DRUPAL_VERSION} -eq 6 || vendor/bin/behat -fprogress --profile=drush --strict
+  # Do not test the Drush profile unless Drupal 7 was installed.
+  - test ${DRUPAL_VERSION} -ne 7 || vendor/bin/behat -fprogress --profile=drush --strict
 
 after_failure:
   - cat ~/debug.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ before_script:
   - cp -r fixtures/drupal${DRUPAL_VERSION}/modules/behat_test ${MODULE_PATH}
   - cd drupal
   - drush --yes en behat_test
+  - mkdir -p $PWD/drupal/drush; git clone https://github.com/drush-ops/behat-drush-endpoint.git $PWD/drupal/drush/behat-drush-endpoint
   # Only revert features on Drupal 7.
   - test \! ${DRUPAL_VERSION} -eq 7 || drush --yes fr behat_test
   # Disable the page cache on Drupal 8.

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,9 @@ before_script:
   - cp -r fixtures/drupal${DRUPAL_VERSION}/modules/behat_test ${MODULE_PATH}
   - cd drupal
   - drush --yes en behat_test
-  - mkdir -p drupal/drush; cd drupal/drush && git clone https://github.com/drush-ops/behat-drush-endpoint.git
+  - mkdir drush; git clone https://github.com/drush-ops/behat-drush-endpoint.git drush/behat-drush-endpoint
   - drush cc drush
-  - drush --root=$PWD/drupal help behat
+  - drush help behat
   # Only revert features on Drupal 7.
   - test \! ${DRUPAL_VERSION} -eq 7 || drush --yes fr behat_test
   # Disable the page cache on Drupal 8.

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,10 @@ before_script:
   - cp -r fixtures/drupal${DRUPAL_VERSION}/modules/behat_test ${MODULE_PATH}
   - cd drupal
   - drush --yes en behat_test
-  - test ${DRUPAL_VERSION} -eq 8 || mkdir drush; git clone https://github.com/drush-ops/behat-drush-endpoint.git drush/behat-drush-endpoint
+  - test ${DRUPAL_VERSION} -ne 7 || mkdir drush; git clone https://github.com/drush-ops/behat-drush-endpoint.git drush/behat-drush-endpoint; (cd drush/behat-drush-endpoint && composer install)
   - test ${DRUPAL_VERSION} -ne 8 || composer require drush-ops/behat-drush-endpoint
   - drush cc drush
-  - drush help behat
+  - test ${DRUPAL_VERSION} -eq 6 || drush help behat
   # Only revert features on Drupal 7.
   - test \! ${DRUPAL_VERSION} -eq 7 || drush --yes fr behat_test
   # Disable the page cache on Drupal 8.

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,8 @@ before_script:
   - cd drupal
   - drush --yes en behat_test
   - mkdir -p $PWD/drupal/drush; git clone https://github.com/drush-ops/behat-drush-endpoint.git $PWD/drupal/drush/behat-drush-endpoint
+  - drush cc drush
+  - drush help behat
   # Only revert features on Drupal 7.
   - test \! ${DRUPAL_VERSION} -eq 7 || drush --yes fr behat_test
   # Disable the page cache on Drupal 8.

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_script:
   - drush --yes en behat_test
   - mkdir -p drupal/drush; cd drupal/drush && git clone https://github.com/drush-ops/behat-drush-endpoint.git
   - drush cc drush
-  - drush help behat
+  - drush --root=$PWD/drupal help behat
   # Only revert features on Drupal 7.
   - test \! ${DRUPAL_VERSION} -eq 7 || drush --yes fr behat_test
   # Disable the page cache on Drupal 8.

--- a/features/drush.feature
+++ b/features/drush.feature
@@ -16,3 +16,10 @@ Feature: Drush-specific steps
     Given I run drush "en" "toolbar -y"
       And I run drush "en" "toolbar -y"
     Then drush output should contain "toolbar is already enabled."
+
+  Scenario: Create and view a node with fields using the Drush driver
+    Given I am viewing an "Article":
+    | title | My article with fields! |
+    | body  | A placeholder           |
+    Then I should see the heading "My article with fields!"
+    And I should see the text "A placeholder"


### PR DESCRIPTION
Add a failing test demonstrating that the Drush driver cannot create content without the Behat Drush Endpoint.

Next will come working tests.