### PR TITLE
Fix scenario outline #288

### DIFF
--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -231,6 +231,10 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
       }
       $this->getDriver()->processBatch();
       $this->users = array();
+      $this->user = FALSE;
+      if ($this->loggedIn()) {
+        $this->logout();
+      }
     }
   }
 

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -84,7 +84,6 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
 
   /**
    * Keep track of any languages that are created so they can easily be removed.
-   * Keep track of any languages that are created so they can easily be removed.
    *
    * @var array
    */

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -84,6 +84,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
 
   /**
    * Keep track of any languages that are created so they can easily be removed.
+   * Keep track of any languages that are created so they can easily be removed.
    *
    * @var array
    */


### PR DESCRIPTION
When using scenario outlines and a logged in user, the user gets invalid on the second run of the oultine, as @afterScenario deletes all created users. The proposed fix invalidates the user-property and logs the user out.