### PR TITLE
[BUGFIX] Mink translations files are not used

### DIFF
--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -17,7 +17,7 @@ class MinkContext extends MinkExtension implements TranslatableContext {
    * @return array
    */
   public static function getTranslationResources() {
-    return glob(__DIR__ . '/../../../../i18n/*.xliff');
+    return glob(__DIR__ . '/../../../../../../behat/mink-extension/i18n/*.xliff');
   }
 
   /**


### PR DESCRIPTION
Hi,

This is a simple patch that updates the path for the mink translation.

It points to the behat/mink-extension folder (using the composer structure), rather tan the local directory that didn't contains those translations.