### PR TITLE
Make the current user available in all contexts.

### DIFF
--- a/features/blackbox.feature
+++ b/features/blackbox.feature
@@ -7,11 +7,11 @@ Feature: Test DrupalContext
   Scenario: Test the ability to find a heading in a region
     Given I am on the homepage
     When I click "Download & Extend"
-    Then I should see the heading "Core" in the "content" region
+    Then I should see the heading "Download" in the "content" region
 
   Scenario: Clicking content in a region
-    Given I am at "download"
-    When I click "About Distributions" in the "content" region
+    Given I am at "community"
+    When I click "IRC" in the "content" region
     Then I should see "Page status" in the "right sidebar"
     And I should see the link "Drupal News" in the "footer" region
 
@@ -79,4 +79,4 @@ Feature: Test DrupalContext
  Scenario: Zombie driver is functional
    Given I am on the homepage
    When I click "Download & Extend"
-   Then I should see the link "Drupal Core"
+   Then I should see the link "Distributions"

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -1,8 +1,8 @@
 <?php
 
-use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
+use Drupal\DrupalExtension\Context\RawDrupalContext;
 use Drupal\DrupalExtension\Hook\Scope\EntityScope;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
@@ -14,7 +14,7 @@ use Symfony\Component\Process\Process;
  * purposes of testing since we can't easily run that as a context due to naming
  * conflicts.
  */
