### PR TITLE
Do not assume nodes of all types have 'body' fields

### DIFF
--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -222,7 +222,6 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
     $node = (object) array(
       'title' => $title,
       'type' => $type,
-      'body' => $this->getRandom()->name(255),
     );
     $saved = $this->nodeCreate($node);
     // Set internal page on the new node.


### PR DESCRIPTION
All nodes have titles and types, but not all of them have bodies. This PR removes the assumption that this is so.
