### PR TITLE
#589 Added expanding/collapsing of <details> element

### DIFF
--- a/features/blackbox.feature
+++ b/features/blackbox.feature
@@ -76,6 +76,11 @@ Feature: Test DrupalContext
     And I should see the "div" element with the "class" attribute set to "class2" in the "left header" region
     And I should see the "div" element with the "class" attribute set to "class3" in the "left header" region
 
+  Scenario: Interact with <details> elements
+    Given I am at "irc.html"
+    When I click details labelled "Click to read more about IRC"
+    Then I should see the text "Join the Drupal community on IRC by connecting to the #drupal channel on Freenode."
+
   Scenario: Error messages
     Given I am on "user.html"
     When I press "Log in"

--- a/features/blackbox.feature
+++ b/features/blackbox.feature
@@ -80,6 +80,9 @@ Feature: Test DrupalContext
     Given I am at "irc.html"
     When I click details labelled "Click to read more about IRC"
     Then I should see the text "Join the Drupal community on IRC by connecting to the #drupal channel on Freenode."
+    # Blackbox driver does not support hiding <details> content, test action but not visibility.
+    And I collapse details labelled "Click to read more about IRC"
+    And I expand details labelled "Click to read more about IRC"
 
   Scenario: Error messages
     Given I am on "user.html"

--- a/features/blackbox.feature
+++ b/features/blackbox.feature
@@ -80,9 +80,6 @@ Feature: Test DrupalContext
     Given I am at "irc.html"
     When I click details labelled "Click to read more about IRC"
     Then I should see the text "Join the Drupal community on IRC by connecting to the #drupal channel on Freenode."
-    # Blackbox driver does not support hiding <details> content, test action but not visibility.
-    And I collapse details labelled "Click to read more about IRC"
-    And I expand details labelled "Click to read more about IRC"
 
   Scenario: Error messages
     Given I am on "user.html"

--- a/fixtures/blackbox/irc.html
+++ b/fixtures/blackbox/irc.html
@@ -9,5 +9,8 @@
     <div id="footer">
       <a href="index.html">Drupal News</a>
     </div>
+    <details><summary>Click to read more about IRC</summary>
+      <p>Join the Drupal community on IRC by connecting to the #drupal channel on Freenode.</p>
+    </details>
   </body>
 </html>

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -650,16 +650,16 @@ JS;
     }
 
   /**
-   * Expand/contract/toggle a <details> element by <summary> text.
+   * Expand/collapse/toggle a <details> element by <summary> text.
    *
    * Usage examples:
    *   When I expand details labelled 'My summary'
-   *   When I contract details labelled "My summary"
+   *   When I collapse details labelled "My summary"
    *   When I click details labelled 'My summary'
    *
    * @When I :action details labelled :summary
    */
