### PR TITLE
#479: Provide more verbose exception message when AJAX fails.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -127,7 +127,7 @@ class MinkContext extends MinkExtension implements TranslatableContext
    *
    * @Given I wait for AJAX to finish
    */
-    public function iWaitForAjaxToFinish($event = NULL)
+    public function iWaitForAjaxToFinish($event = null)
     {
         $condition = <<<JS
     (function() {
@@ -149,19 +149,18 @@ class MinkContext extends MinkExtension implements TranslatableContext
 JS;
         $result = $this->getSession()->wait(1000 * $this->getMinkParameter('ajax_timeout'), $condition);
         if (!$result) {
-          if ($event) {
-            /** @var \Behat\Behat\Hook\Scope\BeforeStepScope $event */
-            $event_data = ' ' . json_encode([
-              'name' => $event->getName(),
-              'feature' => $event->getFeature()->getTitle(),
-              'step' => $event->getStep()->getText(),
-              'suite' => $event->getSuite()->getName(),
-            ]);
-          }
-          else {
-            $event_data = '';
-          }
-           throw new \RuntimeException('Unable to complete AJAX request.' . $event_data);
+            if ($event) {
+                /** @var \Behat\Behat\Hook\Scope\BeforeStepScope $event */
+                $event_data = ' ' . json_encode([
+                    'name' => $event->getName(),
+                    'feature' => $event->getFeature()->getTitle(),
+                    'step' => $event->getStep()->getText(),
+                    'suite' => $event->getSuite()->getName(),
+                ]);
+            } else {
+                $event_data = '';
+            }
+            throw new \RuntimeException('Unable to complete AJAX request.' . $event_data);
         }
     }
   /**

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -98,7 +98,7 @@ class MinkContext extends MinkExtension implements TranslatableContext
         }
         $text = $event->getStep()->getText();
         if (preg_match('/(follow|press|click|submit)/i', $text)) {
-            $this->iWaitForAjaxToFinish();
+            $this->iWaitForAjaxToFinish($event);
         }
     }
 
@@ -116,7 +116,7 @@ class MinkContext extends MinkExtension implements TranslatableContext
         }
         $text = $event->getStep()->getText();
         if (preg_match('/(follow|press|click|submit)/i', $text)) {
-            $this->iWaitForAjaxToFinish();
+            $this->iWaitForAjaxToFinish($event);
         }
     }
 
@@ -127,7 +127,7 @@ class MinkContext extends MinkExtension implements TranslatableContext
    *
    * @Given I wait for AJAX to finish
    */
-    public function iWaitForAjaxToFinish()
+    public function iWaitForAjaxToFinish($event = NULL)
     {
         $condition = <<<JS
     (function() {
@@ -149,7 +149,19 @@ class MinkContext extends MinkExtension implements TranslatableContext
 JS;
         $result = $this->getSession()->wait(1000 * $this->getMinkParameter('ajax_timeout'), $condition);
         if (!$result) {
-            throw new \RuntimeException('Unable to complete AJAX request.');
+          if ($event) {
+            /** @var \Behat\Behat\Hook\Scope\BeforeStepScope $event */
+            $event_data = ' ' . json_encode([
+              'name' => $event->getName(),
+              'feature' => $event->getFeature()->getTitle(),
+              'step' => $event->getStep()->getText(),
+              'suite' => $event->getSuite()->getName(),
+            ]);
+          }
+          else {
+            $event_data = '';
+          }
+           throw new \RuntimeException('Unable to complete AJAX request.' . $event_data);
         }
     }
   /**


### PR DESCRIPTION
Very rough, just as a proof-of-concept, but this seems to help a lot while troubleshooting where a given error is coming from.