### PR TITLE
Test Drupal 8 with Drush 9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   global:
     - PATH=$PATH:/home/travis/.composer/vendor/bin
     - TRAVIS_NODE_VERSION="4.0.0"
-    - DRUPAL_8_MINOR_VERSION=4
   matrix:
     - DRUPAL_VERSION=6
     - DRUPAL_VERSION=7
@@ -18,6 +17,8 @@ env:
 
 matrix:
   exclude:
+    - php: 5.5
+      env: DRUPAL_VERSION=8
     - php: 5.6
       env: DRUPAL_VERSION=6
     - php: 7.0
@@ -36,10 +37,12 @@ install:
   # For Drupal 8 install the behat drush endpoint.
   # Pins symfony/dependency-injection to match core.
   # @see https://github.com/jhedstrom/drupalextension/issues/413
-  - test ${DRUPAL_VERSION} -ne 8 || composer require --prefer-source drush-ops/behat-drush-endpoint drush/drush symfony/dependency-injection:3.2.8
+  # @todo Re-enable behat drush endpoint testing.
+  # @see https://github.com/jhedstrom/drupalextension/issues/458
+  - test ${DRUPAL_VERSION} -ne 8 || composer require --prefer-source drush/drush:~9.0 symfony/dependency-injection:3.2.8
   - composer install
   # Install drush globally.
-  - (test ${DRUPAL_VERSION} -ne 8 && composer global require drush/drush:~8.0) || composer global require drush/drush
+  - (test ${DRUPAL_VERSION} -ne 8 && composer global require drush/drush:~8.0) || composer global require drush/drush:~9.0
   # Install the Behat Drush Endpoint for Drupal 7 tests.
   - test ${DRUPAL_VERSION} -ne 7 || (git clone https://github.com/drush-ops/behat-drush-endpoint.git drush/behat-drush-endpoint && (cd drush/behat-drush-endpoint && composer install && cd -))
   # Pin node version.
@@ -51,15 +54,17 @@ before_script:
   # Set NODE_PATH for zombie driver.
   - export NODE_PATH="`pwd`/node_modules"
   # Define the module path according to the Drupal version being tested.
-  - test ${DRUPAL_VERSION} -eq 8 && export PROJECT_NAME="drupal-8.${DRUPAL_8_MINOR_VERSION}.x" || export PROJECT_NAME="drupal-${DRUPAL_VERSION}.x"
-  - export
   - test ${DRUPAL_VERSION} -ne 8 || export MODULE_PATH="drupal/modules"
   - test ${DRUPAL_VERSION} -eq 8 || export MODULE_PATH="drupal/sites/all/modules" && mkdir -p ${MODULE_PATH}
   # Set sendmail so drush doesn't throw an error during site install.
   - echo "sendmail_path='true'" >> `php --ini | grep "Loaded Configuration" | awk '{print $4}'`
-  # Download and install Drupal so we can test API abilities.
   - mysql -e 'create database drupal'
-  - drush dl --quiet --yes ${PROJECT_NAME} --all --drupal-project-rename=drupal
+  # Download and install Drupal so we can test API abilities.
+  # For Drush 9, dl is deprecated so we must use composer. However, we still
+  # cannot simply require drupal/drupal since it hardcodes it's autoloader
+  # and we'd need to use drupal-scaffold, etc, etc.
+  - test ${DRUPAL_VERSION} -eq 8 || drush dl --quiet --yes drupal-${DRUPAL_VERSION}.x --all --drupal-project-rename=drupal
+  - test ${DRUPAL_VERSION} -ne 8 || (mkdir -p tmp && cd tmp && composer require --no-interaction drupal/drupal && cd - && rm -rf drupal && mv tmp/vendor/drupal/drupal ./drupal && cd drupal && composer install && cd - && rm -rf tmp)
   - drush --yes --root=$PWD/drupal site-install --db-url=mysql://travis:@127.0.0.1/drupal
   # Copy the static HTML that is used for blackbox testing in the web root.
   - cp -r fixtures/blackbox $PWD/drupal
@@ -68,7 +73,9 @@ before_script:
   - cd drupal
   - drush --yes en behat_test
   - drush cc drush
-  - test ${DRUPAL_VERSION} -eq 6 || drush help behat
+  # @todo Re-enable behat drush endpoint testing.
+  # @see https://github.com/jhedstrom/drupalextension/issues/458
+  - test ${DRUPAL_VERSION} -eq 6 || test ${DRUPAL_VERSION} -eq 8 || (test ${DRUPAL_VERSION} -eq 7 && drush help behat)
   # Only revert features on Drupal 7.
   - test \! ${DRUPAL_VERSION} -eq 7 || drush --yes fr behat_test
   # Disable the page cache on Drupal 8.

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "Drupal extension for Behat",
   "keywords": ["drupal", "web", "test"],
   "homepage": "http://drupal.org/project/drupalextension",
-  "license": "GPL-2.0+",
+  "license": "GPL-2.0-or-later",
   "authors": [
     {
       "name": "Jonathan Hedstrom",


### PR DESCRIPTION
Drush 9 is now out, so this needs to happen even if we stop testing the drush behat endpoint until it is ported.

- Fixes #419