### PR TITLE
Big pipe compatibility follow-up

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -114,6 +114,7 @@ drupal8:
         - Drupal\DrupalExtension\Context\MinkContext
         - Drupal\DrupalExtension\Context\MarkupContext
         - Drupal\DrupalExtension\Context\MessageContext
+        - Drupal\DrupalExtension\Context\BigPipeContext
       filters:
         tags: "@d8&&~@d8wip"
   extensions:

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -129,3 +129,4 @@ drupal8:
         content: "#content"
       selectors:
         error_message_selector: '.messages--error'
+        success_message_selector: '.messages--status'

--- a/features/messages.feature
+++ b/features/messages.feature
@@ -3,7 +3,7 @@ Feature: Ensure that messages are working properly on local installs
   In order to be sure that Drupal 8 with Big Pipe enabled can be tested
   Messages are tested against a local installation
 
-  Scenario: Non-JS messages
+  Scenario: Non-JS messages for anonymous
     Given I am on "/user/login"
     When I fill in "a fake user" for "Username"
     And I fill in "a fake password" for "Password"
@@ -11,9 +11,26 @@ Feature: Ensure that messages are working properly on local installs
     Then I should see the error message "Unrecognized username or password"
 
   @javascript
-  Scenario: JS messages
+  Scenario: JS messages for anonymous
     Given I am on "/user/login"
     When I fill in "a fake user" for "Username"
     And I fill in "a fake password" for "Password"
     When I press "Log in"
     Then I should see the error message "Unrecognized username or password"
+
+  Scenario: Non-JS messages for authenticated
+    Given I am logged in as a user with the "access site in maintenance mode,administer site configuration" permissions
+    And I am on "/admin/config/development/maintenance"
+    When I check the box "maintenance_mode"
+    And I press "Save configuration"
+    And print last response
+    Then I should see the message "The configuration options have been saved."
+
+  @javascript
+  Scenario: JS messages for authenticated
+    Given I am logged in as a user with the "access site in maintenance mode,administer site configuration" permissions
+    And I am on "/admin/config/development/maintenance"
+    When I check the box "maintenance_mode"
+    And I press "Save configuration"
+    And print last response
+    Then I should see the message "The configuration options have been saved."

--- a/features/messages.feature
+++ b/features/messages.feature
@@ -23,7 +23,6 @@ Feature: Ensure that messages are working properly on local installs
     And I am on "/admin/config/development/maintenance"
     When I check the box "maintenance_mode"
     And I press "Save configuration"
-    And print last response
     Then I should see the message "The configuration options have been saved."
 
   @javascript

--- a/src/Drupal/DrupalExtension/Context/BigPipeContext.php
+++ b/src/Drupal/DrupalExtension/Context/BigPipeContext.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\DrupalExtension\Context;
+
+use Drupal\big_pipe\Render\Placeholder\BigPipeStrategy;
+use Behat\Mink\Exception\UnsupportedDriverActionException;
+
+/**
+ * Big Pipe context.
+ */
+class BigPipeContext extends RawDrupalContext {
+
+    /**
+     * Prepares Big Pipe NOJS cookie if needed.
+     *
+     * @BeforeScenario
+     */
+    public function prepareBigPipeNoJsCookie()
+    {
+        try {
+            // Check if JavaScript can be executed by Driver.
+            $this->getSession()->getDriver()->executeScript('true');
+        }
+        catch (UnsupportedDriverActionException $e) {
+            // Set NOJS cookie.
+            $this
+              ->getSession()
+              ->setCookie(BigPipeStrategy::NOJS_COOKIE, true);
+
+        }
+        catch (\Exception $e) {
+            // Mute exceptions.
+        }
+    }
+
+}


### PR DESCRIPTION
#259 doesn't test messages for authenticated users. This follow-up PR should prove that messages work only for anonymous users.

In next commits to branch I will suggest how can we fix it (based on workaround proposed here:  https://github.com/jhedstrom/drupalextension/issues/258#issuecomment-193357483)