### PR TITLE
Use new configGetOriginal method from DrupalDriver.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/ConfigContext.php
+++ b/src/Drupal/DrupalExtension/Context/ConfigContext.php
@@ -105,7 +105,7 @@ class ConfigContext extends RawDrupalContext implements TranslatableContext
    */
     public function setConfig($name, $key, $value)
     {
-        $backup = $this->getDriver()->configGet($name, $key);
+        $backup = $this->getDriver()->configGetOriginal($name, $key);
         $this->getDriver()->configSet($name, $key, $value);
         $this->config[$name][$key] = $backup;
     }


### PR DESCRIPTION
The ConfigContext needs to use the "configGetOriginal()" method when backing up the config value.

**Issues also created on Github:**
- https://github.com/jhedstrom/drupalextension/issues/501

- https://github.com/jhedstrom/DrupalDriver/issues/194