### PR TITLE
DriverListener should react to ExampleTested events

### DIFF
--- a/spec/Drupal/DrupalExtension/Listener/DriverListenerSpec.php
+++ b/spec/Drupal/DrupalExtension/Listener/DriverListenerSpec.php
@@ -54,7 +54,7 @@ class DriverListenerSpec extends ObjectBehavior
     {
         $subscribedEvents = array(
             'tester.scenario_tested.before' => array('prepareDefaultDrupalDriver', 11),
-            'tester.outline_tested.before' => array('prepareDefaultDrupalDriver', 11),
+            'tester.example_tested.before' => array('prepareDefaultDrupalDriver', 11),
         );
         $this->getSubscribedEvents()->shouldReturn($subscribedEvents);;
     }

--- a/src/Drupal/DrupalExtension/Listener/DriverListener.php
+++ b/src/Drupal/DrupalExtension/Listener/DriverListener.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\DrupalExtension\Listener;
 
-use Behat\Behat\EventDispatcher\Event\OutlineTested;
+use Behat\Behat\EventDispatcher\Event\ExampleTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioLikeTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
 
@@ -42,7 +42,7 @@ class DriverListener implements EventSubscriberInterface {
   public static function getSubscribedEvents() {
     return array(
       ScenarioTested::BEFORE => array('prepareDefaultDrupalDriver', 11),
-      OutlineTested::BEFORE => array('prepareDefaultDrupalDriver', 11),
+      ExampleTested::BEFORE => array('prepareDefaultDrupalDriver', 11),
     );
   }
 


### PR DESCRIPTION
I discovered a big ol' bug today!

During the environment isolation process, Behat's ContextEnvironmentHandler class will, in its isolateEnvironment() method, convert UninitializedContextEnvironment to InitializedContextEnvironment, which is necessary in order for any Drupal Extension subcontext's getContext() method to work.

Unfortunately, during scenario outline tests, Drupal Extension does not pick up the new environment, so any calls to getContext() in scenario examples results in a fatal error (call to undefined getContexts() method in UninitializedContextEnvironment). This is because the OutlineTested::BEFORE event is fired *before* Behat isolates the environment.

The fix, I discovered, is for Drupal Extension's DriverListener to react to the ExampleTested::BEFORE event instead of OutlineTested::BEFORE, because ExampleTested::BEFORE is fired *after* the environment is isolated. It also is more in line with ScenarioTested::BEFORE in terms of its scope, so it's probably the more "correct" event to react to.