### PR TITLE
Fix drupal-extension requirement

### DIFF
--- a/doc/_static/snippets/composer.json
+++ b/doc/_static/snippets/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "drupal/drupal-extension": "^3.2"
+    "drupal/drupal-extension": "^4.2"
   },
   "config": {
     "bin-dir": "bin/"


### PR DESCRIPTION
With version 3.x the `bin/behat --init` command fails.