### PR TITLE
Corresponding list handler fixes for the Drupal Driver.

### DIFF
--- a/features/field_handlers.feature
+++ b/features/field_handlers.feature
@@ -19,7 +19,7 @@ Feature: FieldHandlers
       | field_post_reference | Page one, Page two                                                               |
       | field_post_date      | 2015-02-08 17:45:00                                                              |
       | field_post_links     | Link 1 - http://example.com, Link 2 - http://example.com                         |
-      | field_post_select    | One, Two                                                                         |
+      | field_post_select    | Select value one, Select value two                                                                         |
       | field_post_address   | country: BE - locality: Brussel - thoroughfare: Louisalaan 1 - postal_code: 1000 |
     Then I should see "Post title"
     And I should see "PLACEHOLDER BODY"
@@ -28,8 +28,9 @@ Feature: FieldHandlers
     And I should see "Sunday, February 8, 2015"
     And I should see the link "Link 1"
     And I should see the link "Link 2"
-    And I should see "One"
-    And I should see "Two"
+    And I should see "Select value one"
+    And I should see "Select value two"
+    And I should not see "Select value three"
     And I should see "Belgium"
     And I should see "Brussel"
     And I should see "1000"
@@ -52,15 +53,15 @@ Feature: FieldHandlers
       | reference | Page one, Page two                                                               |
       | date      | 2015-02-08 17:45:00                                                              |
       | links     | Link 1 - http://example.com, Link 2 - http://example.com                         |
-      | select    | One, Two                                                                         |
+      | select    | Select value one, Select value two                                               |
       | address   | country: BE - locality: Brussel - thoroughfare: Louisalaan 1 - postal_code: 1000 |
     Then I should see "Page one"
     And I should see "Page two"
     And I should see "Sunday, February 8, 2015"
     And I should see the link "Link 1"
     And I should see the link "Link 2"
-    And I should see "One"
-    And I should see "Two"
+    And I should see "Select value one"
+    And I should see "Select value two"
     And I should see "Belgium"
     And I should see "Brussel"
     And I should see "1000"

--- a/fixtures/drupal7/modules/behat_test/behat_test.features.field_base.inc
+++ b/fixtures/drupal7/modules/behat_test/behat_test.features.field_base.inc
@@ -193,9 +193,9 @@ function behat_test_field_default_field_bases() {
     'module' => 'list',
     'settings' => array(
       'allowed_values' => array(
-        1 => 'One',
-        2 => 'Two',
-        3 => 'Three',
+        1 => 'Select value one',
+        2 => 'Select value two',
+        3 => 'Select value three',
       ),
       'allowed_values_function' => '',
     ),

--- a/fixtures/drupal8/modules/behat_test/config/install/field.storage.node.field_post_select.yml
+++ b/fixtures/drupal8/modules/behat_test/config/install/field.storage.node.field_post_select.yml
@@ -12,17 +12,17 @@ settings:
   allowed_values:
     -
       value: '1'
-      label: One
+      label: Select value one
     -
       value: '2'
-      label: Two
+      label: Select value two
     -
       value: '3'
-      label: Three
+      label: Select value three
   allowed_values_function: ''
 module: options
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false


### PR DESCRIPTION
- Changes to test compatiblity with https://github.com/jhedstrom/DrupalDriver/issues/168

It's odd these scenarios were previously passing--the actual field value being saved on the node was `One`, rather than the field key of `1` and `2`.