### PR TITLE
#600: Avoid whitespace in tags 

### DIFF
--- a/src/Drupal/DrupalExtension/Context/MailContext.php
+++ b/src/Drupal/DrupalExtension/Context/MailContext.php
@@ -44,7 +44,7 @@ class MailContext extends RawMailContext
    * Allow opting in to mail collection. When using the default mail manager
    * service, it is not necessary to use this tag.
    *
-   * @BeforeScenario @mail @email
+   * @BeforeScenario @mail,@email
    */
     public function collectMail()
     {
@@ -54,7 +54,7 @@ class MailContext extends RawMailContext
   /**
    * Stop collecting mail at scenario end.
    *
-   * @AfterScenario @mail @email
+   * @AfterScenario @mail,@email
    */
     public function stopCollectingMail()
     {
@@ -143,7 +143,7 @@ class MailContext extends RawMailContext
         $count = $count === 'an' ? 1 : $count;
         $this->assertMailCount($actualMail, $count);
     }
-  
+
   /**
    * @When I follow the link to :urlFragment from the (e)mail
    * @When I follow the link to :urlFragment from the (e)mail to :to


### PR DESCRIPTION
Since Gherkin 4.9.0 tags with whitespace are deprecated: use a comma as an explicit OR operator.

See
- https://github.com/Behat/Gherkin/issues/213
- https://github.com/Behat/Gherkin/pull/215
- https://behat.org/en/latest/user_guide/context/hooks.html#tagged-hooks

Closes #600

Thanks!