### PR TITLE
Changed drupalextension version for Drupal 7

### DIFF
--- a/doc/_static/snippets/composer.json
+++ b/doc/_static/snippets/composer.json
@@ -1,7 +1,7 @@
 {
   "require": {
-    "drupal/drupal-extension": "~3.0"
-},
+    "drupal/drupal-extension": "^3.2"
+  },
   "config": {
     "bin-dir": "bin/"
   }


### PR DESCRIPTION
- `~3.0` conflicts with phpunit ^6.1