### PR TITLE
Changed drupalextension version for Drupal 8

### DIFF
--- a/doc/_static/snippets/composer.json.d8
+++ b/doc/_static/snippets/composer.json.d8
@@ -1,8 +1,8 @@
 {
   "require": {
-    "drupal/drupal-extension": "~3.0",
+    "drupal/drupal-extension": "^3.2",
     "guzzlehttp/guzzle" : "^6.0@dev"
-},
+  },
   "config": {
     "bin-dir": "bin/"
   }


### PR DESCRIPTION
- `~3.0` conflicts with phpunit ^6.1