### PR TITLE
Throw a helpful exception if the AJAX timeout is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+  * [#528](https://github.com/jhedstrom/drupalextension/pull/528) Show a more helpful failure when running `@javascript`
+    scenarios with incorrect configuration.
 ## [4.0.0 beta2] 2018-12-19
 ### Added
   * [#514](https://github.com/jhedstrom/drupalextension/pull/514) Add a note about the need to remove the entries in behat.yml to use BEHAT_PARAMS.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ the [Full documentation](https://behat-drupal-extension.readthedocs.org)
         contexts:
           - Drupal\DrupalExtension\Context\DrupalContext
     extensions:
-      Behat\MinkExtension:
+      Drupal\MinkExtension:
         goutte: ~
         base_url: http://example.org/  # Replace with your site's URL
       Drupal\DrupalExtension:

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -44,7 +44,7 @@ drupal6:
       filters:
         tags: "@d6"
   extensions:
-    Behat\MinkExtension:
+    Drupal\MinkExtension:
       base_url: http://127.0.0.1:8888
     Drupal\DrupalExtension:
       api_driver: "drupal"
@@ -67,7 +67,7 @@ drupal7:
       filters:
         tags: "@d7"
   extensions:
-    Behat\MinkExtension:
+    Drupal\MinkExtension:
       base_url: http://127.0.0.1:8888
     Drupal\DrupalExtension:
       api_driver: "drupal"
@@ -92,7 +92,7 @@ drush:
       filters:
         tags: "@drushTest"
   extensions:
-    Behat\MinkExtension:
+    Drupal\MinkExtension:
       base_url: http://127.0.0.1:8888
     Drupal\DrupalExtension:
       api_driver: "drush"
@@ -119,7 +119,7 @@ drupal8:
       filters:
         tags: "@d8&&~@d8wip"
   extensions:
-    Behat\MinkExtension:
+    Drupal\MinkExtension:
       base_url: http://127.0.0.1:8888
     Drupal\DrupalExtension:
       api_driver: "drupal"

--- a/doc/environment.rst
+++ b/doc/environment.rst
@@ -19,7 +19,7 @@ Example JSON object:
 
     {
         "extensions": {
-            "Behat\\MinkExtension": {
+            "Drupal\\MinkExtension": {
                 "base_url": "http://myproject.localhost"
             },
             "Drupal\\DrupalExtension": {
@@ -36,7 +36,7 @@ object into a single line and surround with single quotes:
 
 .. code-block:: bash
 
-    $ export BEHAT_PARAMS='{"extensions":{"Behat\\MinkExtension":{"base_url":"http://myproject.localhost"},"Drupal\\DrupalExtension":{"drupal":{"drupal_root":"/var/www/myproject"}}}}'
+    $ export BEHAT_PARAMS='{"extensions":{"Drupal\\MinkExtension":{"base_url":"http://myproject.localhost"},"Drupal\\DrupalExtension":{"drupal":{"drupal_root":"/var/www/myproject"}}}}'
 
 You must also remove (or comment out) the entries that you use in behat.yml for the values in BEHAT_PARAMS to take affect.
 
@@ -52,7 +52,7 @@ You must also remove (or comment out) the entries that you use in behat.yml for 
             - Drupal\DrupalExtension\Context\MessageContext
             - Drupal\DrupalExtension\Context\DrushContext
       extensions:
-        Behat\MinkExtension:
+        Drupal\MinkExtension:
           goutte: ~
           selenium2: ~
     # Must comment out for BEHAT_PARAMS to be effective.
@@ -70,7 +70,7 @@ You must also remove (or comment out) the entries that you use in behat.yml for 
     #   bin/behat --profile=local
     local:
       extensions:
-        Behat\MinkExtension:
+        Drupal\MinkExtension:
         base_url: 'localhost'
         Drupal\DrupalExtension:
           drush:

--- a/features/subcontexts/find.feature
+++ b/features/subcontexts/find.feature
@@ -43,7 +43,7 @@ Feature: Ability to find Drupal sub-contexts
           default:
             contexts: [Drupal\DrupalExtension\Context\DrupalContext]
         extensions:
-          Behat\MinkExtension:
+          Drupal\MinkExtension:
             goutte: ~
             selenium2: ~
             base_url: http://drupal.org

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -152,7 +152,11 @@ class MinkContext extends MinkExtension implements TranslatableContext
       );
     }());
 JS;
-        $result = $this->getSession()->wait(1000 * $this->getMinkParameter('ajax_timeout'), $condition);
+        $ajax_timeout = $this->getMinkParameter('ajax_timeout');
+        if ($ajax_timeout === null) {
+            throw new \Exception('No AJAX timeout has been defined. Please verify that "Drupal\MinkExtension" is configured in behat.yml (and not "Behat\MinkExtension").');
+        }
+        $result = $this->getSession()->wait(1000 * $ajax_timeout, $condition);
         if (!$result) {
             if ($event) {
                 /** @var \Behat\Behat\Hook\Scope\BeforeStepScope $event */

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -153,11 +153,11 @@ class MinkContext extends MinkExtension implements TranslatableContext
     }());
 JS;
         $ajax_timeout = $this->getMinkParameter('ajax_timeout');
-        if ($ajax_timeout === null) {
-            throw new \Exception('No AJAX timeout has been defined. Please verify that "Drupal\MinkExtension" is configured in behat.yml (and not "Behat\MinkExtension").');
-        }
         $result = $this->getSession()->wait(1000 * $ajax_timeout, $condition);
         if (!$result) {
+            if ($ajax_timeout === null) {
+                throw new \Exception('No AJAX timeout has been defined. Please verify that "Drupal\MinkExtension" is configured in behat.yml (and not "Behat\MinkExtension").');
+            }
             if ($event) {
                 /** @var \Behat\Behat\Hook\Scope\BeforeStepScope $event */
                 $event_data = ' ' . json_encode([


### PR DESCRIPTION
In https://github.com/jhedstrom/drupalextension/issues/486#issuecomment-459487280 @leevh mentioned that the AJAX timeout won't work if the user has made a mistake in the configuration and used `Behat\MinkExtension` instead of our overridden `Drupal\MinkExtension`.

This is a very easy mistake to make, especially when considering that our documentation for versions 3.x and lower of DrupalExtension suggests to use `Behat\MinkExtension` instead of `Drupal\MinkExtension`. This is also suggested in a number of blog posts and stack overflow answers. Also people upgrading from 3.x will likely hit this bug.

This can be quite insidious, since everything will seem to work as normal, but when the `@javascript` tag is being used then suddenly mysterious failures will pop up: "Unable to complete AJAX request".

I suggest to check if the timeout is set, and if not let's throw an exception that can help people on the right path.