### PR TITLE
drupalExtension is fully translated to Spanish

### DIFF
--- a/features/i18n/es/blackbox.feature
+++ b/features/i18n/es/blackbox.feature
@@ -1,0 +1,106 @@
+# language: es
+@blackbox
+Característica: Test DrupalContext
+  # Esta característica es copia traducida de la "feature" correspondiente
+  # para demostrar que los correspondientes pasos están bien traducidos
+  # al español
+  Para probar el adecuado funcionamiento del contexto Drupal usando el driver "blackbox"
+  Como desarrollador
+  Necesito usar los pasos definidos en este contexto
+
+  Escenario: Prueba la capacidad de encontrar un encabezado en una zona
+    Dado estoy en la página de inicio
+    Cuando hago click en "Download & Extend"
+    Entonces debo ver el encabezado "Download" en la zona "content"
+
+  Escenario: Hacer click en contenido de una zona
+    Dado que estoy en la URL "community.html"
+    Cuando hago click en "IRC" de la zona "content"
+    Entonces debo ver "Page status" en "right sidebar"
+      Y debo ver el enlace "Drupal News" en la zona "footer"
+
+  Escenario: Ver contenido en una zona
+    Dado estoy en la página de inicio
+    Entonces debo ver "Build something amazing." en "left header"
+      Y debo ver "Build something amazing." en la zona "left header"
+
+  Escenario: Prueba la capacidad de buscar texto que no debe aparecer en una zona
+    Dado estoy en la página de inicio
+    Entonces no debo ver el texto "Proprietary software is cutting edge" en "left header"
+      Y no debo ver el texto "Proprietary software is cutting edge" en la zona "left header"
+
+  Escenario: Enviar un formulario de una zona
+    Dado estoy en la página de inicio
+    Cuando relleno el campo "Search…" con "Views" en la zona "navigation"
+      Y pulso "Search" en la zona "navigation"
+    Entonces debo ver el texto "Search again" en la zona "right sidebar"
+
+  Escenario: Prueba que enlace que existe en una zona
+    Dado estoy en la página de inicio
+    Entonces no debo ver el enlace "This link should never exist in a default Drupal install" en "right header"
+
+  Escenario: Encontrar un botón
+    Dado estoy en la página de inicio
+    Entonces debo ver el botón "Search"
+
+  Escenario: Encontrar un botón en una zona
+    Dado estoy en la página de inicio
+    Entonces debo ver el botón "Search" en "navigation"
+      Y debo ver el botón "Search" en la zona "navigation"
+
+  Escenario: Encontrar un elemento en una zona
+    Dado estoy en la página de inicio
+    Entonces debo ver un elemento "h1" en "left header"
+      Y debo ver un elemento "h1" en la zona "left header"
+
+  Escenario: Comprobar que no existe un elemento en una zona
+    Dado estoy en la página de inicio
+    Entonces no debo ver un elemento "h1" en "footer"
+      Y no debo ver un elemento "h1" en la zona "footer"
+
+  Escenario: Comprobar que no existe una elemento con un texto en una zona
+    Dado estoy en la página de inicio
+    Entonces no debo ver "DotNetNuke" en un elemento "h1" en "left header"
+      Y no debo ver "DotNetNuke" en un elemento "h1" en la zona "left header"
+
+  Escenario: Encontrar un elemento con un atributo en una zona
+    Dado estoy en la página de inicio
+    Entonces debo ver un elemento "h1" con el atributo "id" igual a "site-name" en la zona "left header"
+
+  Escenario: Encontrar un texto en un elemento con un atributo en una zona
+    Dado estoy en la página de inicio
+    Entonces debo ver "Drupal" en un elemento "h1" con atributo "id" igual a "site-name" en la zona "left header"
+      Y debo ver "Drupal" en un elemento "h1" con atributo "id" igual a "site-name" en "left header"
+
+  Escenario: Encontrar un elemento con una atributo determinado en una zona
+    Dado que estoy en la URL "assertRegionElementAttribute.html"
+    Entonces debo ver un elemento "div" con el atributo "class" igual a "class1" en la zona "left header"
+      Y debo ver un elemento "div" con el atributo "class" igual a "class2" en "left header"
+      Y debo ver un elemento "div" con el atributo "class" igual a "class3" en "left header"
+
+  Escenario: Encontrar un texto en un elemento con un determinado estilo CSS en una zona
+    Dado que estoy en la URL "assertRegionElementAttribute.html"
+    Entonces debo ver "footer" en un elemento "p" con estilo CSS "color" igual a "red" en la zona "footer"
+    Entonces debo ver "footer" en un elemento "p" con estilo CSS "color" igual a "red" en "footer"
+
+  Escenario: Mensajes de error
+    Dado que estoy en la URL "user.html"
+    Cuando presiono "Log in"
+    Entonces debo ver el mensaje de error "Password field is required"
+      Y debo ver el mensaje de error conteniendo "Password field is required"
+      Y no debo ver el mensaje de error "Sorry, unrecognized username or password"
+      Y no debo ver el mensaje de error conteniendo "Sorry, unrecognized username or password"
+      Y debo ver los siguientes mensajes de error:
+       | error messages                       |
+       | Username or email field is required. |
+       | Password field is required           |
+      Y no debo ver los siguientes mensajes de error:
+       | error messages                                                                |
+       | Sorry, unrecognized username or password                                      |
+       | Unable to send e-mail. Contact the site administrator if the problem persists |
+
+  @javascript
+  Escenario: El driver Zombie funciona adecuadamente
+    Dado estoy en la página de inicio
+    Cuando hago click en "Download & Extend"
+    Entonces debo ver el enlace "Distributions"

