### PR TITLE
Extend 'I wait for ajax' step

### DIFF
--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -116,10 +116,20 @@ class MinkContext extends MinkExtension implements TranslatableContext {
   /**
    * Wait for AJAX to finish.
    *
+   * @param int $seconds
+   *   Max time to wait for AJAX.
+   *
+   * @Given I wait for AJAX to finish at least :seconds seconds
    * @Given I wait for AJAX to finish
+   *
+   * @throws \Exception
+   *   Ajax call didn't finish on time.
    */
-  public function iWaitForAjaxToFinish() {
-    $this->getSession()->wait(5000, '(typeof(jQuery)=="undefined" || (0 === jQuery.active && 0 === jQuery(\':animated\').length))');
+  public function iWaitForAjaxToFinish($seconds = 5) {
+    $finished = $this->getSession()->wait($seconds * 1000, '(typeof(jQuery)=="undefined" || (0 === jQuery.active && 0 === jQuery(\':animated\').length))');
+    if (!$finished) {
+      throw new \Exception("Ajax call didn't finished within $seconds seconds.");
+    }
   }
 
   /**


### PR DESCRIPTION
Hi.

This pull request include this  features to the '@Given I wait for AJAX' step:
1) Allow specify time to wait, in case requests are longer than 5 seconds, with this sintax:
Given I wait for AJAX to finish at least "5" seconds
2) Throw exception when AJAX petition didn't finish; in some case it breaks the test in another part. There is some reason to don't throw an exception in this step, maybe it's not completely trustworthy?

Can you review this changes and merge? Thanks!