-class FeatureContext implements Context {
+class FeatureContext extends RawDrupalContext {
   /**
    * Hook into node creation to test `@beforeNodeCreate`
    *
@@ -162,6 +162,30 @@ class FeatureContext implements Context {
     });
 
     return new TableNode($table);
+  }
+
+  /**
+   * Creates and authenticates a user with the given username and password.
+   *
+   * In Drupal 8 it is possible to register a user without an e-mail address,
+   * using only a username and password.
+   *
+   * This step definition is intended to test if users that are registered in
+   * one context (in this case FeatureContext) can be accessed in other
+   * contexts.
+   *
+   * See the scenario 'Logging in as a user without an e-mail address' in
+   * d8.feature.
+   *
+   * @Given I am logged in as a user with name :name and password :password
+   */
+  public function assertAuthenticatedByUsernameAndPassword($name, $password) {
+    $user = (object) [
+      'name' => $name,
+      'pass' => $password,
+    ];
+    $this->userCreate($user);
+    $this->login($user);
   }
 
   /**

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -3,6 +3,7 @@
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
+use Drupal\DrupalExtension\Hook\Scope\BeforeNodeCreateScope;
 use Drupal\DrupalExtension\Hook\Scope\EntityScope;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
@@ -20,7 +21,8 @@ class FeatureContext extends RawDrupalContext {
    *
    * @beforeNodeCreate
    */
-  public function alterNodeParameters(EntityScope $scope) {
+  public function alterNodeParameters(BeforeNodeCreateScope $scope) {
+    parent::alterNodeParameters($scope);
     // @see `features/api.feature`
     // Change 'published on' to the expected 'created'.
     $node = $scope->getEntity();

--- a/features/d8.feature
+++ b/features/d8.feature
@@ -30,3 +30,10 @@ Feature: DrupalContext
     Given I am not logged in
     When I am on the homepage
     Then I should see the heading "Search" in the "left sidebar" region
+
+  # This tests that a user that is created in one particular Context class (in
+  # this case FeatureContext::assertLoggedInByUsernameAndPassword()) can be
+  # accessed in another Context (DrupalContext::assertLoggedInByName()).
+  Scenario: Logging in as a user without an e-mail address.
+    Given I am logged in as a user with name "Carrot Ironfoundersson" and password "citywatch1234"
+    Then I am logged in as "Carrot Ironfoundersson"

--- a/spec/Drupal/DrupalExtension/Context/Initializer/DrupalAwareInitializerSpec.php
+++ b/spec/Drupal/DrupalExtension/Context/Initializer/DrupalAwareInitializerSpec.php
@@ -12,6 +12,8 @@ use Behat\Testwork\Environment\EnvironmentManager;
 use Behat\Testwork\Hook\HookDispatcher;
 use Behat\Testwork\Hook\HookRepository;
 
+use Drupal\DrupalUserManager;
+use Drupal\DrupalUserManagerInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -19,14 +21,14 @@ class DrupalAwareInitializerSpec extends ObjectBehavior
 {
     private $dispatcher;
 
-    function let(DrupalDriverManager $drupal)
+    function let(DrupalDriverManager $drupal, DrupalUserManagerInterface $userManager)
     {
         $callCenter = new CallCenter();
         $manager = new EnvironmentManager();
         $repository = new HookRepository($manager);
         // Cannot mock this class as it is marked as final.
         $this->dispatcher = new HookDispatcher($repository, $callCenter);
-        $this->beConstructedWith($drupal, array(), $this->dispatcher);
+        $this->beConstructedWith($drupal, array(), $this->dispatcher, $userManager);
     }
 
     function it_is_a_context_initializer()
@@ -39,11 +41,12 @@ class DrupalAwareInitializerSpec extends ObjectBehavior
         $this->initializeContext($context);
     }
 
-    function it_injects_drupal_and_parameters_and_dispatcher_in_drupal_aware_Contexts(DrupalAwareInterface $context, $drupal)
+    function it_injects_drupal_and_parameters_and_dispatcher_and_user_manager_in_drupal_aware_Contexts(DrupalAwareInterface $context, $drupal, DrupalUserManagerInterface $userManager)
     {
         $context->setDispatcher($this->dispatcher)->shouldBeCAlled();
         $context->setDrupal($drupal)->shouldBeCAlled();
         $context->setDrupalParameters(array())->shouldBeCAlled();
+        $context->setUserManager($userManager)->shouldBeCalled();
         $this->initializeContext($context);
     }
 }

--- a/src/Drupal/DrupalExtension/Context/DrupalAwareInterface.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalAwareInterface.php
@@ -6,6 +6,7 @@ use Behat\Behat\Context\Context;
 use Behat\Testwork\Hook\HookDispatcher;
 
 use Drupal\DrupalDriverManager;
+use Drupal\DrupalUserManagerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 interface DrupalAwareInterface extends Context {
@@ -31,4 +32,18 @@ interface DrupalAwareInterface extends Context {
    * @param array $parameters
    */
   public function setDrupalParameters(array $parameters);
+
+  /**
+   * Sets the Drupal user manager instance.
+   *
+   * @param \Drupal\DrupalUserManagerInterface $userManager
+   */
+  public function setUserManager(DrupalUserManagerInterface $userManager);
+
+  /**
+   * Gets the Drupal user manager instance.
+   *
+   * @return \Drupal\DrupalUserManagerInterface
+   */
+  public function getUserManager();
 }

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -110,12 +110,10 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @Given I am logged in as :name
    */
   public function assertLoggedInByName($name) {
-    if (!isset($this->users[$name])) {
-      throw new \Exception(sprintf('No user with %s name is registered with the driver.', $name));
-    }
+    $manager = $this->getUserManager();
 
     // Change internal current user.
-    $this->user = $this->users[$name];
+    $manager->setCurrentUser($manager->getUser($name));
 
     // Login.
     $this->login();
@@ -247,7 +245,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @Given I am viewing my :type (content )with the title :title
    */
   public function createMyNode($type, $title) {
-    if (!isset($this->user->uid)) {
+    if ($this->getUserManager()->currentUserIsAnonymous()) {
       throw new \Exception(sprintf('There is no current logged in user to create a node for.'));
     }
 
@@ -255,7 +253,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
       'title' => $title,
       'type' => $type,
       'body' => $this->getRandom()->name(255),
-      'uid' => $this->user->uid,
+      'uid' => $this->getUserManager()->getCurrentUser()->uid,
     );
     $saved = $this->nodeCreate($node);
 

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -61,7 +61,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
       }
 
       // Login.
-      $this->login();
+      $this->login($user);
     }
   }
 
@@ -101,7 +101,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
       }
 
       // Login.
-      $this->login();
+      $this->login($user);
     }
   }
 
