### PR TITLE
Start supporting Drupal 7 on PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ matrix:
       env: DRUPAL_VERSION=6
     - php: 7.1
       env: DRUPAL_VERSION=6
-  allow_failures:
-    - php: 7.1
-      env: DRUPAL_VERSION=7
 
 # Enable Travis containers.
 sudo: false


### PR DESCRIPTION
When PHP 7.1 was initially released there were some incompatibilities for Drupal 7 and we temporarily allowed this to fail on Travis. In the meantime D7 works fine on PHP 7.1 and we have a green build!

Let's support this combo from now on.