### PR TITLE
Avoid random failures due to collisions in random directory names

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -230,8 +230,10 @@ class FeatureContext extends RawDrupalContext {
      */
     public function prepareTestFolders()
     {
-        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'behat' . DIRECTORY_SEPARATOR .
-            md5((int) microtime(TRUE) * rand(0, 10000));
+        do {
+            $random_name = md5((int) microtime(true) * rand(0, 100000));
+            $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'behat' . DIRECTORY_SEPARATOR . $random_name;
+        } while (is_dir($dir));
 
         mkdir($dir . '/features/bootstrap/i18n', 0777, true);
 


### PR DESCRIPTION
There have been a few occasions where tests have failed on Travis due to collisions of the random name that is generated for the test folder. The most recent of this occurred in https://travis-ci.org/jhedstrom/drupalextension/jobs/189521981

Let's generate another random name if the folder already exists.