--- a/features/i18n/es/d8.feature
+++ b/features/i18n/es/d8.feature
@@ -14,8 +14,8 @@ Característica: DrupalContext
     Entonces debo ver el texto "Member for"
 
   Escenario: Enlaces dentro de filas de tablas
-    Dado que estoy conectado como usuario con rol "administrator"
-    Cuando estoy en "admin/structure/types"
+    Dado que estoy conectado como un "administrator"
+    Cuando estoy en la URL "admin/structure/types"
       Y hago click en el enlace "Manage fields" de la fila "Article"
     Entonces debo estar en "admin/structure/types/manage/article/fields"
       Y debo ver el enlace "Add field"
@@ -27,7 +27,7 @@ Característica: DrupalContext
         | Jane Doe | jane@example.com |                |
       Y estoy conectado como usuario con rol "administrator"
     Cuando visito "admin/people"
-    Entonces debo ver el texto "administrator" en la fila "Joe User"
+    Entonces debo ver el texto "Administrator" en la fila "Joe User"
       Y no debo ver el texto "administrator" en la fila "Jane Doe"
 
   Escenario: Encontrar un encabezado en una zona

--- a/features/i18n/es/d8.feature
+++ b/features/i18n/es/d8.feature
@@ -1,0 +1,44 @@
+# language: es
+@d8 @api
+Característica: DrupalContext
+  # Esta característica es copia traducida de la "feature" correspondiente
+  # para demostrar que los correspondientes pasos están bien traducidos
+  # al español
+  Para demostrar que el Contexto Drupal funciona adecuadamente con Drupal 8
+  Como desarrollador
+  Necesito usar los pasos definidos para éste Contexto
+
+  Escenario: Crear y conectarte como usuario
+    Dado que estoy conectado como usuario con rol "authenticated user"
+    Cuando hago click en "My account"
+    Entonces debo ver el texto "Member for"
+
+  Escenario: Enlaces dentro de filas de tablas
+    Dado que estoy conectado como usuario con rol "administrator"
+    Cuando estoy en "admin/structure/types"
+      Y hago click en el enlace "Manage fields" de la fila "Article"
+    Entonces debo estar en "admin/structure/types/manage/article/fields"
+      Y debo ver el enlace "Add field"
+
+  Escenario: Cear usuarios con roles
+    Dados usuarios:
+        | name     | mail             | roles          |
+        | Joe User | joe@example.com  | Administrator  |
+        | Jane Doe | jane@example.com |                |
+      Y estoy conectado como usuario con rol "administrator"
+    Cuando visito "admin/people"
+    Entoces debo ver el texto "administrator" en la fila "Joe User"
+      Y no debo ver el texto "administrator" en la fila "Jane Doe"
+
+  Escenario: Encontrar un encabezado en una zona
+    Dado que no estoy conectado
+    Cuando estoy en la página de inicio
+    Entonces debo ver el encabezado "Search" en la zona "left sidebar"
+
+  # lo siguiente comprueba que un usuario creado por una clase Conexto (en este
+  # caso FeatureContext::assertLoggedInByUsernameAndPassword()) puede ser utilizado
+  # por otro Contexto (DrupalContext::assertLoggedInByName()).
+  Escenario: Conectarse como usuario sin dirección de correo
+    # notar que el siguiente paso no está traducido: está definido en FeatureContext (no en DrupalContext)
+    Dado I am logged in as a user with name "Carrot Ironfoundersson" and password "citywatch1234"
+    Entonces estoy conectado como "Carrot Ironfoundersson"

