### PR TITLE
Provide a step to check that a button is not in a region.

### DIFF
--- a/features/blackbox.feature
+++ b/features/blackbox.feature
@@ -43,7 +43,7 @@ Feature: Test DrupalContext
 
   Scenario: Button not in region
     Given I am on the homepage
-    Then I should not see the "Search" button in the "content" region
+    Then I should not see the "Search" button in the "right header" region
 
   Scenario: Find an element in a region
     Given I am on the homepage

--- a/features/blackbox.feature
+++ b/features/blackbox.feature
@@ -41,6 +41,10 @@ Feature: Test DrupalContext
     Given I am on the homepage
     Then I should see the "Search" button in the "navigation"
 
+  Scenario: Button not in region
+    Given I am on the homepage
+    Then I should not see the "Search" button in the "content" region
+
   Scenario: Find an element in a region
     Given I am on the homepage
     Then I should see the "h1" element in the "left header"

--- a/src/Drupal/DrupalExtension/Context/MarkupContext.php
+++ b/src/Drupal/DrupalExtension/Context/MarkupContext.php
@@ -58,6 +58,30 @@ class MarkupContext extends RawMinkContext
         }
     }
 
+    /**
+     * Asserts that a button does not exists in a region.
+     *
+     * @Then I should not see the button :button in the :region( region)
+     * @Then I should not see the :button button in the :region( region)
+     *
+     * @param $button
+     *   string The id|name|title|alt|value of the button
+     * @param $region
+     *   string The region in which the button should not be found
+     *
+     * @throws \Exception
+     *   If region is not found or the button is found within the region.
+     */
+    public function assertNotRegionButton($button, $region)
+    {
+        $regionObj = $this->getRegion($region);
+
+        $buttonObj = $regionObj->findButton($button);
+        if (!empty($buttonObj)) {
+            throw new \Exception(sprintf("The button '%s' was found in the region '%s' on the page %s but should not", $button, $region, $this->getSession()->getCurrentUrl()));
+        }
+    }
+
   /**
    * @Then I( should) see the :tag element in the :region( region)
    */


### PR DESCRIPTION
There is already a step in `MarkupContext` to assert that a button exists within a region but not one to assert that one does not exist. Here is a small patch.