### PR TITLE
Fix null session when first step asserts a login

### DIFF
--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -585,6 +585,9 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    */
   public function loggedIn() {
     $session = $this->getSession();
+    if (!$session->isStarted()) {
+      $session->start();
+    }
     $page = $session->getPage();
 
     // Look for a css selector to determine if a user is logged in.


### PR DESCRIPTION
```
  Scenario: Create and delete a...                         # features/mytest.feature:7
    Given I am logged in as a user with the "administrator" role # Drupal\DrupalExtension\Context\DrupalContext::assertAuthenticatedByRole()
      Behat\Testwork\Call\Exception\FatalThrowableError: Fatal error: Call to a member function elements() on null in /var/www/html/vendor/behat/mink-selenium2-driver/src/Selenium2Driver.php:488
```

https://github.com/minkphp/Mink/pull/705 removes the auto-starting of sessions as this was never a supported use of the API. This PR fixes compatibility Drupal 8.3+ which currently pulls in the master branch.