### PR TITLE
Start testing on PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 env:
   global:
@@ -24,6 +25,8 @@ matrix:
     - php: 7.0
       env: DRUPAL_VERSION=6
     - php: 7.1
+      env: DRUPAL_VERSION=6
+    - php: 7.2
       env: DRUPAL_VERSION=6
 
 # Enable Travis containers.


### PR DESCRIPTION
PHP 7.2 has been stable for some time now, let's add it to the test matrix and find out how well we support it!