### PR TITLE
Add an assert to check if a button is not present on the page.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -309,6 +309,18 @@ class MinkContext extends MinkExtension implements TranslatableContext {
   }
 
   /**
+   * @Then I should not see the button :button
+   * @Then I should not see the :button button
+   */
+  public function assertNotButton($button) {
+    $element = $this->getSession()->getPage();
+    $buttonObj = $element->findButton($button);
+    if (!empty($buttonObj)) {
+      throw new \Exception(sprintf("The button '%s' was found on the page %s", $button, $this->getSession()->getCurrentUrl()));
+    }
+  }
+
+  /**
    * @When I follow/click :link in the :region( region)
    *
    * @throws \Exception


### PR DESCRIPTION
We have an `assertButton()` method to check if a form submit button is present on the page, but its counterpart `assertNotButton()` is missing.