### PR TITLE
remove sudo from composer command

### DIFF
--- a/doc/globalinstall.rst
+++ b/doc/globalinstall.rst
@@ -44,7 +44,7 @@ Install the Drupal Extension
 
 3. Run the install command::
 
-    sudo composer install
+    composer install
 
   It will be a bit before you start seeing any output. It will also suggest
   that you install additional tools, but they're not normally needed so you can


### PR DESCRIPTION
Composer maintainers strongly advise against running composer as sudo/root. On Mac and Ubuntu it appears not to be necessary. Is it possible to accomplish everything without using sudo with composer?

See their FAQ:
How do I install untrusted packages safely? Is it safe to run Composer as superuser or root?
https://getcomposer.org/doc/faqs/how-to-install-untrusted-packages-safely.md