@@ -116,7 +116,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
     $manager->setCurrentUser($manager->getUser($name));
 
     // Login.
-    $this->login();
+    $this->login($manager->getUser($name));
   }
 
   /**
@@ -138,7 +138,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
     $this->roles[] = $rid;
 
     // Login.
-    $this->login();
+    $this->login($user);
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Context/DrupalSubContextBase.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalSubContextBase.php
@@ -34,15 +34,22 @@ abstract class DrupalSubContextBase extends RawDrupalContext implements DrupalSu
 
   /**
    * Get the currently logged in user from DrupalContext.
+   *
+   * @deprecated
+   *   Deprecated in 4.x, will be removed before 5.x.
+   *   The currently logged in user is now available in all context classes.
+   *   Use $this->getUserManager()->getCurrentUser() instead.
    */
   protected function getUser() {
-    /** @var DrupalContext $context */
-    $context = $this->getContext('\Drupal\DrupalExtension\Context\DrupalContext');
-    if (empty($context->user)) {
+    trigger_error('DrupalSubContextBase::getUser() is deprecated. Use RawDrupalContext::getUserManager()->getCurrentUser() instead.', E_USER_DEPRECATED);
+
+    $user = $this->getUserManager()->getCurrentUser();
+
+    if (empty($user)) {
       throw new \Exception('No user is logged in.');
     }
 
-    return $context->user;
+    return $user;
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Context/Initializer/DrupalAwareInitializer.php
+++ b/src/Drupal/DrupalExtension/Context/Initializer/DrupalAwareInitializer.php
@@ -9,14 +9,16 @@ use Behat\Testwork\Hook\HookDispatcher;
 use Drupal\DrupalDriverManager;
 use Drupal\DrupalExtension\Context\DrupalContext;
 use Drupal\DrupalExtension\Context\DrupalAwareInterface;
+use Drupal\DrupalUserManagerInterface;
 
 class DrupalAwareInitializer implements ContextInitializer {
-  private $drupal, $parameters, $dispatcher;
+  private $drupal, $parameters, $dispatcher, $userManager;
 
-  public function __construct(DrupalDriverManager $drupal, array $parameters, HookDispatcher $dispatcher) {
+  public function __construct(DrupalDriverManager $drupal, array $parameters, HookDispatcher $dispatcher, DrupalUserManagerInterface $userManager) {
     $this->drupal = $drupal;
     $this->parameters = $parameters;
     $this->dispatcher = $dispatcher;
+    $this->userManager = $userManager;
   }
 
   /**
@@ -37,6 +39,9 @@ class DrupalAwareInitializer implements ContextInitializer {
 
     // Add all parameters to the context.
     $context->setDrupalParameters($this->parameters);
+
+    // Set the Drupal user manager.
+    $context->setUserManager($this->userManager);
   }
 
 }

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -51,7 +51,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    *
    * @var \Drupal\DrupalUserManagerInterface
    */
-  private $userManager;
+  protected $userManager;
 
   /**
    * Keep track of nodes so they can be cleaned up.

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -61,13 +61,6 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   protected $nodes = array();
 
   /**
-   * Keep track of all users that are created so they can easily be removed.
-   *
-   * @var array
-   */
-  protected $users = array();
-
-  /**
    * Keep track of all terms that are created so they can easily be removed.
    *
    * @var array
@@ -120,10 +113,27 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    * Magic setter.
    */
   public function __set($name, $value) {
-    if ($name === 'user') {
-      // Set the user on the user manager service, so it is shared between all
-      // contexts.
-      $this->getUserManager()->setCurrentUser($value);
+    switch ($name) {
+      case 'user':
+        trigger_error('Interacting directly with the RawDrupalContext::$user property has been deprecated. Use RawDrupalContext::getUserManager->setCurrentUser() instead.', E_USER_DEPRECATED);
+        // Set the user on the user manager service, so it is shared between all
+        // contexts.
+        $this->getUserManager()->setCurrentUser($value);
+        break;
+
+      case 'users':
+        trigger_error('Interacting directly with the RawDrupalContext::$users property has been deprecated. Use RawDrupalContext::getUserManager->addUser() instead.', E_USER_DEPRECATED);
+        // Set the user on the user manager service, so it is shared between all
+        // contexts.
+        if (empty($value)) {
+          $this->getUserManager()->clearUsers();
+        }
+        else {
+          foreach ($value as $user) {
+            $this->getUserManager()->addUser($user);
+          }
+        }
+        break;
     }
   }
 
@@ -131,10 +141,18 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    * Magic getter.
    */
   public function __get($name) {
-    if ($name === 'user') {
-      // Returns the current user from the user manager service. This is shared
-      // between all contexts.
-      return $this->getUserManager()->getCurrentUser();
+    switch ($name) {
+      case 'user':
+        trigger_error('Interacting directly with the RawDrupalContext::$user property has been deprecated. Use RawDrupalContext::getUserManager->getCurrentUser() instead.', E_USER_DEPRECATED);
+        // Returns the current user from the user manager service. This is shared
+        // between all contexts.
+        return $this->getUserManager()->getCurrentUser();
+
+      case 'users':
+        trigger_error('Interacting directly with the RawDrupalContext::$users property has been deprecated. Use RawDrupalContext::getUserManager->getUsers() instead.', E_USER_DEPRECATED);
+        // Returns the current user from the user manager service. This is shared
+        // between all contexts.
+        return $this->getUserManager()->getUsers();
     }
   }
 

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -123,7 +123,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
     if ($name === 'user') {
       // Set the user on the user manager service, so it is shared between all
       // contexts.
-      $this->getUserManager()->setUser($value);
+      $this->getUserManager()->setCurrentUser($value);
     }
   }
 
@@ -134,7 +134,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
     if ($name === 'user') {
       // Returns the current user from the user manager service. This is shared
       // between all contexts.
-      return $this->getUserManager()->getUser();
+      return $this->getUserManager()->getCurrentUser();
     }
   }
 

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -7,6 +7,7 @@ use Behat\Mink\Exception\DriverException;
 use Behat\Testwork\Hook\HookDispatcher;
 
 use Drupal\DrupalDriverManager;
+use Drupal\DrupalUserManagerInterface;
 
 use Drupal\DrupalExtension\Hook\Scope\AfterLanguageEnableScope;
 use Drupal\DrupalExtension\Hook\Scope\AfterNodeCreateScope;
@@ -46,20 +47,18 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   protected $dispatcher;
 
   /**
+   * Drupal user manager.
+   *
+   * @var \Drupal\DrupalUserManagerInterface
+   */
+  private $userManager;
+
+  /**
    * Keep track of nodes so they can be cleaned up.
    *
    * @var array
    */
   protected $nodes = array();
-
-  /**
-   * Current authenticated user.
-   *
-   * A value of FALSE denotes an anonymous user.
-   *
-   * @var \stdClass|bool
-   */
-  public $user = FALSE;
 
   /**
    * Keep track of all users that are created so they can easily be removed.
@@ -105,6 +104,42 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
 
   /**
    * {@inheritDoc}
+   */
+  public function setUserManager(DrupalUserManagerInterface $userManager) {
+    $this->userManager = $userManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getUserManager() {
+    return $this->userManager;
+  }
+
+  /**
+   * Magic setter.
+   */
+  public function __set($name, $value) {
+    if ($name === 'user') {
+      // Set the user on the user manager service, so it is shared between all
+      // contexts.
+      $this->getUserManager()->setUser($value);
+    }
+  }
+
+  /**
+   * Magic getter.
+   */
+  public function __get($name) {
+    if ($name === 'user') {
+      // Returns the current user from the user manager service. This is shared
+      // between all contexts.
+      return $this->getUserManager()->getUser();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
    */
   public function setDispatcher(HookDispatcher $dispatcher) {
     $this->dispatcher = $dispatcher;

--- a/src/Drupal/DrupalExtension/ServiceContainer/config/services.yml
+++ b/src/Drupal/DrupalExtension/ServiceContainer/config/services.yml
@@ -7,6 +7,9 @@ parameters:
   drupal.drupal.default_session: blackbox
   drupal.drupal.api_driver: drush
 
+  # Drupal user manager.
+  drupal.user_manager.class: Drupal\DrupalUserManager
+
   # Random generator.
   drupal.random.class: Drupal\Component\Utility\Random
 
@@ -35,6 +38,8 @@ services:
     arguments:
       - {}
       - "@drupal.random"
+  drupal.user_manager:
+    class: %drupal.user_manager.class%
   drupal.random:
     class: %drupal.random.class%
   drupal.context.initializer:
@@ -43,6 +48,7 @@ services:
       - "@drupal.drupal"
       - %drupal.parameters%
       - "@hook.dispatcher"
+      - "@drupal.user_manager"
     tags:
       - { name: context.initializer }
   drupal.context.environment.reader:

--- a/src/Drupal/DrupalUserManager.php
+++ b/src/Drupal/DrupalUserManager.php
@@ -2,15 +2,22 @@
 
 namespace Drupal;
 
+/**
+ * Default implementation of the Drupal user manager service.
+ */
 class DrupalUserManager implements DrupalUserManagerInterface {
 
   /**
-   * {@inheritdoc}
+   * The user object representing the currently logged in user.
+   *
+   * @var \stdClass|FALSE
    */
   protected $user = FALSE;
 
   /**
-   * {@inheritdoc}
+   * An array of user objects representing users created during the test.
+   *
+   * @var \stdClass[]
    */
   protected $users = [];
 

--- a/src/Drupal/DrupalUserManager.php
+++ b/src/Drupal/DrupalUserManager.php
@@ -12,14 +12,14 @@ class DrupalUserManager implements DrupalUserManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getUser() {
+  public function getCurrentUser() {
     return $this->user;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function setUser($user) {
+  public function setCurrentUser($user) {
     $this->user = $user;
   }
 

--- a/src/Drupal/DrupalUserManager.php
+++ b/src/Drupal/DrupalUserManager.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal;
+
+class DrupalUserManager implements DrupalUserManagerInterface {
+
+  /**
+   * @var \stdClass|bool
+   */
+  protected $user = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getUser() {
+    return $this->user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUser($user) {
+    $this->user = $user;
+  }
+
+}

--- a/src/Drupal/DrupalUserManager.php
+++ b/src/Drupal/DrupalUserManager.php
@@ -5,9 +5,14 @@ namespace Drupal;
 class DrupalUserManager implements DrupalUserManagerInterface {
 
   /**
-   * @var \stdClass|bool
+   * {@inheritdoc}
    */
   protected $user = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $users = [];
 
   /**
    * {@inheritdoc}
@@ -21,6 +26,66 @@ class DrupalUserManager implements DrupalUserManagerInterface {
    */
   public function setCurrentUser($user) {
     $this->user = $user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addUser($user) {
+    $this->users[$user->name] = $user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function removeUser($userName) {
+    unset($this->users[$userName]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getUser($userName) {
+    if (!isset($this->users[$userName])) {
+      throw new \Exception(sprintf('No user with %s name is registered with the driver.', $userName));
+    }
+    return $this->users[$userName];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getUsers() {
+    return $this->users;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function clearUsers() {
+    $this->user = FALSE;
+    $this->users = [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function hasUsers() {
+    return !empty($this->users);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function currentUserIsAnonymous() {
+    return empty($this->user);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function currentUserHasRole($role) {
+    return !$this->currentUserIsAnonymous() && !empty($this->user->role) && $this->user->role == $role;
   }
 
 }

--- a/src/Drupal/DrupalUserManagerInterface.php
+++ b/src/Drupal/DrupalUserManagerInterface.php
@@ -3,7 +3,7 @@
 namespace Drupal;
 
 /**
- * Interface for classes that manage the currently logged in user.
+ * Interface for classes that manage users created during tests.
  */
 interface DrupalUserManagerInterface {
 
@@ -14,13 +14,89 @@ interface DrupalUserManagerInterface {
    *
    * @return \stdClass|bool
    */
-  public function getUser();
+  public function getCurrentUser();
 
   /**
    * Sets the currently logged in user.
    *
    * @param \stdClass|bool $user
    */
-  public function setUser($user);
+  public function setCurrentUser($user);
+
+  /**
+   * Adds a new user.
+   *
+   * Call this after creating a new user to keep track of all the users that are
+   * created in a test scenario. They can then be cleaned up after completing
+   * the test.
+   *
+   * @see \Drupal\DrupalExtension\Context\RawDrupalContext::cleanUsers()
+   *
+   * @param \stdClass
+   *   The user object.
+   */
+  public function addUser($user);
+
+  /**
+   * Removes a user from the list of users that were created in the test.
+   *
+   * @param $userName
+   *   The name of the user to remove.
+   */
+  public function removeUser($userName);
+
+  /**
+   * Returns the list of users that were created in the test.
+   *
+   * @return \stdClass[]
+   *   An array of user objects.
+   */
+  public function getUsers();
+
+  /**
+   * Returns the user with the given user name.
+   *
+   * @param string $userName
+   *   The name of the user to return.
+   *
+   * @return \stdClass
+   *   The user object.
+   *
+   * @throws \Exception
+   *   Thrown when the user with the given name does not exist.
+   */
+  public function getUser($userName);
+
+  /**
+   * Clears the list of users that were created in the test.
+   */
+  public function clearUsers();
+
+  /**
+   * Returns whether or not any users were created in the test.
+   *
+   * @return bool
+   *   TRUE if any users are tracked, FALSE if not.
+   */
+  public function hasUsers();
+
+  /**
+   * Returns whether the current user is anonymous.
+   *
+   * @return bool
+   *   TRUE if the current user is anonymous.
+   */
+  public function currentUserIsAnonymous();
+
+  /**
+   * Checks if the current user has the given role(s)
+   *
+   * @param string $role
+   *   A single role, or multiple comma-separated roles in a single string.
+   *
+   * @return boolean
+   *   Returns TRUE if the currently logged in user has this role (or roles).
+   */
+  public function currentUserHasRole($role);
 
 }

--- a/src/Drupal/DrupalUserManagerInterface.php
+++ b/src/Drupal/DrupalUserManagerInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal;
+
+/**
+ * Interface for classes that manage the currently logged in user.
+ */
+interface DrupalUserManagerInterface {
+
+  /**
+   * Returns the currently logged in user.
+   *
+   * A value of FALSE denotes an anonymous user.
+   *
+   * @return \stdClass|bool
+   */
+  public function getUser();
+
+  /**
+   * Sets the currently logged in user.
+   *
+   * @param \stdClass|bool $user
+   */
+  public function setUser($user);
+
+}

--- a/src/Drupal/DrupalUserManagerInterface.php
+++ b/src/Drupal/DrupalUserManagerInterface.php
@@ -10,9 +10,8 @@ interface DrupalUserManagerInterface {
   /**
    * Returns the currently logged in user.
    *
-   * A value of FALSE denotes an anonymous user.
-   *
    * @return \stdClass|bool
+   *   The user object, or FALSE if the user is anonymous.
    */
   public function getCurrentUser();
 
@@ -20,6 +19,7 @@ interface DrupalUserManagerInterface {
    * Sets the currently logged in user.
    *
    * @param \stdClass|bool $user
+   *   The user object, or FALSE if the user has been logged out.
    */
   public function setCurrentUser($user);
 


### PR DESCRIPTION
This is a proof of concept for #306.

I have created a very simple `DrupalUserManager` service that has a getter and setter for the current user object. This allows to persist the logged in user and share it between the different contexts that all extend `RawDrupalContext`.

In order to make this work with existing code that accesses the `RawDrupalContext::$user` property directly I'm hijjacking it with a magic getter and setter. This should in theory be compatible with all  existing 3.x code, but let's have a look at how this affects the current test suite first :)

Now that we have a 4.x branch I'd love to go a bit further. We can get rid of all code that directly accesses `RawDrupalContext::$user` and `RawDrupalContext::$users`, and replace it with this service.
