### PR TITLE
Improve verbosity of login failure.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -427,7 +427,12 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
     $submit->click();
 
     if (!$this->loggedIn()) {
-      throw new \Exception(sprintf("Failed to log in as user '%s' with role '%s'", $this->user->name, $this->user->role));
+      if (isset($this->user->role)) {
+        throw new \Exception(sprintf("Unable to determine if logged in because 'log_out' link cannot be found for user '%s' with role '%s'", $this->user->name, $this->user->role));
+      }
+      else {
+        throw new \Exception(sprintf("Unable to determine if logged in because 'log_out' link cannot be found for user '%s'", $this->user->name));
+      }
     }
   }
 


### PR DESCRIPTION
This PR should address the usability and PHP error found in #227 

The check for a logged-in user is the same as Drupal's SimpleTest, which is the existence of a "log_out" link. I think it's fair to continue to look for that, but the error today doesn't describe the problem and has a PHP error if certain conditions are met.

Current:

> Failed to log in as user '%s' with role '%s'

Proposed solution:

> Unable to determine if logged in because 'log_out' link cannot be found for user '%s' with role '%s'

That way, developers know why the test is failing rather than something that implies that there's a problem with roles (there isn't).

Also, there's a PHP error if `$this->user->role` is missing, which was being experienced if you attempt to log in with permissions, not roles, which is why I'm checking for the existence of the property. Let me know if you think that's worth hunting down (I'm not familiar with it enough to know if it's working as designed).