### PR TITLE
Use better technique to determine whether user is logged in - Backport

### DIFF
--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -12,6 +12,7 @@ use Drupal\Drupal;
 use Drupal\DrupalExtension\Event\EntityEvent;
 use Drupal\DrupalExtension\Context\DrupalSubContextInterface;
 
+use Drupal\Exception\Exception;
 use Symfony\Component\Process\Process;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -347,7 +348,7 @@ class DrupalContext extends MinkContext implements DrupalAwareInterface, Transla
       if ($page->has('css', $this->getDrupalSelector('logged_in_selector'))) {
         return TRUE;
       }
-    } catch (\Behat\Mink\Exception\DriverException $e) {
+    } catch (Exception $e) {
       // This test may fail if the driver did not load any site yet.
     }
     // Some themes do not add that class to the body, so lets check if the

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -339,12 +339,27 @@ class DrupalContext extends MinkContext implements DrupalAwareInterface, Transla
    */
   public function loggedIn() {
     $session = $this->getSession();
+    $page = $session->getPage();
+    // Look for a css selector to determine if a user is logged in.
+    // Default is the logged-in class on the body tag.
+    // Which should work with almost any theme.
+    try {
+      if ($page->has('css', $this->getDrupalSelector('logged_in_selector'))) {
+        return TRUE;
+      }
+    } catch (\Behat\Mink\Exception\DriverException $e) {
+      // This test may fail if the driver did not load any site yet.
+    }
+    // Some themes do not add that class to the body, so lets check if the
+    // login form is displayed on /user/login.
+    $session->visit($this->locatePath('/user/login'));
+    if (!$page->has('css', $this->getDrupalSelector('login_form_selector'))) {
+      return TRUE;
+    }
     $session->visit($this->locatePath('/'));
-
-    // If a logout link is found, we are logged in. While not perfect, this is
-    // how Drupal SimpleTests currently work as well.
-    $element = $session->getPage();
-    return $element->findLink($this->getDrupalText('log_out'));
+    // As a last resort, if a logout link is found, we are logged in. While not
+    // perfect, this is how Drupal SimpleTests currently work as well.
+    return $page->findLink($this->getDrupalText('log_out'));
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Extension.php
+++ b/src/Drupal/DrupalExtension/Extension.php
@@ -138,6 +138,13 @@ class Extension implements ExtensionInterface {
             scalarNode('error_message_selector')->end()->
             scalarNode('success_message_selector')->end()->
             scalarNode('warning_message_selector')->end()->
+            scalarNode('login_form_selector')->end()->
+            scalarNode('logged_in_selector')->
+              defaultValue('body.logged-in')->
+            end()->
+            scalarNode('login_form_selector')->
+              defaultValue('form#user-login')->
+            end()->
           end()->
         end()->
         // Drupal drivers.


### PR DESCRIPTION
This P.R. is to backport the functionality that LionsAd did for the 1.0 release of Behat