### PR TITLE
Throw an exception when the environment is not yet initialized

### DIFF
--- a/src/Drupal/DrupalExtension/Context/DrupalSubContextBase.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalSubContextBase.php
@@ -57,10 +57,22 @@ abstract class DrupalSubContextBase extends RawDrupalContext implements DrupalSu
    *
    * @return \Behat\Behat\Context\Context|false
    *   The requested context, or FALSE if the context is not registered.
+   *
+   * @throws \Exception
+   *   Thrown when the environment is not yet initialized, meaning that contexts
+   *   cannot yet be retrieved.
    */
   protected function getContext($class) {
     /** @var InitializedContextEnvironment $environment */
     $environment = $this->drupal->getEnvironment();
+    // Throw an exception if the environment is not yet initialized. To make
+    // sure state doesn't leak between test scenarios, the environment is
+    // reinitialized at the start of every scenario. If this code is executed
+    // before a test scenario starts (e.g. in a `@BeforeScenario` hook) then the
+    // contexts cannot yet be retrieved.
+    if (!$environment instanceof InitializedContextEnvironment) {
+      throw new \Exception('Cannot retrieve contexts when the environment is not yet initialized.');
+    }
     foreach ($environment->getContexts() as $context) {
       if ($context instanceof $class) {
         return $context;


### PR DESCRIPTION
This PR introduces a new exception that should help developers understand under which circumstances contexts cannot be retrieved.

This is a DX improvement that is inspired by issue #386.