### PR TITLE
remove sudo from composer command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
       env: DRUPAL_VERSION=6
   allow_failures:
     - php: 7.0
+      env: DRUPAL_VERSION=7
     - php: 5.3
 
 # Enable Travis containers.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -16,6 +17,8 @@ env:
 
 matrix:
   exclude:
+    - php: 5.3
+      env: DRUPAL_VERSION=8
     - php: 5.4
       env: DRUPAL_VERSION=8
     - php: 5.6
@@ -24,6 +27,7 @@ matrix:
       env: DRUPAL_VERSION=6
   allow_failures:
     - php: 7.0
+    - php: 5.3
 
 # Enable Travis containers.
 sudo: false
@@ -33,7 +37,10 @@ install:
   # Use the example composer.json file for Drupal 8.
   - test ${DRUPAL_VERSION} -eq 8 && cp doc/_static/composer.json.d8 ./composer.json || true
   - composer install
-  - composer global require drush/drush:dev-master --prefer-source
+  # Drush version must vary depending on environment and version of core.
+  - test ${TRAVIS_PHP_VERSION} == "5.3" && composer global require drush/drush:~6.0 || composer global require drush/drush:dev-master
+  # PHP 5.3 requires the cgi extension for runserver.
+  - test ${TRAVIS_PHP_VERSION} == "5.3" && pecl install cgi || true
   - npm install
 
 before_script:
@@ -63,6 +70,7 @@ before_script:
   - sleep 4s
 
 script:
