### PR TITLE
For compatability with drupal 8.1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "behat/behat": "~3.1.0-rc2",
     "behat/mink-extension": "~2.0",
     "drupal/drupal-driver": "dev-master",
-    "symfony/dependency-injection": "~2.7",
-    "symfony/event-dispatcher": "~2.7"
+    "symfony/dependency-injection": "2.8.*",
+    "symfony/event-dispatcher": "2.8.*"
   },
   "require-dev": {
     "phpspec/phpspec": "~2.0",


### PR DESCRIPTION
Not sure if there's a reason to pin these versions, mainly opening this up for the conversation and to see what breaks.

See https://github.com/drupal-composer/drupal-core/blob/8.1.x/composer.json#L10