### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ the [Full documentation](https://behat-drupal-extension.readthedocs.org)
         contexts:
           - Drupal\DrupalExtension\Context\DrupalContext
     extensions:
-      Drupal\MinkExtension:
+      Behat\MinkExtension:
         goutte: ~
         base_url: http://example.org/  # Replace with your site's URL
       Drupal\DrupalExtension:


### PR DESCRIPTION
I'm pretty sure this is a typo. If you try to follow the instructions as written you get the following error:
> In ExtensionManager.php line 194:
Drupal\MinkExtension` extension file or class could not be located.