### PR TITLE
WIP PHP 8.1 compatibility.

### DIFF
--- a/src/Drupal/DrupalDriverManager.php
+++ b/src/Drupal/DrupalDriverManager.php
@@ -64,7 +64,12 @@ class DrupalDriverManager implements DrupalDriverManagerInterface
      */
     public function getDriver($name = null)
     {
-        $name = strtolower($name) ?: $this->defaultDriverName;
+        if (null === $name) {
+            $name = $this->defaultDriverName;
+        }
+        else {
+            $name = strtolower($name);
+        }
 
         if (null === $name) {
             throw new \InvalidArgumentException('Specify a Drupal driver to get.');


### PR DESCRIPTION
Hello,

I tried to update my skeleton on PHP 8.1 https://gitlab.com/florenttorregrosa-drupal/docker-drupal-project/-/merge_requests/107 and Behat is not working.

I tried to debug so here is a PR but encountered other problems.

First:
```
Run behat tests.

Deprecated: Method ReflectionParameter::getClass() is deprecated in /project/vendor/behat/mink-extension/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php on line 119

Deprecated: Method ReflectionParameter::getClass() is deprecated in /project/vendor/behat/mink-extension/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php on line 119

Deprecated: Return type of GuzzleHttp\Cookie\CookieJar::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /project/vendor/guzzlehttp/guzzle/src/Cookie/CookieJar.php on line 220

Deprecated: Return type of GuzzleHttp\Cookie\CookieJar::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /project/vendor/guzzlehttp/guzzle/src/Cookie/CookieJar.php on line 225
Feature: Global Elements

  ┌─ @BeforeScenario # Drupal\DrupalExtension\Context\MailContext::disableMail()
  │
  ╳  8192: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /project/vendor/drupal/drupal-extension/src/Drupal/DrupalDriverManager.php line 71
  │
  @api
  Scenario: Homepage Contact Link                                                    # features/global.feature:4
    Given I am on the homepage                                                       # Drupal\DrupalExtension\Context\MinkContext::iAmOnHomepage()
    Then I should see the link "Home" in the "primary_menu" region                   # Drupal\DrupalExtension\Context\MinkContext::assertLinkRegion()
    Then I should see the link "Log in" in the "secondary_menu" region               # Drupal\DrupalExtension\Context\MinkContext::assertLinkRegion()
    Then I should see the link "Contact" in the "footer_fifth" region                # Drupal\DrupalExtension\Context\MinkContext::assertLinkRegion()
    Then I should see the "Search" button in the "sidebar_first" region              # Drupal\DrupalExtension\Context\MarkupContext::assertRegionButton()
    Then I should see the "div#block-bartik-branding" element in the "header" region # Drupal\DrupalExtension\Context\MarkupContext::assertRegionElement()

  ┌─ @BeforeScenario # Drupal\DrupalExtension\Context\MailContext::disableMail()
  │
  ╳  8192: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /project/vendor/drupal/drupal-extension/src/Drupal/DrupalDriverManager.php line 71
  │
  @api
  Scenario: Create a node                                              # features/global.feature:13
    Given I am logged in as a user with the "administrator" role       # Drupal\DrupalExtension\Context\DrupalContext::assertAuthenticatedByRole()
    When I am viewing an "article" content with the title "My article" # Drupal\DrupalExtension\Context\DrupalContext::createNode()
    Then I should see the heading "My article"                         # Drupal\DrupalExtension\Context\MinkContext::assertHeading()

--- Skipped scenarios:

    features/global.feature:4
    features/global.feature:13

2 scenarios (2 skipped)
9 steps (9 skipped)
0m0.50s (7.62Mb)
make: *** [Makefile:537 : tests-behat] Erreur 1

```

Then with the PR:
```
Deprecated: Method ReflectionParameter::getClass() is deprecated in /project/vendor/behat/mink-extension/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php on line 119

Deprecated: Method ReflectionParameter::getClass() is deprecated in /project/vendor/behat/mink-extension/src/Behat/MinkExtension/ServiceContainer/Driver/GoutteFactory.php on line 119

Deprecated: Return type of GuzzleHttp\Cookie\CookieJar::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /project/vendor/guzzlehttp/guzzle/src/Cookie/CookieJar.php on line 220

Deprecated: Return type of GuzzleHttp\Cookie\CookieJar::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /project/vendor/guzzlehttp/guzzle/src/Cookie/CookieJar.php on line 225
Feature: Global Elements

  @api
  Scenario: Homepage Contact Link                                                    # features/global.feature:4
    Given I am on the homepage                                                       # Drupal\DrupalExtension\Context\MinkContext::iAmOnHomepage()
    Then I should see the link "Home" in the "primary_menu" region                   # Drupal\DrupalExtension\Context\MinkContext::assertLinkRegion()
    Then I should see the link "Log in" in the "secondary_menu" region               # Drupal\DrupalExtension\Context\MinkContext::assertLinkRegion()
    Then I should see the link "Contact" in the "footer_fifth" region                # Drupal\DrupalExtension\Context\MinkContext::assertLinkRegion()
    Then I should see the "Search" button in the "sidebar_first" region              # Drupal\DrupalExtension\Context\MarkupContext::assertRegionButton()
    Then I should see the "div#block-bartik-branding" element in the "header" region # Drupal\DrupalExtension\Context\MarkupContext::assertRegionElement()

  @api
  Scenario: Create a node                                              # features/global.feature:13
    Given I am logged in as a user with the "administrator" role       # Drupal\DrupalExtension\Context\DrupalContext::assertAuthenticatedByRole()
    When I am viewing an "article" content with the title "My article" # Drupal\DrupalExtension\Context\DrupalContext::createNode()
    Then I should see the heading "My article"                         # Drupal\DrupalExtension\Context\MinkContext::assertHeading()
  │
  ╳  Type error: Drupal\Core\Routing\UrlGenerator::setContext(): Argument #1 ($context) must be of type Symfony\Component\Routing\RequestContext, null given (Behat\Testwork\Call\Exception\FatalThrowableError)
  │
  └─ @AfterScenario # Drupal\DrupalExtension\Context\ConfigContext::cleanUsers()
  │
  ╳  Circular reference detected for service "url_generator", path: "url_generator". (Drupal\Core\Entity\EntityStorageException)
  │
  └─ @AfterScenario # Drupal\DrupalExtension\Context\DrupalContext::cleanNodes()
  │
  ╳  Circular reference detected for service "url_generator", path: "url_generator". (Drupal\Core\Entity\EntityStorageException)
  │
  └─ @AfterScenario # Drupal\DrupalExtension\Context\DrupalContext::cleanUsers()
  │
  ╳  Circular reference detected for service "url_generator", path: "url_generator". (Drupal\Core\Entity\EntityStorageException)
  │
  └─ @AfterScenario # Drupal\DrupalExtension\Context\MailContext::cleanUsers()
  │
  ╳  Circular reference detected for service "url_generator", path: "url_generator". (Drupal\Core\Entity\EntityStorageException)
  │
  └─ @AfterScenario # Drupal\DrupalExtension\Context\MessageContext::cleanUsers()
  │
  ╳  Circular reference detected for service "url_generator", path: "url_generator". (Drupal\Core\Entity\EntityStorageException)
  │
  └─ @AfterScenario # Drupal\DrupalExtension\Context\RandomContext::cleanUsers()

2 scenarios (2 passed)
9 steps (9 passed)
0m13.60s (16.63Mb)
make: *** [Makefile:537 : tests-behat] Erreur 1
```

Thanks for any help.