### PR TITLE
#446 Check for session first before logging out in fastLogout method of DrupalAuthenticationManager

### DIFF
--- a/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
@@ -133,7 +133,7 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
         $session = $this->getSession();
         if ($session->isStarted()) {
             $session->reset();
-            $this->userManager->setCurrentUser(false);
         }
+        $this->userManager->setCurrentUser(false);
     }
 }

--- a/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
@@ -132,8 +132,8 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
     {
         $session = $this->getSession();
         if ($session->isStarted()) {
-          $session->reset();
-          $this->userManager->setCurrentUser(FALSE);
+            $session->reset();
+            $this->userManager->setCurrentUser(false);
         }
     }
 }

--- a/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
@@ -130,7 +130,10 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
      */
     public function fastLogout()
     {
-        $this->getSession()->reset();
-        $this->userManager->setCurrentUser(false);
+        $session = $this->getSession();
+        if ($session->isStarted()) {
+          $session->reset();
+          $this->userManager->setCurrentUser(FALSE);
+        }
     }
 }


### PR DESCRIPTION
Attempt at resolving #446.