### PR TITLE
Add support for Drupal 8.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   - test ${DRUPAL_VERSION} -ne 8 || (cp doc/_static/composer.json.d8 ./composer.json && composer require --prefer-source drush-ops/behat-drush-endpoint drupal/drupal-driver:dev-master)
   - composer install
   # Drush version must vary depending on environment and version of core.
-  - test ${TRAVIS_PHP_VERSION} == "5.3" && composer global require drush/drush:~6.0 || composer global require drush/drush:dev-master
+  - test ${TRAVIS_PHP_VERSION} == "5.3" && composer global require drush/drush:~6.0 || composer global require drush/drush:~8.0
   # Install the Behat Drush Endpoint for Drupal 7 tests.
   - test ${DRUPAL_VERSION} -ne 7 || (git clone https://github.com/drush-ops/behat-drush-endpoint.git drush/behat-drush-endpoint && (cd drush/behat-drush-endpoint && composer install))
   # PHP 5.3 requires the cgi extension for runserver.

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "behat/behat": "~3.1.0-rc2",
     "behat/mink-extension": "~2.0",
     "drupal/drupal-driver": "dev-master",
-    "symfony/dependency-injection": "2.7.*",
-    "symfony/event-dispatcher": "2.7.*"
+    "symfony/dependency-injection": "~2.7",
+    "symfony/event-dispatcher": "~2.7"
   },
   "require-dev": {
     "phpspec/phpspec": "~2.0",

--- a/doc/_static/composer.json.d8
+++ b/doc/_static/composer.json.d8
@@ -19,8 +19,8 @@
     "behat/mink-extension": "~2.0",
     "drupal/drupal-driver": "dev-master",
     "guzzlehttp/guzzle" : "^6.0@dev",
-    "symfony/dependency-injection": "2.8.2",
-    "symfony/event-dispatcher": "2.8.2"
+    "symfony/dependency-injection": "~2.8.2",
+    "symfony/event-dispatcher": "~2.8.2"
   },
   "require-dev": {
     "phpspec/phpspec": "~2.0",

--- a/doc/_static/composer.json.d8
+++ b/doc/_static/composer.json.d8
@@ -19,8 +19,8 @@
     "behat/mink-extension": "~2.0",
     "drupal/drupal-driver": "dev-master",
     "guzzlehttp/guzzle" : "^6.0@dev",
-    "symfony/dependency-injection": "~2.8.2",
-    "symfony/event-dispatcher": "~2.8.2"
+    "symfony/dependency-injection": "2.8.2",
+    "symfony/event-dispatcher": "2.8.2"
   },
   "require-dev": {
     "phpspec/phpspec": "~2.0",


### PR DESCRIPTION
Drupal 8.1 is going to be released soon. It's using Symfony 2.8. We need to update our dependencies to support this, or this will cause conflicts in projects that depend both on Drupal core and Drupal extension. One example is my fork of Drupal-project: https://github.com/pfrenssen/drupal-project.