### PR TITLE
Provide steps to install and uninstall modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,19 @@
     "behat/mink-selenium2-driver": "~1.1",
     "behat/behat": "~3.0,>=3.0.5",
     "behat/mink-extension": "~2.0",
-    "drupal/drupal-driver": "~1.0@dev"
+    "drupal/drupal-driver": "dev-install-uninstall-modules"
   },
   "require-dev": {
     "phpspec/phpspec": "~2.0",
     "phpunit/phpunit": "3.7.*",
     "behat/mink-zombie-driver": "^1.2"
   },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/pfrenssen/DrupalDriver"
+    }
+  ],
   "autoload": {
     "psr-0": {
       "Drupal\\Drupal": "src/",

--- a/features/modules.feature
+++ b/features/modules.feature
@@ -1,0 +1,22 @@
+@api @d6 @d7 @d8
+Feature: Module support
+  In order to be able to test optional features
+  As a developer for a Drupal distribution
+  I need to be able to install and uninstall modules
+
+  # These test scenarios assume to have a clean installation of the "standard"
+  # profile and that the "behat_test" module from the "fixtures/" folder is
+  # enabled on the site.
+
+  Scenario: Enable module with dependencies
+    # The Comment module is enabled in the standard install.
+    Given the "comment" module should be active
+
+    # Check that we can disable modules.
+    When the "comment" module is disabled
+    Then the "comment" module should not be active
+
+    # The Forum module depends on the Comment module, so both should be enabled.
+    Given the "forum" module is enabled
+    Then the "forum" module should be active
+    Then the "comment" module should be active

--- a/features/modules.feature
+++ b/features/modules.feature
@@ -20,3 +20,21 @@ Feature: Module support
     Given the "forum" module is enabled
     Then the "forum" module should be active
     Then the "comment" module should be active
+
+  Scenario: Enable and disable multiple modules at once
+    Given the following modules are enabled:
+    | module |
+    | color  |
+    | forum  |
+    | search |
+    Then the "color" module should be active
+    And the "forum" module should be active
+    And the "search" module should be active
+    When the following modules are disabled:
+    | module |
+    | color  |
+    | forum  |
+    | search |
+    Then the "color" module should not be active
+    And the "forum" module should not be active
+    And the "search" module should not be active

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -399,6 +399,108 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
   }
 
   /**
+   * Installs the given module.
+   *
+   * @Given the :module module is enabled/installed
+   *
+   * @param string $module
+   *   The name of the module to install.
+   */
+  public function installModule($module) {
+    $this->installModules(array($module));
+  }
+
+  /**
+   * Installs the given modules.
+   *
+   * @Given the following modules are enabled/installed:
+   *
+   * Provide the list of modules in the following format:
+   * | modules |
+   * | comment |
+   * | forum   |
+   *
+   * @param TableNode $modulesTable
+   *   The list of modules to install.
+   */
+  public function installModuleList(TableNode $modulesTable) {
+    $modules = array();
+    foreach ($modulesTable->getHash() as $row) {
+      $modules[] = $row['module'];
+    }
+    $this->installModules($modules);
+  }
+
+  /**
+   * Uninstalls the given module.
+   *
+   * @Given the :module module is disabled/uninstalled
+   *
+   * @param string $module
+   *   The name of the module to uninstall.
+   */
+  public function uninstallModule($module) {
+    $this->uninstallModules(array($module));
+  }
+
+  /**
+   * Uninstalls the given modules.
+   *
+   * @Given the following modules are disabled/uninstalled:
+   *
+   * Provide the list of modules in the following format:
+   * | modules |
+   * | comment |
+   * | forum   |
+   *
+   * @param TableNode $modulesTable
+   *   The list of modules to uninstall.
+   */
+  public function uninstallModuleList(TableNode $modulesTable) {
+    $modules = array();
+    foreach ($modulesTable->getHash() as $row) {
+      $modules[] = $row['module'];
+    }
+    $this->uninstallModules($modules);
+  }
+
+  /**
+   * Checks if the given module is active.
+   *
+   * @Then the :module module should be enabled/active
+   *
+   * @param string $module
+   *   The name of the module to check.
+   *
+   * @throws \Exception
+   *   Thrown when the module is not active.
+   */
+  public function assertModuleActive($module) {
+    $module_list = $this->getDriver()->getCore()->getModuleList();
+    if (!in_array($module, $module_list)) {
+      throw new \Exception(sprintf('The %s module is not active.', $module));
+    }
+  }
+
+  /**
+   * Checks if the given module is not active.
+   *
+   * @Then the :module module should not be enabled/active
+   *
+   * @param string $module
+   *   The name of the module to check.
+   *
+   * @throws \Exception
+   *   Thrown when the module is active.
+   */
+  public function assertModuleNotActive($module) {
+    $module_list = $this->getDriver()->getCore()->getModuleList();
+    if (in_array($module, $module_list)) {
+      throw new \Exception(sprintf('The %s module is active.', $module));
+    }
+  }
+
+  /**
    * Pauses the scenario until the user presses a key. Useful when debugging a scenario.
    *
    * @Then (I )break

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -89,6 +89,13 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   protected $languages = array();
 
   /**
+   * Keep track of any modules that are installed so they can be uninstalled.
+   *
+   * @var array
+   */
+  protected $modules = array();
+
+  /**
    * {@inheritDoc}
    */
   public function setDrupal(DrupalDriverManager $drupal) {
@@ -225,6 +232,18 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
       $this->getDriver()->languageDelete($language);
       unset($this->languages[$language->langcode]);
     }
+  }
+
+  /**
+   * Uninstall any installed modules.
+   *
+   * @AfterScenario
+   */
+  public function cleanModules() {
+    if (!empty($this->modules)) {
+      $this->uninstallModules($this->modules);
+    }
+    $this->modules = array();
   }
 
   /**
@@ -465,6 +484,27 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    */
   public function loggedInWithRole($role) {
     return $this->loggedIn() && $this->user && isset($this->user->role) && $this->user->role == $role;
+  }
+
+  /**
+   * Installs the given modules.
+   *
+   * @param array $modules
+   *   A list of machine names of modules to install.
+   */
+  public function installModules(array $modules) {
+    $this->getDriver()->installModules($modules);
+    $this->modules = array_merge($this->modules, $modules);
+  }
+
+  /**
+   * Uninstalls the given modules.
+   *
+   * @param array $modules
+   *   A list of machine names of modules to uninstall.
+   */
+  public function uninstallModules(array $modules) {
+    $this->getDriver()->uninstallModules($modules);
   }
 
 }


### PR DESCRIPTION
I'm using DrupalDriver to test a distribution with a whole bunch of optional features. I would like to be able to install and uninstall them.

This pull request adds step definitions to install and uninstall modules. It relies on this sister PR in DrupalDriver: https://github.com/jhedstrom/DrupalDriver/pull/69

I have omitted the enabling and disabling of modules since this has been removed from Drupal 8 for good reasons. Since from an end user / BDD perspective there isn't much difference between installing and enabling a module I even made both terms available.

I've tested this only on Drupal 7 for now. Will test D6 and D8 tomorrow, and hopefully Drush too.
