### PR TITLE
Created TestModuleContext.

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -8,6 +8,7 @@ default:
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\MinkContext
         - Drupal\DrupalExtension\Context\MarkupContext
+        - Drupal\DrupalExtension\Context\TestModuleContext
       filters:
         tags: "@blackbox"
   extensions:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "repositories": [
     {
       "type": "vcs",
-      "url": "https://github.com/phenaproxima/drupaldriver"
+      "url": "https://github.com/phenaproxima/DrupalDriver"
     }
   ],
   "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,12 @@
       "homepage": "https://github.com/pfrenssen"
     }
   ],
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/phenaproxima/drupaldriver"
+    }
+  ],
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,6 @@
       "homepage": "https://github.com/pfrenssen"
     }
   ],
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/phenaproxima/DrupalDriver"
-    }
-  ],
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
@@ -33,7 +27,7 @@
     "behat/mink-extension": "~2.0",
     "behat/mink-goutte-driver": "~1.0",
     "behat/mink-selenium2-driver": "~1.1",
-    "drupal/drupal-driver": "dev-master",
+    "drupal/drupal-driver": "dev-master#e692d85d56fc613d2601619d7873d157c724112b",
     "symfony/dependency-injection": "~2.7|~3.0",
     "symfony/event-dispatcher": "~2.7|~3.0"
   },

--- a/doc/contexts.rst
+++ b/doc/contexts.rst
@@ -37,6 +37,14 @@ following contexts:
 *BatchContext*
   Steps for creating batch items and ensuring a batch is finished processing.
 
+*TestModuleContext*
+  Allows modules to be automatically installed during a scenario, then
+  automatically uninstalled afterwards. Scenarios can enable as many modules as
+  they like using tags; for example, a scenario with the ```@with-module:webform```
+  tag will install Webform before the scenario begins, then uninstall it after
+  the scenario ends. Features can also use this tag to enable modules for every
+  one of their scenarios.
+
 Custom Contexts
 ---------------
 

--- a/features/modules.feature
+++ b/features/modules.feature
@@ -1,0 +1,10 @@
+@api @d8
+Feature: Ensure that test modules are automatically enabled in annotated scenarios
+  In order to use special test modules during test scenarios
+  Modules should be automatically enabled
+
+  @with-module:migrate
+  Scenario: Enabling a module
+    Given I am logged in as a user with the "administer modules" permission
+    When I visit "/admin/modules"
+    Then the checkbox "modules[migrate][enable]" should be checked

--- a/src/Drupal/DrupalExtension/Context/TestModuleContext.php
+++ b/src/Drupal/DrupalExtension/Context/TestModuleContext.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Drupal\DrupalExtension\Context;
+
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Behat\Hook\Scope\ScenarioScope;
+
+/**
+ * Provides the ability to automatically enable and disable test modules.
+ */
+class TestModuleContext extends RawDrupalContext
+{
+  /**
+   * Gets all with-module tags from a scenario scope.
+   *
+   * @param \Behat\Behat\Hook\Scope\ScenarioScope $scope
+   *   The scenario scope.
+   *
+   * @return string[]
+   *   The machine names of the modules to enable during the scenario.
+   */
+  protected function getTestModulesFromTags(ScenarioScope $scope)
+  {
+    $modules = array();
+    $tags = array_merge($scope->getFeature()->getTags(), $scope->getScenario()->getTags());
+
+    foreach ($tags as $tag) {
+      if (strpos($tag, 'with-module:') === 0) {
+        array_push($modules, substr($tag, 12));
+      }
+    }
+    return array_unique($modules);
+  }
+
+  /**
+   * Installs test modules for this scenario.
+   *
+   * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope
+   *   The scenario scope.
+   *
+   * @BeforeScenario
+   */
+  public function installTestModules(BeforeScenarioScope $scope)
+  {
+    foreach ($this->getTestModulesFromTags($scope) as $module) {
+      $this->getDriver()->moduleInstall($module);
+    }
+  }
+
+  /**
+   * Unistalls test modules for this scenario.
+   *
+   * @param \Behat\Behat\Hook\Scope\BeforeScenarioScope $scope
+   *   The scenario scope.
+   *
+   * @AfterScenario
+   */
+  public function uninstallTestModules(BeforeScenarioScope $scope)
+  {
+    foreach ($this->getTestModulesFromTags($scope) as $module) {
+      $this->getDriver()->moduleUninstall($module);
+    }
+  }
+}


### PR DESCRIPTION
Requires jhedstrom/DrupalDriver#164.

This adds a new context, TestModuleContext, which allows scenarios to automatically enable a module or set of modules before they start, then automatically uninstall those modules after the scenario is completed. This brings the paradigm of test modules, used extensively in Drupal core, to Behat.

To use it, a scenario (or feature) can add tags of the format ```@with-module:MODULENAME```, and the module MODULENAME will be installed before the scenario, and uninstalled afterwards.

This is already implemented (and works!) over in acquia/lightning-dev.