### PR TITLE
Use a more specific exception to indicate unmet expectations in MessageContext

### DIFF
--- a/src/Drupal/DrupalExtension/Context/MessageContext.php
+++ b/src/Drupal/DrupalExtension/Context/MessageContext.php
@@ -4,6 +4,7 @@ namespace Drupal\DrupalExtension\Context;
 
 use Behat\Behat\Context\TranslatableContext;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Exception\ExpectationException;
 
 /**
  * Provides step-definitions for interacting with Drupal messages.
@@ -252,20 +253,22 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    * @param $exceptionMsgMissing
    *   string The message being thrown when the message is not contained, string
    *   should contain two '%s' as placeholders for the current URL and the message.
-   * @throws \Exception
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   *   Thrown when the expected message is not present in the page.
    */
   private function _assert($message, $selectorId, $exceptionMsgNone, $exceptionMsgMissing) {
     $selector = $this->getDrupalSelector($selectorId);
     $selectorObjects = $this->getSession()->getPage()->findAll("css", $selector);
     if (empty($selectorObjects)) {
-      throw new \Exception(sprintf($exceptionMsgNone, $this->getSession()->getCurrentUrl()));
+      throw new ExpectationException(sprintf($exceptionMsgNone, $this->getSession()->getCurrentUrl()));
     }
     foreach ($selectorObjects as $selectorObject) {
       if (strpos(trim($selectorObject->getText()), $message) !== FALSE) {
         return;
       }
     }
-    throw new \Exception(sprintf($exceptionMsgMissing, $this->getSession()->getCurrentUrl(), $message));
+    throw new ExpectationException(sprintf($exceptionMsgMissing, $this->getSession()->getCurrentUrl(), $message));
   }
 
   /**
@@ -278,7 +281,9 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    * @param $exceptionMsg
    *   string The message being thrown when the message is contained, string
    *   should contain two '%s' as placeholders for the current URL and the message.
-   * @throws \Exception
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   *   Thrown when the expected message is present in the page.
    */
   private function _assertNot($message, $selectorId, $exceptionMsg) {
     $selector = $this->getDrupalSelector($selectorId);
@@ -286,7 +291,7 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
     if (!empty($selectorObjects)) {
       foreach ($selectorObjects as $selectorObject) {
         if (strpos(trim($selectorObject->getText()), $message) !== FALSE) {
-          throw new \Exception(sprintf($exceptionMsg, $this->getSession()->getCurrentUrl(), $message));
+          throw new ExpectationException(sprintf($exceptionMsg, $this->getSession()->getCurrentUrl(), $message));
         }
       }
     }


### PR DESCRIPTION
I am using an `@AfterStep` to take screenshot if I have PHP notices on the screen. I suddenly noticed this started taking screenshots of every step, even if there were no PHP notices.

This was because I was checking the notices with the MessageContext, and somewhere in the chain an exception was thrown. My code could not distinguish between an actual failed message and an unrelated exception:

```
try {
  $context->assertNotWarningMessage('Notice:');
}
catch (\Exception $e) {
  $this->saveScreenshot();
}
```

Let's use a more specific exception to indicate that our expectation was not met.

Note that this is a potential B/C break with the current code base in the 3.x branch. If people have been using code like in this example snippet, then they won't be able to catch messages any more.