### PR TITLE
Provide an example that uses human readable field names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "behat/mink": "~1.5",
     "behat/mink-goutte-driver": "~1.0",
     "behat/mink-selenium2-driver": "~1.1",
-    "behat/behat": "~3.0,>=3.0.5",
+    "behat/behat": "dev-master#2059cbe",
     "behat/mink-extension": "~2.0",
     "drupal/drupal-driver": "dev-master"
   },

--- a/doc/_static/composer.json.d8
+++ b/doc/_static/composer.json.d8
@@ -12,14 +12,15 @@
      }
   ],
   "require": {
-    "behat/behat": "~3.0,>=3.0.5",
+    "behat/behat": "dev-master#2059cbe",
     "behat/mink": "~1.5",
     "behat/mink-extension": "~2.0",
     "behat/mink-goutte-driver": "~1.0",
     "behat/mink-selenium2-driver": "~1.1",
-    "drupal/drupal-driver": "~1.0@dev",
+    "drupal/drupal-driver": "dev-master",
     "guzzlehttp/guzzle" : "^6.0@dev",
-    "symfony/dependency-injection": "2.7.*"
+    "symfony/dependency-injection": "2.7.*",
+    "symfony/event-dispatcher": "2.7.*"
   },
   "require-dev": {
     "phpspec/phpspec": "~2.0",

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -130,6 +130,41 @@ class FeatureContext implements Context {
   }
 
   /**
+   * Transforms human readable field names into machine names.
+   *
+   * This is used in field_handlers.feature for testing if human readable names
+   * can be used instead of machine names in tests.
+   *
+   * @param TableNode $post_table
+   *   The original table.
+   *
+   * @return TableNode
+   *   The transformed table.
+   *
+   * @Transform rowtable:title,body,reference,date,links,select,address
+   */
+  public function transformPostContentTable(TableNode $post_table) {
+    $aliases = array(
+      'reference' => 'field_post_reference',
+      'date' => 'field_post_date',
+      'links' => 'field_post_links',
+      'select' => 'field_post_select',
+      'address' => 'field_post_address',
+    );
+
+    $table = $post_table->getTable();
+    array_walk($table, function (&$row) use ($aliases) {
+      // The first column of the row contains the field names. Replace the
+      // human readable field name with the machine name if it exists.
+      if (array_key_exists($row[0], $aliases)) {
+        $row[0] = $aliases[$row[0]];
+      }
+    });
+
+    return new TableNode($table);
+  }
+
+  /**
    * From here down is the Behat FeatureContext.
    *
    * @defgroup Behat FeatureContext

--- a/features/field_handlers.feature
+++ b/features/field_handlers.feature
@@ -33,6 +33,37 @@ Feature: FieldHandlers
     And I should see "1000"
     And I should see "Louisalaan 1"
 
+  # This is identical to the previous test, but uses human readable names for
+  # the field names. This is better from a BDD standpoint. Please have a look at
+  # FeatureContext::transformPostContentTable() to see how the mapping between
+  # the machine names and human readable names is defined.
+  @d7 @d8
+  Scenario: Test using human readable names for fields using @Transform
+    Given "page" content:
+      | title      |
+      | Page one   |
+      | Page two   |
+      | Page three |
+    When I am viewing a "post" content:
+      | title     | Post title                                                                       |
+      | body      | PLACEHOLDER BODY                                                                 |
+      | reference | Page one, Page two                                                               |
+      | date      | 2015-02-08 17:45:00                                                              |
+      | links     | Link 1 - http://example.com, Link 2 - http://example.com                         |
+      | select    | One, Two                                                                         |
+      | address   | country: BE - locality: Brussel - thoroughfare: Louisalaan 1 - postal_code: 1000 |
+    Then I should see "Page one"
+    And I should see "Page two"
+    And I should see "Sunday, February 8, 2015"
+    And I should see the link "Link 1"
+    And I should see the link "Link 2"
+    And I should see "One"
+    And I should see "Two"
+    And I should see "Belgium"
+    And I should see "Brussel"
+    And I should see "1000"
+    And I should see "Louisalaan 1"
+
   @d7 @d8
   Scenario: Test alternative syntax for named field columns on node content
     When I am viewing a "post" content:


### PR DESCRIPTION
Recently support was added to Behat to do @transform on row-based tables: [PR #654: Add support for row table transformations](https://github.com/Behat/Behat/pull/654). This finally makes it possible to use human readable names for fields.

## Before

Up to now we were forced to use machine names which are not only ugly, but violate the BDD principle of using domain specific language:

```
When I am viewing a "post" content:
  | title                | Post title          |
  | body                 | Body text           |
  | field_post_reference | Page one, Page two  |
  | field_post_date      | 2015-02-08 17:45:00 |
```

## After

```
When I am viewing a "post" content:
  | title     | Post title          |
  | body      | Body text           |
  | reference | Page one, Page two  |
  | date      | 2015-02-08 17:45:00 |
```

Much better!

Note that this currently relies on code that has recently been committed to the master branch of Behat. We might want to wait on a new release of Behat before merging this in.