### PR TITLE
Turn on the Drush Driver tests for Drupal 8, and see how far we get.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,8 @@ script:
   - vendor/bin/phpspec run -f pretty --no-interaction
   - vendor/bin/behat -fprogress --strict
   - vendor/bin/behat -fprogress --profile=drupal${DRUPAL_VERSION} --strict
-  # Do not test the Drush profile unless Drupal 7 was installed.
-  - test ${DRUPAL_VERSION} -ne 7 || vendor/bin/behat -fprogress --profile=drush --strict
+  # Test the Drush profile on Drupal 7 and Drupal 8, but not on Drupal 6.
+  - test ${DRUPAL_VERSION} -eq 6 || vendor/bin/behat -fprogress --profile=drush --strict
 
 after_failure:
   - cat ~/debug.txt


### PR DESCRIPTION
Trying out the tests on Drupal 8, now that there have been some fixes made in the drush driver.
