### PR TITLE
[WIP] Extend test coverage for the D8 API and fix any uncovered problems

### DIFF
--- a/doc/_static/composer.json.d8
+++ b/doc/_static/composer.json.d8
@@ -18,7 +18,8 @@
     "behat/behat": "~3.0,>=3.0.5",
     "behat/mink-extension": "~2.0",
     "drupal/drupal-driver": "~1.0@dev",
-    "guzzlehttp/guzzle" : "^6.0@dev"
+    "guzzlehttp/guzzle" : "^6.0@dev",
+    "symfony/dependency-injection": "2.7.*"
   },
   "require-dev": {
     "phpspec/phpspec": "~2.0",

--- a/doc/_static/composer.json.d8
+++ b/doc/_static/composer.json.d8
@@ -12,11 +12,11 @@
      }
   ],
   "require": {
+    "behat/behat": "~3.0,>=3.0.5",
     "behat/mink": "~1.5",
+    "behat/mink-extension": "~2.0",
     "behat/mink-goutte-driver": "~1.0",
     "behat/mink-selenium2-driver": "~1.1",
-    "behat/behat": "~3.0,>=3.0.5",
-    "behat/mink-extension": "~2.0",
     "drupal/drupal-driver": "~1.0@dev",
     "guzzlehttp/guzzle" : "^6.0@dev",
     "symfony/dependency-injection": "2.7.*"

--- a/features/api.feature
+++ b/features/api.feature
@@ -12,13 +12,21 @@ Feature: DrupalContext
     When I click "My account"
     Then I should see the text "Member for"
 
-  @drushTest @d7 @d8
+  @drushTest @d7
   Scenario: Target links within table rows
     Given I am logged in as a user with the "administrator" role
     When I am at "admin/structure/types"
     And I click "manage fields" in the "Article" row
     Then I should be on "admin/structure/types/manage/article/fields"
     And I should see text matching "Add new field"
+
+  @d8
+  Scenario: Target links within table rows
+    Given I am logged in as a user with the "administrator" role
+    When I am at "admin/structure/types"
+    And I click "Manage fields" in the "Article" row
+    Then I should be on "admin/structure/types/manage/article/fields"
+    And I should see text matching "Add field"
 
   @drushTest @d7 @d8
   Scenario: Find a heading in a region

--- a/features/api.feature
+++ b/features/api.feature
@@ -135,7 +135,7 @@ Feature: DrupalContext
     When I am viewing a "tags" term with the name "My tag"
     Then I should see the heading "My tag"
 
-  @d7 @d8
+  @d7
   Scenario: Create many terms
     Given "tags" terms:
     | name    |
@@ -146,7 +146,18 @@ Feature: DrupalContext
     Then I should see "Tag one"
     And I should see "Tag two"
 
-  @d7 @d8
+  @d8
+  Scenario: Create many terms
+    Given "tags" terms:
+    | name    |
+    | Tag one |
+    | Tag two |
+    And I am logged in as a user with the "administrator" role
+    When I go to "admin/structure/taxonomy/manage/tags/overview"
+    Then I should see "Tag one"
+    And I should see "Tag two"
+
+  @d7
   Scenario: Create terms using vocabulary title rather than machine name.
     Given "Tags" terms:
     | name    |
@@ -154,6 +165,17 @@ Feature: DrupalContext
     | Tag two |
     And I am logged in as a user with the "administrator" role
     When I go to "admin/structure/taxonomy/tags"
+    Then I should see "Tag one"
+    And I should see "Tag two"
+
+  @d8
+  Scenario: Create terms using vocabulary title rather than machine name.
+    Given "Tags" terms:
+    | name    |
+    | Tag one |
+    | Tag two |
+    And I am logged in as a user with the "administrator" role
+    When I go to "admin/structure/taxonomy/manage/tags/overview"
     Then I should see "Tag one"
     And I should see "Tag two"
 

--- a/features/api.feature
+++ b/features/api.feature
@@ -231,7 +231,7 @@ Feature: DrupalContext
   @d7 @d8
   Scenario: Node edit access by administrator
     Given I am logged in as a user with the "administrator" role
-    Then I should be able to edit an "Article"
+    Then I should be able to edit an "article"
 
   @d7 @d8
   Scenario: User hooks are functioning

--- a/features/api.feature
+++ b/features/api.feature
@@ -209,7 +209,7 @@ Feature: DrupalContext
     When I visit "admin/people"
     Then I should see the link "Joe User"
 
-  @d7 @d8
+  @d7
   Scenario: Term hooks are functioning
     Given "tags" terms:
     | Label     |
@@ -217,6 +217,17 @@ Feature: DrupalContext
     | Tag two   |
     And I am logged in as a user with the "administrator" role
     When I go to "admin/structure/taxonomy/tags"
+    Then I should see "Tag one"
+    And I should see "Tag two"
+
+  @d8
+  Scenario: Term hooks are functioning
+    Given "tags" terms:
+    | Label     |
+    | Tag one   |
+    | Tag two   |
+    And I am logged in as a user with the "administrator" role
+    When I go to "admin/structure/taxonomy/manage/tags/overview"
     Then I should see "Tag one"
     And I should see "Tag two"
 

--- a/features/api.feature
+++ b/features/api.feature
@@ -28,11 +28,17 @@ Feature: DrupalContext
     Then I should be on "admin/structure/types/manage/article/fields"
     And I should see text matching "Add field"
 
-  @drushTest @d7 @d8
+  @drushTest @d7
   Scenario: Find a heading in a region
     Given I am not logged in
     When I am on the homepage
     Then I should see the heading "User login" in the "left sidebar" region
+
+  @drushTest @d8
+  Scenario: Find a heading in a region
+    Given I am not logged in
+    When I am on the homepage
+    Then I should see the heading "Search" in the "left sidebar" region
 
   @drushTest @d7 @d8
   Scenario: Clear cache

--- a/features/api.feature
+++ b/features/api.feature
@@ -34,7 +34,7 @@ Feature: DrupalContext
     When I am on the homepage
     Then I should see the heading "User login" in the "left sidebar" region
 
-  @drushTest @d8
+  @d8
   Scenario: Find a heading in a region
     Given I am not logged in
     When I am on the homepage

--- a/features/api.feature
+++ b/features/api.feature
@@ -10,7 +10,7 @@ Feature: DrupalContext
   Scenario: Create and log in as a user
     Given I am logged in as a user with the "authenticated user" role
     When I click "My account"
-    Then I should see the heading "History"
+    Then I should see the text "Member for"
 
   @drushTest @d7 @d8
   Scenario: Target links within table rows

--- a/features/api.feature
+++ b/features/api.feature
@@ -103,7 +103,7 @@ Feature: DrupalContext
     When I visit "admin/people"
     Then I should see the link "Joe User"
 
-  @d7 @d8
+  @d7
   Scenario: Create users with roles
     Given users:
     | name     | mail            | roles         |
@@ -111,6 +111,15 @@ Feature: DrupalContext
     And I am logged in as a user with the "administrator" role
     When I visit "admin/people"
     Then I should see the text "administrator" in the "Joe User" row
+
+  @d8
+  Scenario: Create users with roles
+    Given users:
+    | name     | mail            | roles         |
+    | Joe User | joe@example.com | administrator |
+    And I am logged in as a user with the "administrator" role
+    When I visit "admin/people"
+    Then I should see the text "Administrator" in the "Joe User" row
 
   @d7 @d8
   Scenario: Login as a user created during this scenario

--- a/features/api.feature
+++ b/features/api.feature
@@ -179,7 +179,9 @@ Feature: DrupalContext
     Then I should see "Tag one"
     And I should see "Tag two"
 
-  @d7 @d8
+  @d7 @d8wip
+  # TODO: This doesn't work on Drupal 8 yet. For nodes the 'author' field is
+  # called 'uid' and only accepts numerical IDs.
   Scenario: Create nodes with specific authorship
     Given users:
     | name     | mail            | status |

--- a/features/api.feature
+++ b/features/api.feature
@@ -88,7 +88,7 @@ Feature: DrupalContext
 
   @d7 @d8
   Scenario: Create and view a node with fields
-    Given I am viewing an "Article":
+    Given I am viewing an "article":
     | title | My article with fields! |
     | body  | A placeholder           |
     Then I should see the heading "My article with fields!"

--- a/features/api.feature
+++ b/features/api.feature
@@ -1,18 +1,18 @@
-@d7 @api
+@api
 Feature: DrupalContext
   In order to prove the Drupal context is working properly
   As a developer
   I need to use the step definitions of this context
 
-  # These scenarios assume a "standard" install of Drupal 7.
+  # These scenarios assume a "standard" install of Drupal 7 and 8.
 
-  @drushTest
+  @drushTest @d7 @d8
   Scenario: Create and log in as a user
     Given I am logged in as a user with the "authenticated user" role
     When I click "My account"
     Then I should see the heading "History"
 
-  @drushTest
+  @drushTest @d7 @d8
   Scenario: Target links within table rows
     Given I am logged in as a user with the "administrator" role
     When I am at "admin/structure/types"
@@ -20,32 +20,32 @@ Feature: DrupalContext
     Then I should be on "admin/structure/types/manage/article/fields"
     And I should see text matching "Add new field"
 
-  @drushTest
+  @drushTest @d7 @d8
   Scenario: Find a heading in a region
     Given I am not logged in
     When I am on the homepage
     Then I should see the heading "User login" in the "left sidebar" region
 
-  @drushTest @d8 @d8wip
+  @drushTest @d7 @d8
   Scenario: Clear cache
     Given the cache has been cleared
     When I am on the homepage
     Then I should get a "200" HTTP response
 
-  @d8
+  @d7 @d8
   Scenario: Create a node
     Given I am logged in as a user with the "administrator" role
     When I am viewing an "article" with the title "My article"
     Then I should see the heading "My article"
 
-  @drushTest @d8
+  @drushTest @d7 @d8
   Scenario: Run cron
     Given I am logged in as a user with the "administrator" role
     When I run cron
     And am on "admin/reports/dblog"
     Then I should see the link "Cron run completed"
 
-  @d8
+  @d7 @d8
   Scenario: Create many nodes
     Given "page" content:
     | title    |
@@ -62,7 +62,7 @@ Feature: DrupalContext
     And I should see "First article"
     And I should see "Second article"
 
-  @d8
+  @d7 @d8
   Scenario: Create nodes with fields
     Given "article" content:
     | title                     | promote | body             |
@@ -72,6 +72,7 @@ Feature: DrupalContext
     And follow "First article with fields"
     Then I should see the text "PLACEHOLDER BODY"
 
+  @d7 @d8
   Scenario: Create and view a node with fields
     Given I am viewing an "Article":
     | title | My article with fields! |
@@ -79,7 +80,7 @@ Feature: DrupalContext
     Then I should see the heading "My article with fields!"
     And I should see the text "A placeholder"
 
-  @d8
+  @d7 @d8
   Scenario: Create users
     Given users:
     | name     | mail            | status |
@@ -88,6 +89,7 @@ Feature: DrupalContext
     When I visit "admin/people"
     Then I should see the link "Joe User"
 
+  @d7 @d8
   Scenario: Create users with roles
     Given users:
     | name     | mail            | roles         |
@@ -96,7 +98,7 @@ Feature: DrupalContext
     When I visit "admin/people"
     Then I should see the text "administrator" in the "Joe User" row
 
-  @d8
+  @d7 @d8
   Scenario: Login as a user created during this scenario
     Given users:
     | name      | status |
@@ -104,11 +106,13 @@ Feature: DrupalContext
     When I am logged in as "Test user"
     Then I should see the link "Log out"
 
+  @d7 @d8
   Scenario: Create a term
     Given I am logged in as a user with the "administrator" role
     When I am viewing a "tags" term with the name "My tag"
     Then I should see the heading "My tag"
 
+  @d7 @d8
   Scenario: Create many terms
     Given "tags" terms:
     | name    |
@@ -119,6 +123,7 @@ Feature: DrupalContext
     Then I should see "Tag one"
     And I should see "Tag two"
 
+  @d7 @d8
   Scenario: Create terms using vocabulary title rather than machine name.
     Given "Tags" terms:
     | name    |
@@ -129,6 +134,7 @@ Feature: DrupalContext
     Then I should see "Tag one"
     And I should see "Tag two"
 
+  @d7 @d8
   Scenario: Create nodes with specific authorship
     Given users:
     | name     | mail            | status |
@@ -141,6 +147,7 @@ Feature: DrupalContext
     And I follow "Article by Joe"
     Then I should see the link "Joe User"
 
+  @d7 @d8
   Scenario: Create an article with multiple term references
     Given "tags" terms:
     | name      |
@@ -158,6 +165,7 @@ Feature: DrupalContext
     And I should see the link "Tag three"
     And I should see the link "Tag four"
 
+  @d7 @d8
   Scenario: Readable created dates
     Given "article" content:
     | title        | body             | created            | status | promote |
@@ -165,6 +173,7 @@ Feature: DrupalContext
     When I am on the homepage
     Then I should see the text "Sun, 07/27/2014 - 00:03"
 
+  @d7 @d8
   Scenario: Node hooks are functioning
     Given "article" content:
     | title        | body        | published on       | status | promote |
@@ -172,10 +181,12 @@ Feature: DrupalContext
     When I am on the homepage
     Then I should see the text "Sat, 04/27/2013 - 11:11"
 
+  @d7 @d8
   Scenario: Node edit access by administrator
     Given I am logged in as a user with the "administrator" role
     Then I should be able to edit an "Article"
 
+  @d7 @d8
   Scenario: User hooks are functioning
     Given users:
     | First name | Last name | E-mail               |
@@ -184,6 +195,7 @@ Feature: DrupalContext
     When I visit "admin/people"
     Then I should see the link "Joe User"
 
+  @d7 @d8
   Scenario: Term hooks are functioning
     Given "tags" terms:
     | Label     |
@@ -194,7 +206,7 @@ Feature: DrupalContext
     Then I should see "Tag one"
     And I should see "Tag two"
 
-  @d8
+  @d7 @d8
   Scenario: Log in as a user with specific permissions
     Given I am logged in as a user with the "Administer content types" permission
     When I go to "admin/structure/types"

--- a/features/field_handlers.feature
+++ b/features/field_handlers.feature
@@ -21,7 +21,8 @@ Feature: FieldHandlers
       | field_post_links     | Link 1 - http://example.com, Link 2 - http://example.com                         |
       | field_post_select    | One, Two                                                                         |
       | field_post_address   | country: BE - locality: Brussel - thoroughfare: Louisalaan 1 - postal_code: 1000 |
-    Then I should see "Page one"
+    Then I should see "Post title"
+    And I should see "PLACEHOLDER BODY"
     And I should see "Page two"
     And I should see "Sunday, February 8, 2015"
     And I should see the link "Link 1"

--- a/features/field_handlers.feature
+++ b/features/field_handlers.feature
@@ -23,6 +23,7 @@ Feature: FieldHandlers
       | field_post_address   | country: BE - locality: Brussel - thoroughfare: Louisalaan 1 - postal_code: 1000 |
     Then I should see "Post title"
     And I should see "PLACEHOLDER BODY"
+    And I should see "Page one"
     And I should see "Page two"
     And I should see "Sunday, February 8, 2015"
     And I should see the link "Link 1"

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -297,7 +297,10 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @Then I should be able to edit a/an :type( content)
    */
   public function assertEditNodeOfType($type) {
-    $node = (object) array('type' => $type);
+    $node = (object) array(
+      'type' => $type,
+      'title' => "Test $type",
+    );
     $saved = $this->nodeCreate($node);
 
     // Set internal browser on the node edit page.

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -165,11 +165,18 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    * @beforeNodeCreate
    */
   public function alterNodeParameters(BeforeNodeCreateScope $scope) {
-    $drupal_version = $scope->getContext()->getDrupal()->getDriver()->version;
     $node = $scope->getEntity();
 
+    // Get the Drupal API version if available. This is not available when
+    // using e.g. the BlackBoxDriver or DrushDriver.
+    $api_version = NULL;
+    $driver = $scope->getContext()->getDrupal()->getDriver();
+    if ($driver instanceof \Drupal\Driver\DrupalDriver) {
+      $api_version = $scope->getContext()->getDrupal()->getDriver()->version;
+    }
+
     // On Drupal 8 the timestamps should be in UNIX time.
-    switch ($drupal_version) {
+    switch ($api_version) {
       case 8:
         foreach (array('changed', 'created', 'revision_timestamp') as $field) {
           if (!empty($node->$field) && !is_numeric($node->$field)) {

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -160,6 +160,27 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   }
 
   /**
+   * Massage node values to match the expectations on different Drupal versions.
+   *
+   * @beforeNodeCreate
+   */
+  public function alterNodeParameters(BeforeNodeCreateScope $scope) {
+    $drupal_version = $scope->getContext()->getDrupal()->getDriver()->version;
+    $node = $scope->getEntity();
+
+    // On Drupal 8 the timestamps should be in UNIX time.
+    switch ($drupal_version) {
+      case 8:
+        foreach (array('changed', 'created', 'revision_timestamp') as $field) {
+          if (!empty($node->$field) && !is_numeric($node->$field)) {
+            $node->$field = strtotime($node->$field);
+          }
+        }
+      break;
+    }
+  }
+
+  /**
    * Remove any created nodes.
    *
    * @AfterScenario


### PR DESCRIPTION
Currently the test coverage in `features/api.feature` mainly covers Drupal 7, but looking through the tests all this functionality should already be present in the D8 driver. Let's enable as many tests for Drupal 8 as are feasible.