### PR TITLE
Add a quit handler to breakpoint

### DIFF
--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -433,7 +433,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
           case 81: //Q
             throw new \Exception("Exiting test intentionally.");
           default:
-            fwrite(STDOUT, sprintf("\nInvalid charCode %s.  Please enter 'y', 'q', or the enter key.\n", $charCode));
+            fwrite(STDOUT, sprintf("\nInvalid entry '%s'.  Please enter 'y', 'q', or the enter key.\n", $line));
           break;
         }
       } while (true);

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -423,7 +423,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
         //handle other character sets.
         $charCode = ord($line);
         switch($charCode){
-          case 10: //CR
+          case 0: //CR
           case 121: //y
           case 89: //Y
             break 2;
@@ -433,11 +433,10 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
           case 81: //Q
             throw new \Exception("Exiting test intentionally.");
           default:
-            print "\nInvalid.  Please enter 'y', 'n', or the enter key.";
+            fwrite(STDOUT, sprintf("\nInvalid charCode %s.  Please enter 'y', 'q', or the enter key.\n", $charCode));
           break;
         }
       } while (true);
-      fwrite(STDOUT, "\033[u");
     }
 
 }

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -437,6 +437,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
           break;
         }
       } while (true);
+      fwrite(STDOUT, "\033[u");
     }
 
 }

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -416,10 +416,28 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    */
     public function iPutABreakpoint()
     {
-      fwrite(STDOUT, "\033[s \033[93m[Breakpoint] Press \033[1;93m[RETURN]\033[0;93m to continue...\033[0m");
-      while (fgets(STDIN, 1024) == '') {}
+      fwrite(STDOUT, "\033[s \033[93m[Breakpoint] Press \033[1;93m[RETURN]\033[0;93m to continue, or 'q' to quit...\033[0m");
+      do {
+        $line = trim(fgets(STDIN, 1024));
+        //Note: this assumes ASCII encoding.  Should probably be revamped to
+        //handle other character sets.
+        $charCode = ord($line);
+        switch($charCode){
+          case 10: //CR
+          case 121: //y
+          case 89: //Y
+            break 2;
+          // case 78: //N
+          // case 110: //n
+          case 113: //q
+          case 81: //Q
+            throw new \Exception("Exiting test intentionally.");
+          default:
+            print "\nInvalid.  Please enter 'y', 'n', or the enter key.";
+          break;
+        }
+      } while (true);
       fwrite(STDOUT, "\033[u");
-      return;
     }
 
 }


### PR DESCRIPTION
Currently, the existing breakpoint function in DrupalContext waits on a carriage return key to continue.  If you're using this breakpoint to inspect a particular test, and you wish to exit after you have determined the test has failed, the existing method offers no option for it.  You could use Ctrl+C (on POSIX), but in my experience, db cleanup operations are improperly handled after a SIGINT.

This change side-steps the problem by throwing an exception after a 'q' entry by the user.  This in turn results in a test exit with a proper cleanup.