-    public function iExpandOrContractDetailsByLabel($action, $summary)
+    public function iExpandOrCollapseDetailsByLabel($action, $summary)
     {
         $page = $this->getSession()->getPage();
 
@@ -668,12 +668,12 @@ JS;
 
         if ($action === 'expand') {
             $expandedState = "[not(@open)]";
-        } elseif ($action === 'contract') {
+        } elseif ($action === 'collapse') {
             $expandedState = "[@open]";
         } elseif ($action === 'click') {
             $expandedState = '';
         } else {
-            throw new \InvalidArgumentException("Unknown action '{$action}'. Expected expand, contract, or click.");
+            throw new \InvalidArgumentException("Unknown action '{$action}'. Expected expand, collapse, or click.");
         }
 
         $xpath = "//details/summary{$expandedState}[normalize-space()][contains(normalize-space(.), {$literal})]";
@@ -687,8 +687,8 @@ JS;
         $ajax_timeout = $this->getMinkParameter('ajax_timeout');
         try {
             $element->click();
-            // Wait 1/50th of ajax_timeout for the details to expand.
-            usleep(1000000 * $ajax_timeout / 50);
+            // Wait 1/50th of ajax_timeout in microseconds for details to expand.
+            usleep($ajax_timeout * 20000);
         } catch (UnsupportedDriverActionException $exception) {
           // Goutte etc only supports clicking link, submit, button;
           // for non-JS drivers this won't impact test.

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -657,7 +657,7 @@ JS;
     public function iExpandDetailsByLabel($summary)
     {
         $page = $this->getSession()->getPage();
-        $element = $page->find('xpath', "//details/summary[@aria-expanded='false']/*[text()='$summary']");
+        $element = $page->find('xpath', "//details/summary[@aria-expanded='false'][text()][contains(., '$summary')]");
         if (empty($element)) {
             throw new \Exception("Unable to find details element containing text $summary");
         }

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -667,9 +667,9 @@ JS;
         $literal = $this->getSession()->getSelectorsHandler()->xpathLiteral($summary);
 
         if ($action === 'expand') {
-            $expandedState = "[@aria-expanded='false']";
+            $expandedState = "[not(@open)]";
         } elseif ($action === 'contract') {
-            $expandedState = "[@aria-expanded='true']";
+            $expandedState = "[@open]";
         } elseif ($action === 'click') {
             $expandedState = '';
         } else {

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -684,11 +684,12 @@ JS;
             throw new \Exception("Unable to find details summary {$stateDescription} containing text {$summary} for action {$action}");
         }
 
-        $ajax_timeout = $this->getMinkParameter('ajax_timeout');
+        $ajax_timeout = $this->getMinkParameter('ajax_timeout') || 5;
+        // 1/10th of ajax_timeout, in microseconds.
+        $animate_delay = $ajax_timeout * 100000;
         try {
             $element->click();
-            // Wait 1/50th of ajax_timeout in microseconds for details to expand.
-            usleep($ajax_timeout * 20000);
+            usleep($animate_delay);
         } catch (UnsupportedDriverActionException $exception) {
           // Goutte etc only supports clicking link, submit, button;
           // for non-JS drivers this won't impact test.

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -676,12 +676,11 @@ JS;
             throw new \InvalidArgumentException("Unknown action '{$action}'. Expected expand, collapse, or click.");
         }
 
-        $xpath = "//details/summary{$expandedState}[normalize-space()][contains(normalize-space(.), {$literal})]";
-        $stateDescription = $action === 'click' ? '' : " in {$action}ed state";
+        $xpath = "//details{$expandedState}/summary[normalize-space()][contains(normalize-space(.), {$literal})]";
 
         $element = $page->find('xpath', $xpath);
         if (!$element) {
-            throw new \Exception("Unable to find details summary {$stateDescription} containing text {$summary} for action {$action}");
+            throw new \Exception("Unable to find details{$expandedState} containing text {$summary} for action {$action}");
         }
 
         $ajax_timeout = $this->getMinkParameter('ajax_timeout') || 5;

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -683,9 +683,11 @@ JS;
             throw new \Exception("Unable to find details summary {$expandedState} containing text {$summary} for action {$action}");
         }
 
+        $ajax_timeout = $this->getMinkParameter('ajax_timeout');
         try {
             $element->click();
-            usleep(100000);
+            // Wait 1/50th of ajax_timeout for the details to expand.
+            usleep(1000000 * $ajax_timeout / 50);
         } catch (UnsupportedDriverActionException $exception) {
           // Goutte etc only supports clicking link, submit, button;
           // for non-JS drivers this won't impact test.

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -650,6 +650,27 @@ JS;
     }
 
   /**
+   * Expand a <details> element by <summary>.
+   *
+   * @Given I expand details labelled :summary
+   */
+    public function iExpandDetailsByLabel($summary)
+    {
+        $page = $this->getSession()->getPage();
+        $element = $page->find('xpath', "//details/summary[@aria-expanded='false']/*[text()='$summary']");
+        if (empty($element)) {
+            throw new \Exception("Unable to find details element containing text $summary");
+        }
+        try {
+            $element->click();
+            usleep(100000);
+        } catch (UnsupportedDriverActionException $exception) {
+          // Goutte etc only supports clicking link, submit, button;
+          // for non-JS drivers this won't impact test.
+        }
+    }
+
+  /**
    * @} End of defgroup "mink extensions"
    */
 }

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -677,10 +677,11 @@ JS;
         }
 
         $xpath = "//details/summary{$expandedState}[normalize-space()][contains(normalize-space(.), {$literal})]";
