### PR TITLE
Use better technique to determine whether user is logged in #131

### DIFF
--- a/src/Drupal/DrupalExtension/Context/MessageContext.php
+++ b/src/Drupal/DrupalExtension/Context/MessageContext.php
@@ -240,20 +240,6 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
   }
 
   /**
-   * Returns a specific css selector.
-   *
-   * @param $name
-   *   string CSS selector name
-   */
-  public function getDrupalSelector($name) {
-    $text = $this->getDrupalParameter('selectors');
-    if (!isset($text[$name])) {
-      throw new \Exception(sprintf('No such selector configured: %s', $name));
-    }
-    return $text[$name];
-  }
-
-  /**
    * Internal callback to check for a specific message in a given context.
    *
    * @param $message

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -3,6 +3,7 @@
 namespace Drupal\DrupalExtension\Context;
 
 use Behat\MinkExtension\Context\RawMinkContext;
+use Behat\Mink\Exception\DriverException;
 use Behat\Testwork\Hook\HookDispatcher;
 
 use Drupal\DrupalDriverManager;
@@ -154,7 +155,6 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   public function getDrupalSelector($name) {
     $text = $this->getDrupalParameter('selectors');
     if (!isset($text[$name])) {
-      var_dump($text);
       throw new \Exception(sprintf('No such selector configured: %s', $name));
     }
     return $text[$name];
@@ -503,7 +503,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
       if ($page->has('css', $this->getDrupalSelector('logged_in_selector'))) {
         return TRUE;
       }
-    } catch (\Behat\Mink\Exception\DriverException $e) {
+    } catch (DriverException $e) {
       // This test may fail if the driver did not load any site yet.
     }
 

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -146,6 +146,21 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   }
 
   /**
+   * Returns a specific css selector.
+   *
+   * @param $name
+   *   string CSS selector name
+   */
+  public function getDrupalSelector($name) {
+    $text = $this->getDrupalParameter('selectors');
+    if (!isset($text[$name])) {
+      var_dump($text);
+      throw new \Exception(sprintf('No such selector configured: %s', $name));
+    }
+    return $text[$name];
+  }
+
+  /**
    * Get active Drupal Driver.
    */
   public function getDriver($name = NULL) {
@@ -479,12 +494,31 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    */
   public function loggedIn() {
     $session = $this->getSession();
+    $page = $session->getPage();
+
+    // Look for a css selector to determine if a user is logged in.
+    // Default is the logged-in class on the body tag.
+    // Which should work with almost any theme.
+    try {
+      if ($page->has('css', $this->getDrupalSelector('logged_in_selector'))) {
+        return TRUE;
+      }
+    } catch (\Behat\Mink\Exception\DriverException $e) {
+      // This test may fail if the driver did not load any site yet.
+    }
+
+    // Some themes do not add that class to the body, so lets check if the
+    // login form is displayed on /user/login.
+    $session->visit($this->locatePath('/user/login'));
+    if (!$page->has('css', $this->getDrupalSelector('login_form_selector'))) {
+      return TRUE;
+    }
+
     $session->visit($this->locatePath('/'));
 
-    // If a logout link is found, we are logged in. While not perfect, this is
-    // how Drupal SimpleTests currently work as well.
-    $element = $session->getPage();
-    return $element->findLink($this->getDrupalText('log_out'));
+    // As a last resort, if a logout link is found, we are logged in. While not
+    // perfect, this is how Drupal SimpleTests currently work as well.
+    return $page->findLink($this->getDrupalText('log_out'));
   }
 
   /**

--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -142,7 +142,7 @@ class DrupalExtension implements ExtensionInterface {
               defaultValue('form#user-login')->
             end()->
             scalarNode('logged_in_selector')->
-              defaultValue('body.logged-in')->
+              defaultValue('body.logged-in,body.user-logged-in')->
             end()->
           end()->
         end()->

--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -132,11 +132,18 @@ class DrupalExtension implements ExtensionInterface {
           end()->
         end()->
         arrayNode('selectors')->
+          addDefaultsIfNotSet()->
           children()->
             scalarNode('message_selector')->end()->
             scalarNode('error_message_selector')->end()->
             scalarNode('success_message_selector')->end()->
             scalarNode('warning_message_selector')->end()->
+            scalarNode('login_form_selector')->
+              defaultValue('form#user-login')->
+            end()->
+            scalarNode('logged_in_selector')->
+              defaultValue('body.logged-in')->
+            end()->
           end()->
         end()->
         // Drupal drivers.


### PR DESCRIPTION
Based heavily on https://github.com/jhedstrom/drupalextension/pull/131

This makes Drupal 7 work for themes without logout link on front-page and also makes Drupal 8 minimal profile, which uses stark work.

For most cases it can also avoid the visit to an additional page, which is great.

### Original report

Not all websites have the logout link on the front page, in my case, Chrome with Selenium was simply to fast, admin-menu showed up after the check for the link happened.

Since there is no real 100% reliable method in D7, I've implemented two more methods to determine if a user is logged in. (D8 has the user information in the global Drupal Javascript object)

First test: Check for a "logged-in" class on the body element, most themes support this. (Mothership for example doesn't)
Second test: Visit "/user/login", if there is no login form, the user should be logged in.

I also had the Idea to simple check "/user/login" for a 403 status code, but this is not supported by Selenium because it is out of scope. (https://code.google.com/p/selenium/issues/detail?id=141)