### PR TITLE
Add space arround the keywords to avoid wrongly matching.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -103,7 +103,7 @@ class MinkContext extends MinkExtension implements TranslatableContext
             return;
         }
         $text = $event->getStep()->getText();
-        if (preg_match('/(follow|press|click|submit)/i', $text)) {
+        if (preg_match('/\b(follow|press|click|submit)\b/i', $text)) {
             $this->iWaitForAjaxToFinish($event);
         }
     }
@@ -120,7 +120,7 @@ class MinkContext extends MinkExtension implements TranslatableContext
             return;
         }
         $text = $event->getStep()->getText();
-        if (preg_match('/(follow|press|click|submit)/i', $text)) {
+        if (preg_match('/\b(follow|press|click|submit)\b/i', $text)) {
             $this->iWaitForAjaxToFinish($event);
         }
     }


### PR DESCRIPTION
Trying to fix jhedstrom#560.

Maybe there is a better way.