### PR TITLE
Missing link text in the exception thrown in DrupalContext::assertClickInTableRow()

### DIFF
--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -189,9 +189,9 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    */
   public function assertClickInTableRow($link, $rowText) {
     $page = $this->getSession()->getPage();
-    if ($link = $this->getTableRow($page, $rowText)->findLink($link)) {
+    if ($link_element = $this->getTableRow($page, $rowText)->findLink($link)) {
       // Click the link and return.
-      $link->click();
+      $link_element->click();
       return;
     }
     throw new \Exception(sprintf('Found a row containing "%s", but no "%s" link on the page %s', $rowText, $link, $this->getSession()->getCurrentUrl()));


### PR DESCRIPTION
The `$link` variable is reused in `DrupalContext::assertClickInTableRow()` causing the exception text to lack the link text when it is thrown:

> Found a row containing "Article", but no "" link on the page http://drupal.local/admin/structure/types (Exception)