### PR TITLE
There is a new release candidate for Behat.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "behat/mink": "~1.5",
     "behat/mink-goutte-driver": "~1.0",
     "behat/mink-selenium2-driver": "~1.1",
-    "behat/behat": "dev-master#2059cbe",
+    "behat/behat": "~3.1.0-rc1",
     "behat/mink-extension": "~2.0",
     "drupal/drupal-driver": "dev-master"
   },


### PR DESCRIPTION
Version 3.1.0-rc1 contains the fix for PR #801 that we needed. We no longer need to track the development branch now.