### PR TITLE
Revert to stable release of Behat

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,32 @@ the [Full documentation](https://behat-drupal-extension.readthedocs.org)
  * [Drupal form element visibility](https://gist.github.com/pbuyle/7698675)
  * [Track down PHP notices](https://www.godel.com.au/blog/use-behat-track-down-php-notices-they-take-over-your-drupal-site-forever)
  * [Support for sites using basic HTTP authentication](https://gist.github.com/jhedstrom/5bc5192d6dacbf8cc459)
+
+## Release notes
+
+### Backwards incompatible changes
+
+Starting with 3.3.0 Behat Drupal Extension depends on Behat 3.2.0 which
+requires all callbacks to be defined as static methods.
+
+Before 3.3.0:
+
+```
+/**
+ * @afterUserCreate
+ */
+public function afterUserCreate(EntityScope $scope) {
+  // ...
+}
+```
+
+Starting with 3.3.0:
+
+```
+/**
+ * @afterUserCreate
+ */
+public static function afterUserCreate(EntityScope $scope) {
+  // ...
+}
+```

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
     "behat/mink": "~1.5",
     "behat/mink-goutte-driver": "~1.0",
     "behat/mink-selenium2-driver": "~1.1",
-    "behat/behat": "~3.1.0-rc2",
+    "behat/behat": "~3.2",
     "behat/mink-extension": "~2.0",
     "drupal/drupal-driver": "dev-master",
-    "symfony/dependency-injection": "~2.7",
-    "symfony/event-dispatcher": "~2.7"
+    "symfony/dependency-injection": "~2.7|~3.0",
+    "symfony/event-dispatcher": "~2.7|~3.0"
   },
   "require-dev": {
     "phpspec/phpspec": "~2.0",

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -21,8 +21,8 @@ class FeatureContext extends RawDrupalContext {
    *
    * @beforeNodeCreate
    */
-  public function alterNodeParameters(BeforeNodeCreateScope $scope) {
-    parent::alterNodeParameters($scope);
+  public static function alterNodeParameters(BeforeNodeCreateScope $scope) {
+    call_user_func('parent::alterNodeParameters', $scope);
     // @see `features/api.feature`
     // Change 'published on' to the expected 'created'.
     $node = $scope->getEntity();
@@ -37,7 +37,7 @@ class FeatureContext extends RawDrupalContext {
    *
    * @beforeTermCreate
    */
-  public function alterTermParameters(EntityScope $scope) {
+  public static function alterTermParameters(EntityScope $scope) {
     // @see `features/api.feature`
     // Change 'Label' to expected 'name'.
     $term = $scope->getEntity();
@@ -52,7 +52,7 @@ class FeatureContext extends RawDrupalContext {
    *
    * @beforeUserCreate
    */
-  public function alterUserParameters(EntityScope $scope) {
+  public static function alterUserParameters(EntityScope $scope) {
     // @see `features/api.feature`
     // Concatenate 'First name' and 'Last name' to form user name.
     $user = $scope->getEntity();
@@ -72,7 +72,7 @@ class FeatureContext extends RawDrupalContext {
    *
    * @afterNodeCreate
    */
-  public function afterNodeCreate(EntityScope $scope) {
+  public static function afterNodeCreate(EntityScope $scope) {
     if (!$node = $scope->getEntity()) {
       throw new \Exception('Failed to find a node in @afterNodeCreate hook.');
     }
@@ -83,7 +83,7 @@ class FeatureContext extends RawDrupalContext {
    *
    * @afterTermCreate
    */
-  public function afterTermCreate(EntityScope $scope) {
+  public static function afterTermCreate(EntityScope $scope) {
     if (!$term = $scope->getEntity()) {
       throw new \Exception('Failed to find a term in @afterTermCreate hook.');
     }
@@ -94,7 +94,7 @@ class FeatureContext extends RawDrupalContext {
    *
    * @afterUserCreate
    */
-  public function afterUserCreate(EntityScope $scope) {
+  public static function afterUserCreate(EntityScope $scope) {
     if (!$user = $scope->getEntity()) {
       throw new \Exception('Failed to find a user in @afterUserCreate hook.');
     }

--- a/src/Drupal/DrupalExtension/Context/Environment/Reader/Reader.php
+++ b/src/Drupal/DrupalExtension/Context/Environment/Reader/Reader.php
@@ -90,13 +90,23 @@ final class Reader implements EnvironmentReader {
     $contextClasses = $this->findSubContextClasses();
 
     foreach ($contextClasses as $contextClass) {
-      $callees = array_merge(
-        $callees,
-        $this->readContextCallees($environment, $contextClass)
-      );
+      // When executing test scenarios with an examples table the registering of
+      // contexts is handled differently in newer version of Behat. Starting
+      // with Behat 3.2.0 the contexts are already registered, and the callees
+      // are returned by the default reader.
+      // Work around this and provide compatibility with Behat 3.1.0 as well as
+      // 3.2.0 and higher by checking if the class already exists before
+      // registering it and returning the callees.
+      // @see https://github.com/Behat/Behat/issues/758
+      if (!$environment->hasContextClass($contextClass)) {
+        $callees = array_merge(
+          $callees,
+          $this->readContextCallees($environment, $contextClass)
+        );
 
-      // Register context.
-      $environment->registerContextClass($contextClass, array($this->drupal));
+        // Register context.
+        $environment->registerContextClass($contextClass, array($this->drupal));
+      }
     }
 
     return $callees;

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -234,7 +234,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    *
    * @beforeNodeCreate
    */
-  public function alterNodeParameters(BeforeNodeCreateScope $scope) {
+  public static function alterNodeParameters(BeforeNodeCreateScope $scope) {
     $node = $scope->getEntity();
 
     // Get the Drupal API version if available. This is not available when


### PR DESCRIPTION
I just noticed in our project we were stuck on an old release of Behat, while the new 3.2.2 version was released a couple of days ago. Seems like we forgot to update our dependencies when 3.1.0 was released back in March.