--- a/features/i18n/es/d8.feature
+++ b/features/i18n/es/d8.feature
@@ -27,7 +27,7 @@ Característica: DrupalContext
         | Jane Doe | jane@example.com |                |
       Y estoy conectado como usuario con rol "administrator"
     Cuando visito "admin/people"
-    Entoces debo ver el texto "administrator" en la fila "Joe User"
+    Entonces debo ver el texto "administrator" en la fila "Joe User"
       Y no debo ver el texto "administrator" en la fila "Jane Doe"
 
   Escenario: Encontrar un encabezado en una zona

--- a/features/i18n/es/language.feature
+++ b/features/i18n/es/language.feature
@@ -1,0 +1,24 @@
+# language: es
+@api @d7 @d8
+Característica: Soporte para idiomas
+  # Esta característica es copia traducida de la "feature" correspondiente
+  # para demostrar que los correspondientes pasos están bien traducidos
+  # al español
+  Para demostrar la integración de idiomas
+  Como desarrollador de Behat Extension
+  Necesito proveer casos de test para soporte de idiomas
+
+  # Este escenario asume que existe una instalación limpia del perfil "standard"
+  # y que el módulo "behat_test" del directorio "fixtures/" esta activo
+
+  Escenario: Habilita múltiples idiomas
+    Dado que los siguientes idiomas estan disponibles:
+        | languages |
+        | en        |
+        | fr        |
+        | de        |
+      Y estoy conectado como usuario con rol 'administrator'
+    Cuando voy a "admin/config/regional/language"
+    Entonces debo ver "English"
+      Y debo ver "French"
+      Y debo ver "German"

--- a/fixtures/blackbox/assertRegionElementAttribute.html
+++ b/fixtures/blackbox/assertRegionElementAttribute.html
@@ -15,6 +15,7 @@
       </div>
     </div>
     <div id="footer">
+      <p style="color:red">footer</p>
     </div>
   </body>
 </html>

--- a/i18n/es.xliff
+++ b/i18n/es.xliff
@@ -13,6 +13,10 @@
         <source><![CDATA[I am logged in as a user with the :role role(s)]]></source>
         <target><![CDATA[(que )estoy conectado como usuario con rol(es) :role]]></target>
       </trans-unit>
+      <trans-unit id="I-am-logged-in-as-a-an-role">
+        <source><![CDATA[I am logged in as a/an :role]]></source>
+        <target><![CDATA[(que )estoy conectado como un :role]]></target>
+      </trans-unit>
       <trans-unit id="i-am-logged-in-as-name">
         <source><![CDATA[I am logged in as :name]]></source>
         <target><![CDATA[(que )estoy conectado como :name]]></target>
@@ -280,6 +284,10 @@
       <trans-unit id="i-select-the-radio-button-label">
         <source><![CDATA[I select the radio button :label]]></source>
         <target><![CDATA[selecciono el botón de radio :label]]></target>
+      </trans-unit>
+      <trans-unit id="the-these-following-languages-are-available">
+        <source><![CDATA[the/these (following )languages are available:]]></source>
+        <target><![CDATA[(que )el/los siguiente(s) idioma(s) esta(n) disponible(s):]]></target>
       </trans-unit>
     </body>
   </file>

