### PR TITLE
RawDrupalContext::loggedIn() can return false positive

### DIFF
--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -145,7 +145,7 @@ class DrupalExtension implements ExtensionInterface
             scalarNode('success_message_selector')->end()->
             scalarNode('warning_message_selector')->end()->
             scalarNode('login_form_selector')->
-              defaultValue('form#user-login')->
+              defaultValue('form#user-login,form#user-login-form')->
             end()->
             scalarNode('logged_in_selector')->
               defaultValue('body.logged-in,body.user-logged-in')->


### PR DESCRIPTION
The default `login_form_selector` is using `form#user-login` as a selector, but the actual drupal login form (at least for current d8) uses `form#user-login-form` as the id. My guess is an update to underlying form changed this at some point (maybe during migration to drupal 8?)? 

This can ultimately cause false positives from `RawDrupalContext::loggedIn()` - in some scenarios the login is validated by manually checking the  `/user/login` page and looking for the form via this selector - if its not found, the user is assumed to be logged in. In this case even though the user is anonymous, the form is not found, so it returns true. 

I left the old selector in for any possible BC issues, similar to how the `logged_in_selector` works. 

For example, here's a blank site spun up w/ simplytest.me showing the actual selector:
![image](https://user-images.githubusercontent.com/8114580/44352973-af0f2600-a473-11e8-90f1-a3bd76490030.png)
