### PR TITLE
add quotes to lines with @

### DIFF
--- a/src/Drupal/DrupalExtension/ServiceContainer/config/drivers/drupal.yml
+++ b/src/Drupal/DrupalExtension/ServiceContainer/config/drivers/drupal.yml
@@ -17,7 +17,7 @@ services:
     arguments:
       - %drupal.driver.drupal.drupal_root%
       - %mink.base_url%
-      - @drupal.driver.random
+      - "@drupal.driver.random"
     tags:
       - { name: drupal.driver, alias: drupal }
   drupal.driver.cores.6:
@@ -27,7 +27,7 @@ services:
     arguments:
       - %drupal.driver.drupal.drupal_root%
       - %mink.base_url%
-      - @drupal.driver.random
+      - "@drupal.driver.random"
   drupal.driver.cores.7:
     class: %drupal.driver.cores.7.class%
     tags:
@@ -35,7 +35,7 @@ services:
     arguments:
       - %drupal.driver.drupal.drupal_root%
       - %mink.base_url%
-      - @drupal.driver.random
+      - "@drupal.driver.random"
   drupal.driver.cores.8:
     class: %drupal.driver.cores.8.class%
     tags:
@@ -43,4 +43,4 @@ services:
     arguments:
       - %drupal.driver.drupal.drupal_root%
       - %mink.base_url%
-      - @drupal.driver.random
+      - "@drupal.driver.random"

--- a/src/Drupal/DrupalExtension/ServiceContainer/config/drivers/drush.yml
+++ b/src/Drupal/DrupalExtension/ServiceContainer/config/drivers/drush.yml
@@ -13,6 +13,6 @@ services:
       - %drupal.driver.drush.alias%
       - %drupal.driver.drush.root%
       - %drupal.driver.drush.binary%
-      - @drupal.driver.random
+      - "@drupal.driver.random"
     tags:
       - { name: drupal.driver, alias: drush }

--- a/src/Drupal/DrupalExtension/ServiceContainer/config/services.yml
+++ b/src/Drupal/DrupalExtension/ServiceContainer/config/services.yml
@@ -34,21 +34,21 @@ services:
     class: %drupal.drupal.class%
     arguments:
       - {}
-      - @drupal.random
+      - "@drupal.random"
   drupal.random:
     class: %drupal.random.class%
   drupal.context.initializer:
     class: %drupal.context.initializer.class%
     arguments:
-      - @drupal.drupal
+      - "@drupal.drupal"
       - %drupal.parameters%
-      - @hook.dispatcher
+      - "@hook.dispatcher"
     tags:
       - { name: context.initializer }
   drupal.context.environment.reader:
     class: %drupal.context.environment.reader.class%
     arguments:
-      - @drupal.drupal
+      - "@drupal.drupal"
       - %drupal.parameters%
     tags:
       - { name: environment.reader }
@@ -60,7 +60,7 @@ services:
   drupal.listener.driver:
     class: %drupal.listener.drivers.class%
     arguments:
-      - @drupal.drupal
+      - "@drupal.drupal"
       - %drupal.parameters%
     tags:
       - { name: event_dispatcher.subscriber, priority: 0 }


### PR DESCRIPTION
```
[Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]                                                                                                       
  The file "/home/tikolakin/work/gridics/behat_tests/vendor/drupal/drupal-extension/src/Drupal/DrupalExtension/ServiceContainer/config/services.yml" does not contain valid YAML.  
                                                                                                                                  
  [Symfony\Component\Yaml\Exception\ParseException]                                                                           
  The reserved indicator "@" cannot start a plain scalar; you need to quote the scalar at line 37 (near "- @drupal.random"). 

```

Referring to the UPGRADE Guide in the yaml section: https://github.com/symfony/symfony/blob/master/UPGRADE-3.0.md#yaml

```
Starting an unquoted string with @, `, |, or > leads to a ParseException.
```