+  - find ./src -name "*.php" -print0 | xargs -0 -n1 -P8 php -l
   - vendor/bin/phpspec run -f pretty --no-interaction
   - vendor/bin/behat -fprogress --strict
   - vendor/bin/behat -fprogress --profile=drupal${DRUPAL_VERSION} --strict

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ the [Full documentation](https://behat-drupal-extension.readthedocs.org)
     mkdir projectdir
     cd projectdir
     curl -sS https://getcomposer.org/installer | php
-    php composer.phar require drupal/drupal-extension='~3.0'
+    COMPOSER_BIN_DIR=bin php composer.phar require drupal/drupal-extension='~3.0'
     ```
 
 1.  In the projectdir, create a file called `behat.yml`. Below is the

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Drupal Extension is an integration layer between [Behat](http://behat.org),
 provides step definitions for common testing scenarios specific to Drupal
 sites.
 
-[![Build Status](https://travis-ci.org/jhedstrom/drupalextension.png?branch=3.0)](https://travis-ci.org/jhedstrom/drupalextension)
+[![Build Status](https://travis-ci.org/jhedstrom/drupalextension.png?branch=3.1)](https://travis-ci.org/jhedstrom/drupalextension)
 
 The Drupal Extension 3 supports Drupal 6, 7 and 8, and utilizes Behat 3.
 
@@ -13,7 +13,7 @@ The Drupal Extension 3 supports Drupal 6, 7 and 8, and utilizes Behat 3.
 [![Total Downloads](https://poser.pugx.org/drupal/drupal-extension/downloads.svg)](https://packagist.org/packages/drupal/drupal-extension)
 [![Latest Unstable Version](https://poser.pugx.org/drupal/drupal-extension/v/unstable.svg)](https://packagist.org/packages/drupal/drupal-extension)
 [![License](https://poser.pugx.org/drupal/drupal-extension/license.svg)](https://packagist.org/packages/drupal/drupal-extension)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/jhedstrom/drupalextension/badges/quality-score.png?b=3.0)](https://scrutinizer-ci.com/g/jhedstrom/drupalextension/?branch=3.0)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/jhedstrom/drupalextension/badges/quality-score.png?b=3.1)](https://scrutinizer-ci.com/g/jhedstrom/drupalextension/?branch=3.1)
 
 
 
@@ -22,7 +22,7 @@ The Drupal Extension 3 supports Drupal 6, 7 and 8, and utilizes Behat 3.
 If you're new to the Drupal Extension, we recommend starting with 
 the [Full documentation](https://behat-drupal-extension.readthedocs.org)
 
-[![Documentation Status](https://readthedocs.org/projects/behat-drupal-extension/badge/?version=master)](https://behat-drupal-extension.readthedocs.org)
+[![Documentation Status](https://readthedocs.org/projects/behat-drupal-extension/badge/?version=3.1)](https://behat-drupal-extension.readthedocs.org)
 
 ### Quick start
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "behat/mink-selenium2-driver": "~1.1",
     "behat/behat": "~3.0,>=3.0.5",
     "behat/mink-extension": "~2.0",
-    "drupal/drupal-driver": "~1.0@dev"
+    "drupal/drupal-driver": "~1.1"
   },
   "require-dev": {
     "phpspec/phpspec": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,5 @@
       "Drupal\\Exception": "src/",
       "Drupal\\DrupalExtension": "src/"
     }
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "3.0.x-dev"
-    }
   }
 }

--- a/doc/globalinstall.rst
+++ b/doc/globalinstall.rst
@@ -44,7 +44,7 @@ Install the Drupal Extension
 
 3. Run the install command::
 
-    sudo composer install
+    composer install
 
   It will be a bit before you start seeing any output. It will also suggest
   that you install additional tools, but they're not normally needed so you can

--- a/doc/subcontexts.rst
+++ b/doc/subcontexts.rst
@@ -17,7 +17,7 @@ behat.yml
 .. literalinclude:: _static/snippets/behat-sub.yml
    :language: yaml
    :linenos:
-   :emphasize-lines: 18-20
+   :emphasize-lines: 22-24
 
 The Drupal Extension will search recursively within the directory or
 directories specified to discover and load any file ending in `.behat.inc`. This
@@ -34,11 +34,11 @@ following:
 .. literalinclude:: _static/snippets/behat-auto.yml
    :language: yaml
    :linenos:
-   :emphasize-lines: 21 
+   :emphasize-lines: 25 
 
 For Contributors
 ----------------
-Behat `sucontexts
+Behat `subcontexts
 <http://docs.behat.org/guides/4.context.html#using-subcontexts>`_ are no longer
 supported in version 3. The Drupal Extension, however, continues to support
 saving module-specific contexts in a file ending with `.behat.inc` 

--- a/features/api.feature
+++ b/features/api.feature
@@ -20,7 +20,7 @@ Feature: DrupalContext
     Then I should be on "admin/structure/types/manage/article/fields"
     And I should see text matching "Add new field"
 
-  @drushTest @d8
+  @drushTest
   Scenario: Find a heading in a region
     Given I am not logged in
     When I am on the homepage

--- a/features/blackbox.feature
+++ b/features/blackbox.feature
@@ -78,5 +78,5 @@ Feature: Test DrupalContext
  @javascript
  Scenario: Zombie driver is functional
    Given I am on the homepage
-   When I click "Commits"
-   Then I should see the link "More commit messages…"
+   When I click "Download & Extend"
+   Then I should see the link "Drupal Core"

--- a/features/blackbox.feature
+++ b/features/blackbox.feature
@@ -17,7 +17,7 @@ Feature: Test DrupalContext
 
   Scenario: Viewing content in a region
     Given I am on the homepage
-    Then I should see "Come for the software, stay for the community" in the "left header"
+    Then I should see "Build something amazing." in the "left header"
 
   Scenario: Test ability to find text that should not appear in a region
     Given I am on the homepage
@@ -25,7 +25,7 @@ Feature: Test DrupalContext
 
   Scenario: Submit a form in a region
     Given I am on the homepage
-    When I fill in "Search Drupal.org" with "Views" in the "right header" region
+    When I fill in "Search …" with "Views" in the "right header" region
     And I press "Search" in the "right header" region
     Then I should see the text "Search again" in the "right sidebar" region
 
@@ -74,12 +74,6 @@ Feature: Test DrupalContext
    | error messages                                                                |
    | Sorry, unrecognized username or password                                      |
    | Unable to send e-mail. Contact the site administrator if the problem persists |
-
- Scenario: Messages
-   Given I am on "/user/register"
-   When I press "Create new account"
-   Then I should see the message "Username field is required"
-   But I should not see the message "Registration successful. You are now logged in"
 
  @javascript
  Scenario: Zombie driver is functional

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -107,12 +107,12 @@ class FeatureContext implements Context {
    * @Transform table:name,mail,street,city,postcode,country
    */
   public function castUsersTable(TableNode $user_table) {
-    $aliases = [
+    $aliases = array(
       'country' => 'field_post_address:country',
       'city' => 'field_post_address:locality',
       'street' => 'field_post_address:thoroughfare',
       'postcode' => 'field_post_address:postal_code',
-    ];
+    );
 
     // The first row of the table contains the field names.
     $table = $user_table->getTable();

--- a/features/d8.feature
+++ b/features/d8.feature
@@ -24,3 +24,8 @@ Feature: DrupalContext
     And I am logged in as a user with the "administrator" role
     When I visit "admin/people"
     Then I should see the text "Administrator" in the "Joe User" row
+
+  Scenario: Find a heading in a region
+    Given I am not logged in
+    When I am on the homepage
+    Then I should see the heading "Search" in the "left sidebar" region

--- a/fixtures/drupal8/modules/behat_test/config/install/field.field.node.post.field_post_reference.yml
+++ b/fixtures/drupal8/modules/behat_test/config/install/field.field.node.post.field_post_reference.yml
@@ -4,8 +4,6 @@ dependencies:
   config:
     - field.storage.node.field_post_reference
     - node.type.post
-  module:
-    - entity_reference
 id: node.post.field_post_reference
 field_name: field_post_reference
 entity_type: node

--- a/fixtures/drupal8/modules/behat_test/config/install/field.field.user.user.field_post_reference.yml
+++ b/fixtures/drupal8/modules/behat_test/config/install/field.field.user.user.field_post_reference.yml
@@ -3,8 +3,6 @@ status: true
 dependencies:
   config:
     - field.storage.user.field_post_reference
-  module:
-    - entity_reference
 id: user.user.field_post_reference
 field_name: field_post_reference
 entity_type: user

--- a/fixtures/drupal8/modules/behat_test/config/install/field.field.user.user.field_tags.yml
+++ b/fixtures/drupal8/modules/behat_test/config/install/field.field.user.user.field_tags.yml
@@ -5,7 +5,6 @@ dependencies:
     - field.storage.user.field_tags
   module:
     - taxonomy
-    - entity_reference
 id: user.user.field_tags
 field_name: field_tags
 entity_type: user

--- a/fixtures/drupal8/modules/behat_test/config/install/field.storage.node.field_post_reference.yml
+++ b/fixtures/drupal8/modules/behat_test/config/install/field.storage.node.field_post_reference.yml
@@ -2,7 +2,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - entity_reference
     - node
 id: node.field_post_reference
 field_name: field_post_reference

--- a/fixtures/drupal8/modules/behat_test/config/install/field.storage.user.field_post_reference.yml
+++ b/fixtures/drupal8/modules/behat_test/config/install/field.storage.user.field_post_reference.yml
@@ -2,7 +2,6 @@ langcode: en
 status: true
 dependencies:
   module:
-    - entity_reference
     - user
 id: user.field_post_reference
 field_name: field_post_reference
@@ -10,7 +9,7 @@ entity_type: user
 type: entity_reference
 settings:
   target_type: node
-module: entity_reference
+module: core
 locked: false
 cardinality: -1
 translatable: true

--- a/fixtures/drupal8/modules/behat_test/config/install/field.storage.user.field_tags.yml
+++ b/fixtures/drupal8/modules/behat_test/config/install/field.storage.user.field_tags.yml
@@ -10,7 +10,7 @@ entity_type: user
 type: entity_reference
 settings:
   target_type: taxonomy_term
-module: entity_reference
+module: core
 locked: false
 cardinality: -1
 translatable: true

--- a/fixtures/drupal8/modules/behat_test/src/Plugin/Field/FieldFormatter/AddressFieldFormatter.php
+++ b/fixtures/drupal8/modules/behat_test/src/Plugin/Field/FieldFormatter/AddressFieldFormatter.php
@@ -80,7 +80,7 @@ class AddressFieldFormatter extends FormatterBase implements ContainerFactoryPlu
   /**
    * {@inheritdoc}
    */
-  public function viewElements(FieldItemListInterface $items) {
+  public function viewElements(FieldItemListInterface $items, $language) {
     $elements = [];
 
     foreach ($items as $delta => $item) {

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -189,9 +189,9 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    */
   public function assertClickInTableRow($link, $rowText) {
     $page = $this->getSession()->getPage();
-    if ($link = $this->getTableRow($page, $rowText)->findLink($link)) {
+    if ($link_element = $this->getTableRow($page, $rowText)->findLink($link)) {
       // Click the link and return.
-      $link->click();
+      $link_element->click();
       return;
     }
     throw new \Exception(sprintf('Found a row containing "%s", but no "%s" link on the page %s', $rowText, $link, $this->getSession()->getCurrentUrl()));

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -287,7 +287,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
     $multicolumn_field = '';
     $multicolumn_fields = array();
 
-    foreach ($entity as $field => $field_value) {
+    foreach (clone $entity as $field => $field_value) {
       // Reset the multicolumn field if the field name does not contain a column.
       if (strpos($field, ':') === FALSE) {
         $multicolumn_field = '';

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -285,7 +285,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    */
   public function parseEntityFields($entity_type, \stdClass $entity) {
     $multicolumn_field = '';
-    $multicolumn_fields = [];
+    $multicolumn_fields = array();
 
     foreach ($entity as $field => $field_value) {
       // Reset the multicolumn field if the field name does not contain a column.
@@ -312,12 +312,12 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
       $field_name = $multicolumn_field ?: $field;
       if ($this->getDriver()->isField($entity_type, $field_name)) {
         // Split up multiple values in multi-value fields.
-        $values = [];
+        $values = array();
         foreach (explode(', ', $field_value) as $key => $value) {
           $columns = $value;
           // Split up field columns if the ' - ' separator is present.
           if (strstr($value, ' - ') !== FALSE) {
-            $columns = [];
+            $columns = array();
             foreach (explode(' - ', $value) as $column) {
               // Check if it is an inline named column.
               if (!$is_multicolumn && strpos($column, ': ', 1) !== FALSE) {

--- a/src/Drupal/DrupalExtension/ServiceContainer/config/drivers/drupal.yml
+++ b/src/Drupal/DrupalExtension/ServiceContainer/config/drivers/drupal.yml
@@ -17,7 +17,7 @@ services:
     arguments:
       - %drupal.driver.drupal.drupal_root%
       - %mink.base_url%
-      - @drupal.driver.random
+      - "@drupal.driver.random"
     tags:
       - { name: drupal.driver, alias: drupal }
   drupal.driver.cores.6:
@@ -27,7 +27,7 @@ services:
     arguments:
       - %drupal.driver.drupal.drupal_root%
       - %mink.base_url%
-      - @drupal.driver.random
+      - "@drupal.driver.random"
   drupal.driver.cores.7:
     class: %drupal.driver.cores.7.class%
     tags:
@@ -35,7 +35,7 @@ services:
     arguments:
       - %drupal.driver.drupal.drupal_root%
       - %mink.base_url%
-      - @drupal.driver.random
+      - "@drupal.driver.random"
   drupal.driver.cores.8:
     class: %drupal.driver.cores.8.class%
     tags:
@@ -43,4 +43,4 @@ services:
     arguments:
       - %drupal.driver.drupal.drupal_root%
       - %mink.base_url%
-      - @drupal.driver.random
+      - "@drupal.driver.random"

--- a/src/Drupal/DrupalExtension/ServiceContainer/config/drivers/drush.yml
+++ b/src/Drupal/DrupalExtension/ServiceContainer/config/drivers/drush.yml
@@ -13,6 +13,6 @@ services:
       - %drupal.driver.drush.alias%
       - %drupal.driver.drush.root%
       - %drupal.driver.drush.binary%
-      - @drupal.driver.random
+      - "@drupal.driver.random"
     tags:
       - { name: drupal.driver, alias: drush }

--- a/src/Drupal/DrupalExtension/ServiceContainer/config/services.yml
+++ b/src/Drupal/DrupalExtension/ServiceContainer/config/services.yml
@@ -34,21 +34,21 @@ services:
     class: %drupal.drupal.class%
     arguments:
       - {}
-      - @drupal.random
+      - "@drupal.random"
   drupal.random:
     class: %drupal.random.class%
   drupal.context.initializer:
     class: %drupal.context.initializer.class%
     arguments:
-      - @drupal.drupal
+      - "@drupal.drupal"
       - %drupal.parameters%
-      - @hook.dispatcher
+      - "@hook.dispatcher"
     tags:
       - { name: context.initializer }
   drupal.context.environment.reader:
     class: %drupal.context.environment.reader.class%
     arguments:
-      - @drupal.drupal
+      - "@drupal.drupal"
       - %drupal.parameters%
     tags:
       - { name: environment.reader }
@@ -60,7 +60,7 @@ services:
   drupal.listener.driver:
     class: %drupal.listener.drivers.class%
     arguments:
-      - @drupal.drupal
+      - "@drupal.drupal"
       - %drupal.parameters%
     tags:
       - { name: event_dispatcher.subscriber, priority: 0 }


### PR DESCRIPTION
Composer maintainers strongly advise against running composer as sudo/root. On Mac and Ubuntu it appears not to be necessary. Is it possible to accomplish everything without using sudo with composer?

See their FAQ:
How do I install untrusted packages safely? Is it safe to run Composer as superuser or root?
https://getcomposer.org/doc/faqs/how-to-install-untrusted-packages-safely.md