### PR TITLE
Adding the option to specify a custom login/logout path in your behat.yml

### DIFF
--- a/doc/blackbox.rst
+++ b/doc/blackbox.rst
@@ -89,6 +89,8 @@ customized the label visible to users, you can change that text as follows:
 
      Drupal\DrupalExtension:
        text:
+         login_url: "/user"
+         logout_url: "/user/logout"
          log_out: "Sign out"
          log_in: "Sign in"
          password_field: "Enter your password"

--- a/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
@@ -47,7 +47,7 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
         // Ensure we aren't already logged in.
         $this->fastLogout();
 
-        $this->getSession()->visit($this->locatePath('/user'));
+        $this->getSession()->visit($this->locatePath($this->getDrupalText('login_url')));
         $element = $this->getSession()->getPage();
         $element->fillField($this->getDrupalText('username_field'), $user->name);
         $element->fillField($this->getDrupalText('password_field'), $user->pass);
@@ -75,7 +75,7 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
      */
     public function logout()
     {
-        $this->getSession()->visit($this->locatePath('/user/logout'));
+        $this->getSession()->visit($this->locatePath($this->getDrupalText('logout_url')));
         $this->userManager->setCurrentUser(false);
     }
 
@@ -104,8 +104,9 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
         }
 
         // Some themes do not add that class to the body, so lets check if the
-        // login form is displayed on /user/login.
-        $session->visit($this->locatePath('/user/login'));
+        // login form is displayed on the page with the login form (defaults to
+        // /user/login)
+        $session->visit($this->locatePath($this->getDrupalText('login_url')));
         if ($page->has('css', $this->getDrupalSelector('login_form_selector'))) {
             $this->fastLogout();
             return false;

--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -116,6 +116,8 @@ class DrupalExtension implements ExtensionInterface
         arrayNode('text')->
           info(
               'Text strings, such as Log out or the Username field can be altered via behat.yml if they vary from the default values.' . PHP_EOL
+              . '  login_url: "/user"' . PHP_EOL
+              . '  logout_url: "/user/logout"' . PHP_EOL
               . '  log_out: "Sign out"' . PHP_EOL
               . '  log_in: "Sign in"' . PHP_EOL
               . '  password_field: "Enter your password"' . PHP_EOL
@@ -123,6 +125,12 @@ class DrupalExtension implements ExtensionInterface
           )->
           addDefaultsIfNotSet()->
           children()->
+            scalarNode('login_url')->
+              defaultValue('/user')->
+            end()->
+            scalarNode('logout_url')->
+              defaultValue('/user/logout')->
+            end()->
             scalarNode('log_in')->
               defaultValue('Log in')->
             end()->


### PR DESCRIPTION
Inspired by https://www.drupal.org/project/drupalextension/issues/2958158

In certain circumstances it can be a good idea to change the standard drupal login path (ie: for security improvements).
In that case, the Drupal Behat extension will not be able to log in to the standard /user URL.

I've developed a little patch that adds a further configuration option to specify custom login/logout URL.