### PR TITLE
Stop testing on PHP 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
@@ -17,8 +16,6 @@ env:
 
 matrix:
   exclude:
-    - php: 5.4
-      env: DRUPAL_VERSION=8
     - php: 5.6
       env: DRUPAL_VERSION=6
     - php: 7.0


### PR DESCRIPTION
In PR #324 we are making sure BDE is compatible with the latest versions of Behat and Symfony components. These no longer support PHP 5.4, so let's stop testing that version.