### PR TITLE
Fixes #614 for PHP 8.1, Symfony 6, Drush 11, etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.3
   - 7.4
   - 8.0
   - 8.1
@@ -11,7 +10,6 @@ env:
     - PATH=$PATH:/home/travis/.config/composer/vendor/bin
     - TRAVIS_NODE_VERSION="4.0.0"
   matrix:
-    - DRUPAL_VERSION=7
     - DRUPAL_VERSION=9
 
 # Enable Travis containers.
@@ -28,17 +26,13 @@ install:
   # @todo Re-enable behat drush endpoint testing.
   # @see https://github.com/jhedstrom/drupalextension/issues/458
   - test ${DRUPAL_VERSION} -lt 8 || composer require --no-interaction --dev --no-update drupal/core-recommended:^${DRUPAL_VERSION} drupal/core-composer-scaffold:^${DRUPAL_VERSION} drush/drush:^10
-  # Remove core/drush deps for Drupal 7.
-  - test ${DRUPAL_VERSION} -ge 8 || composer remove --dev drush/drush drupal/core-recommended drupal/core-composer-scaffold
   - composer install
   # For Drupal 8, change composer.json to require symfony 3.x as conflicting
   # versions between the separate drupal and drupalextension vendor folders
   # can create conflicts.
   # Install drush globally.
   - (test ${DRUPAL_VERSION} -lt 8 && composer global require drush/drush:~8.0 drupal/drupal-driver) || composer global require drush/drush:~10.0
-  # Install the Behat Drush Endpoint for Drupal 7 tests.
-  - test ${DRUPAL_VERSION} -gt 7 || (git clone https://github.com/drush-ops/behat-drush-endpoint.git drush/behat-drush-endpoint && (cd drush/behat-drush-endpoint && composer install --no-dev && cd -))
-  # Pin node version.
+   # Pin node version.
   # @see http://austinpray.com/ops/2015/09/20/change-travis-node-version.html
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
   - npm install
@@ -67,8 +61,6 @@ before_script:
   # @todo Re-enable behat drush endpoint testing.
   # @see https://github.com/jhedstrom/drupalextension/issues/458
   # - test ${DRUPAL_VERSION} -eq 6 || test ${DRUPAL_VERSION} -eq 8 || (test ${DRUPAL_VERSION} -eq 7 && drush help behat)
-  # Only revert features on Drupal 7.
-  - test \! ${DRUPAL_VERSION} -eq 7 || drush --yes fr behat_test
   # Disable the page cache on Drupal 8.
   - test \! ${DRUPAL_VERSION} -ge 8 || drush --yes pmu page_cache
   # Test with big_pipe enabled for Drupal 8.
@@ -84,8 +76,6 @@ script:
   - npm test
   - vendor/bin/behat -fprogress --strict
   - vendor/bin/behat -fprogress --profile=drupal${DRUPAL_VERSION} --strict
-  # Do not test the Drush profile unless Drupal 7 was installed.
-  - test ${DRUPAL_VERSION} -ne 7 || vendor/bin/behat -fprogress --profile=drush --strict
 
 after_failure:
   - cat ~/debug.txt

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
     "behat/mink-goutte-driver": "~1|^2",
     "behat/mink-selenium2-driver": "~1.1",
     "drupal/drupal-driver": "^2.1.0",
-    "symfony/browser-kit": "^3.4|~4.4|^6",
-    "symfony/dependency-injection": "~3.0|~4.4|^6",
-    "symfony/translation": "^3.4|~4.4|^6"
+    "symfony/browser-kit": "~4.4|^6",
+    "symfony/dependency-injection": "~4.4|^6",
+    "symfony/translation": "~4.4|^6",
   },
   "require-dev": {
     "composer/installers": "^1.2|^2",

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,13 @@
   "require": {
     "behat/behat": "~3.2",
     "behat/mink": "~1.5",
-    "friends-of-behat/mink-extension": "^2",
+    "friends-of-behat/mink-extension": "^2.7.2",
     "behat/mink-goutte-driver": "~1|^2",
     "behat/mink-selenium2-driver": "~1.1",
     "drupal/drupal-driver": "^2.1.0",
     "symfony/browser-kit": "~4.4|^6",
     "symfony/dependency-injection": "~4.4|^6",
-    "symfony/translation": "~4.4|^6",
+    "symfony/translation": "~4.4|^6"
   },
   "require-dev": {
     "composer/installers": "^1.2|^2",

--- a/composer.json
+++ b/composer.json
@@ -20,23 +20,24 @@
     }
   ],
   "prefer-stable": true,
+  "minimum-stability": "dev",
   "require": {
     "behat/behat": "~3.2",
     "behat/mink": "~1.5",
     "friends-of-behat/mink-extension": "^2",
-    "behat/mink-goutte-driver": "~1.0",
+    "behat/mink-goutte-driver": "~1|^2",
     "behat/mink-selenium2-driver": "~1.1",
     "drupal/drupal-driver": "^2.1.0",
-    "symfony/browser-kit": "^3.4|~4.4",
-    "symfony/dependency-injection": "~3.0|~4.4",
-    "symfony/translation": "^3.4|~4.4"
+    "symfony/browser-kit": "^3.4|~4.4|^6",
+    "symfony/dependency-injection": "~3.0|~4.4|^6",
+    "symfony/translation": "^3.4|~4.4|^6"
   },
   "require-dev": {
-    "composer/installers": "^1.2",
+    "composer/installers": "^1.2|^2",
     "drupal/coder": "^8.3",
-    "drupal/core-composer-scaffold": "^9.1",
-    "drupal/core-recommended": "^9.1",
-    "drush/drush": "^10.5",
+    "drupal/core-composer-scaffold": "^9.1|^10.0.0-alpha1",
+    "drupal/core-recommended": "^9.1|^10.0.0-alpha1",
+    "drush/drush": "^10.5|^11 ",
     "php-parallel-lint/php-parallel-lint": "^1.3",
     "phpspec/phpspec": "^4.0 || ^6.0 || ^7.0"
   },


### PR DESCRIPTION
Updates the following:

- drupal related dependencies to allow 10.x
- drush to allow drush 11
- behat/mink-goutte-driver to allow 2.x
- symfony packages to allow ^6