+        $stateDescription = $action === 'click' ? '' : " in {$action}ed state";
 
         $element = $page->find('xpath', $xpath);
         if (!$element) {
-            throw new \Exception("Unable to find details summary {$expandedState} containing text {$summary} for action {$action}");
+            throw new \Exception("Unable to find details summary {$stateDescription} containing text {$summary} for action {$action}");
         }
 
         $ajax_timeout = $this->getMinkParameter('ajax_timeout');

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -650,17 +650,39 @@ JS;
     }
 
   /**
-   * Expand a <details> element by <summary>.
+   * Expand/contract/toggle a <details> element by <summary> text.
    *
-   * @Given I expand details labelled :summary
+   * Usage examples:
+   *   When I expand details labelled 'My summary'
+   *   When I contract details labelled "My summary"
+   *   When I click details labelled 'My summary'
+   *
+   * @When I :action details labelled :summary
    */
-    public function iExpandDetailsByLabel($summary)
+    public function iExpandOrContractDetailsByLabel($action, $summary)
     {
         $page = $this->getSession()->getPage();
-        $element = $page->find('xpath', "//details/summary[@aria-expanded='false'][text()][contains(., '$summary')]");
-        if (empty($element)) {
-            throw new \Exception("Unable to find details element containing text $summary");
+
+        $action = strtolower(trim($action));
+        $literal = $this->getSession()->getSelectorsHandler()->xpathLiteral($summary);
+
+        if ($action === 'expand') {
+            $expandedState = "[@aria-expanded='false']";
+        } elseif ($action === 'contract') {
+            $expandedState = "[@aria-expanded='true']";
+        } elseif ($action === 'click') {
+            $expandedState = '';
+        } else {
+            throw new \InvalidArgumentException("Unknown action '{$action}'. Expected expand, contract, or click.");
         }
+
+        $xpath = "//details/summary{$expandedState}[normalize-space()][contains(normalize-space(.), {$literal})]";
+
+        $element = $page->find('xpath', $xpath);
+        if (!$element) {
+            throw new \Exception("Unable to find details summary {$expandedState} containing text {$summary} for action {$action}");
+        }
+
         try {
             $element->click();
             usleep(100000);


### PR DESCRIPTION
Closes #589

This uses xpath to locate the `<details>` element `<summary>` text to expand/collapse the display of details.

On a Drupal create node form, you might:
- `Then I expand details labelled "Menu settings"`
- `Then I expand details labelled "Metatag"`
- `Then I expand details labelled "URL alias"`

You can also:
- `Then I collapse details labelled :summary`
- `Then I click details labelled :summary`

Case does matter for these labels. Some admin themes may _display_ the summary text in uppercase via CSS.

I hoped to use `$this->getSession()->wait();` instead of `usleep()` here but that didn't work (the details to be expanded weren't visibly expanded in a screenshot in the next step). Input welcome, happy to improve on this PR!

This new step should be a no-op for drivers such as Goutte that don't support click on non-link/submit/button elements; they are likely to have the collapsed details "visible" anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI: Added ability to expand, collapse, or click collapsible details/summary sections via user interactions.

* **Tests**
  * Added a blackbox scenario that interacts with a details/summary element and verifies revealed content.
  * Included a sample page with a collapsible details section used by the new test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->