### PR TITLE
Wait for AJAX to complete on Behat's :Behat\MinkExtension\Context\MinkContext::attachFileToField()

### DIFF
--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -103,7 +103,7 @@ class MinkContext extends MinkExtension implements TranslatableContext
             return;
         }
         $text = $event->getStep()->getText();
-        if (preg_match('/\b(follow|press|click|submit)\b/i', $text)) {
+        if (preg_match('/\b(follow|press|click|submit|attach)\b/i', $text)) {
             $this->iWaitForAjaxToFinish($event);
         }
     }
@@ -120,7 +120,7 @@ class MinkContext extends MinkExtension implements TranslatableContext
             return;
         }
         $text = $event->getStep()->getText();
-        if (preg_match('/\b(follow|press|click|submit)\b/i', $text)) {
+        if (preg_match('/\b(follow|press|click|submit|attach)\b/i', $text)) {
             $this->iWaitForAjaxToFinish($event);
         }
     }


### PR DESCRIPTION
Drupal 8 Media performs AJAX after a file is selected in the media upload widget, and we should wait for that to complete.

- https://github.com/Behat/MinkExtension/blob/80f7849ba53867181b7e412df9210e12fba50177/src/Behat/MinkExtension/Context/MinkContext.php#L200-L219