--- a/i18n/es.xliff
+++ b/i18n/es.xliff
@@ -30,7 +30,7 @@
         <target><![CDATA[debo ver (el texto ):text en la fila :rowText]]></target>
       </trans-unit>
       <trans-unit id="i-not-should-see-the-text-text-in-the-rowtext-row">
-        <source><![CDATA[I not should see (the text ):text in the :rowText row]]></source>
+        <source><![CDATA[I should not see (the text ):text in the :rowText row]]></source>
         <target><![CDATA[no debo ver (el texto ):text en la fila :rowText]]></target>
       </trans-unit>
       <trans-unit id="i-click-link-in-the-rowtext-row">
@@ -171,7 +171,7 @@
       </trans-unit>
       <trans-unit id="i-am-at-path">
         <source><![CDATA[I am at :path]]></source>
-        <target><![CDATA[(que )estoy en :path]]></target>
+        <target><![CDATA[(que )estoy en la URL :path]]></target>
       </trans-unit>
       <trans-unit id="i-visit-path">
         <source><![CDATA[I visit :path]]></source>

--- a/i18n/es.xliff
+++ b/i18n/es.xliff
@@ -26,8 +26,12 @@
         <target><![CDATA[(que )estoy conectado com un usuario con permiso(s) :permissions]]></target>
       </trans-unit>
       <trans-unit id="i-should-see-the-text-text-in-the-rowtext-row">
-        <source><![CDATA[I should see (the text ):text in the ":rowText" row]]></source>
-        <target><![CDATA[debo ver (el texto ):text en la fila ":rowText"]]></target>
+        <source><![CDATA[I should see (the text ):text in the :rowText row]]></source>
+        <target><![CDATA[debo ver (el texto ):text en la fila :rowText]]></target>
+      </trans-unit>
+      <trans-unit id="i-not-should-see-the-text-text-in-the-rowtext-row">
+        <source><![CDATA[I not should see (the text ):text in the :rowText row]]></source>
+        <target><![CDATA[no debo ver (el texto ):text en la fila :rowText]]></target>
       </trans-unit>
       <trans-unit id="i-click-link-in-the-rowtext-row">
         <source><![CDATA[I click :link in the :rowText row]]></source>
@@ -79,7 +83,7 @@
       </trans-unit>
       <trans-unit id="users">
         <source><![CDATA[users:]]></source>
-        <target><![CDATA[users:]]></target>
+        <target><![CDATA[usuarios:]]></target>
       </trans-unit>
       <trans-unit id="vocabulary-terms">
         <source><![CDATA[:vocabulary terms:]]></source>

--- a/i18n/es.xliff
+++ b/i18n/es.xliff
@@ -115,7 +115,7 @@
       </trans-unit>
       <trans-unit id="i-should-see-the-error-message-containing-message">
         <source><![CDATA[I should see the error message( containing) :message]]></source>
-        <target><![CDATA[debo ver un mensaje de error( conteniendo) :message]]></target>
+        <target><![CDATA[debo ver el mensaje de error( conteniendo) :message]]></target>
       </trans-unit>
       <trans-unit id="i-should-see-the-following-error-messages">
         <source><![CDATA[I should see the following error message(s):]]></source>
@@ -123,7 +123,7 @@
       </trans-unit>
       <trans-unit id="i-should-not-see-the-error-message-containing-message">
         <source><![CDATA[I should not see the error message( containing) :message]]></source>
-        <target><![CDATA[no debo ver un mensaje de error( conteniendo) :message]]></target>
+        <target><![CDATA[no debo ver el mensaje de error( conteniendo) :message]]></target>
       </trans-unit>
       <trans-unit id="i-should-not-see-the-following-error-messages">
         <source><![CDATA[I should not see the following error messages:]]></source>
@@ -292,6 +292,46 @@
       <trans-unit id="the-these-following-languages-are-available">
         <source><![CDATA[the/these (following )languages are available:]]></source>
         <target><![CDATA[(que )el/los siguiente(s) idioma(s) esta(n) disponible(s):]]></target>
