### PR TITLE
Use a 'test' script for running tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,10 +89,7 @@ before_script:
   - sleep 4s
 
 script:
-  - vendor/bin/parallel-lint src spec features fixtures
-  - vendor/bin/phpcs --standard=./phpcs-ruleset.xml -p
-  - vendor/bin/phpcs --standard=./phpcs-drupal-ruleset.xml -p
-  - vendor/bin/phpspec run -f pretty --no-interaction
+  - composer test
   - vendor/bin/behat -fprogress --strict
   - vendor/bin/behat -fprogress --profile=drupal${DRUPAL_VERSION} --strict
   # Do not test the Drush profile unless Drupal 7 was installed.

--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,19 @@
     "symfony/event-dispatcher": "~3.0"
   },
   "require-dev": {
-    "phpspec/phpspec": "~2.0",
-    "phpunit/phpunit": "3.7.*",
+    "phpspec/phpspec": "~2.0 || ~4.0",
     "behat/mink-zombie-driver": "^1.2",
     "jakub-onderka/php-parallel-lint": "^0.9.2",
     "drupal/coder": "^8.2"
+  },
+  "scripts": {
+    "test": [
+      "composer validate --no-interaction",
+      "parallel-lint src spec features fixtures",
+      "phpcs --standard=./phpcs-ruleset.xml -p",
+      "phpcs --standard=./phpcs-drupal-ruleset.xml -p",
+      "phpspec run -f pretty --no-interaction"
+    ]
   },
   "autoload": {
     "psr-0": {


### PR DESCRIPTION
- Allows higher phpspec version
- Removes unused phpunit requirement
- Fixes #474