+      </trans-unit>
+      <trans-unit id="I-should-see-the-button-button">
+        <source><![CDATA[I (should ) see the button :button]]></source>
+        <target><![CDATA[debo ver el botón :button]]></target>
+      </trans-unit>
+      <trans-unit id="I-should-not-see-the-button-button">
+        <source><![CDATA[I should not see the button :button]]></source>
+        <target><![CDATA[no debo ver el botón :button]]></target>
+      </trans-unit>
+      <trans-unit id="I-should-see-the-button-button-in-the-region-region">
+        <source><![CDATA[I should see the button :button in the :region( region)]]></source>
+        <target><![CDATA[debo ver el botón :button en (la zona ):region]]></target>
+      </trans-unit>
+      <trans-unit id="I-should-see-the-tag-element-in-the-region-region">
+        <source><![CDATA[I( should) see the :tag element in the :region( region)]]></source>
+        <target><![CDATA[debo ver un elemento :tag en (la zona ):region]]></target>
+      </trans-unit>
+      <trans-unit id="I-should-not-see-the-tag-element-in-the-region-region">
+        <source><![CDATA[I( should) not see the :tag element in the :region( region)]]></source>
+        <target><![CDATA[no debo ver un elemento :tag en (la zona ):region]]></target>
+      </trans-unit>
+      <trans-unit id="I-should-see-text-in-the-tag-element-in-the-region-region">
+        <source><![CDATA[I( should) see :text in the :tag element in the :region( region)]]></source>
+        <target><![CDATA[debo ver :text en un elemento :tag en (la zona ):region]]></target>
+      </trans-unit>
+      <trans-unit id="I-should-not-see-text-in-the-tag-element-in-the-region-region">
+        <source><![CDATA[I( should) not see :text in the :tag element in the :region( region)]]></source>
+        <target><![CDATA[no debo ver :text en un elemento :tag en (la zona ):region]]></target>
+      </trans-unit>
+      <trans-unit id="I-should-see-the-tag-element-with-the-attribute-attribute-set-to-value-in-the-region-region">
+        <source><![CDATA[I( should) see the :tag element with the :attribute attribute set to :value in the :region( region)]]></source>
+        <target><![CDATA[debo ver un elemento :tag con el atributo :attribute igual a :value en (la zona ):region]]></target>
+      </trans-unit>
+      <trans-unit id="I-should-see-text-in-the-tag-element-with-the-attribute-attribute-set-to-value-in-the-region-region-">
+        <source><![CDATA[I( should) see :text in the :tag element with the :attribute attribute set to :value in the :region( region)]]></source>
+        <target><![CDATA[debo ver :text en un elemento :tag con atributo :attribute igual a :value en (la zona ):region]]></target>
+      </trans-unit>
+      <trans-unit id="I-should-see-text-in-the-tag-element-with-the-property-CSS-property-set-to-value-in-the-region-region">
+        <source><![CDATA[I( should) see :text in the :tag element with the :property CSS property set to :value in the :region( region)]]></source>
+        <target><![CDATA[debo ver :text en un elemento :tag con estilo CSS :property igual a :value en (la zona ):region]]></target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
Steps translated:
* the/these (following )languages are available:
* users:
* I should see (the text ):text in the :rowText row
* I should not see (the text ):text in the :rowText row
* I am logged in as a/an :role
* I (should ) see the button :button
* I (should ) see the :button button
* I should not see the button :button
* I should not see the :button button
* I should see the button :button in the :region( region)
* I should see the :button button in the :region( region)
* I( should) see the :tag element in the :region( region)
* I( should) not see the :tag element in the :region( region)
* I( should) not see :text in the :tag element in the :region( region)
* I( should) see the :tag element with the :attribute attribute set to :value in the :region( region)
* I( should) see :text in the :tag element with the :attribute attribute set to :value in the :region( region)
* I( should) see :text in the :tag element with the :property CSS property set to :value in the :region( region)

I think with this PR drupalExtension is fully translated to Spanish.

This PR creates an environment for testing translations placing a 'i18n' directory in which to place the translations of the features.

