### PR TITLE
Make Guzzle request options configurable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_version: ["8.1", "8.2"]
-        drupal_version: ["10.0", "10.1"]
+        php_version: ["7.4", "8.0", "8.1", "8.2"]
+        drupal_version: ["9", "10.0", "10.1"]
+        exclude:
+          - php_version: "7.4"
+            drupal_version: "10.0"
+          - php_version: "7.4"
+            drupal_version: "10.1"
+          - php_version: "8.0"
+            drupal_version: "10.0"
+          - php_version: "8.0"
+            drupal_version: "10.1"
+          - php_version: "8.2"
+            drupal_version: "9"
     env:
       PHP_VERSION: ${{ matrix.php_version }}
       DRUPAL_VERSION: ${{ matrix.drupal_version }}
@@ -39,7 +50,12 @@ jobs:
         run: docker-compose exec -T php composer test
       - name: behat --profile=blackbox
         run: docker-compose exec -T php vendor/bin/behat -fprogress --strict
-      - name: behat --profile=drupal
-        run: docker-compose exec -T php cat && docker-compose exec -T php vendor/bin/behat -fprogress --profile=drupal --strict
+      - name: behat --profile=drupal9
+        if: "${{ matrix.drupal_version == '9'}}"
+        run: docker-compose exec -T php cat && docker-compose exec -T php vendor/bin/behat -fprogress --profile=drupal9 --strict
+      - name: behat --profile=drupal10
+        if: "${{ matrix.drupal_version != '9'}}"
+        run: docker-compose exec -T php cat && docker-compose exec -T php vendor/bin/behat -fprogress --profile=drupal10 --strict
       - name: behat --profile=drupal_https
+        if: "${{ matrix.drupal_version != '9'}}"
         run: docker-compose exec -T php cat && docker-compose exec -T php vendor/bin/behat -fprogress --profile=drupal_https --strict

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_version: ["7.4", "8.0", "8.1", "8.2"]
-        drupal_version: ["9", "10"]
-        exclude:
-          - php_version: "7.4"
-            drupal_version: "10"
-          - php_version: "8.0"
-            drupal_version: "10"
-          - php_version: "8.2"
-            drupal_version: "9"
+        php_version: ["8.1", "8.2"]
+        drupal_version: ["10.0", "10.1"]
     env:
       PHP_VERSION: ${{ matrix.php_version }}
       DRUPAL_VERSION: ${{ matrix.drupal_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,5 @@ jobs:
         run: docker-compose exec -T php vendor/bin/behat -fprogress --strict
       - name: behat --profile=drupal
         run: docker-compose exec -T php cat && docker-compose exec -T php vendor/bin/behat -fprogress --profile=drupal --strict
+      - name: behat --profile=drupal_https
+        run: docker-compose exec -T php cat && docker-compose exec -T php vendor/bin/behat -fprogress --profile=drupal_https --strict

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: copy fixtures
         run: docker-compose exec -T php cp -r fixtures/drupal/modules/behat_test drupal/modules
       - name: drush pmu page_cache
-        run: docker-compose exec -T php ./vendor/bin/drush --yes --root=drupal pmu page_cache
+        run: docker-compose exec -T php ./vendor/bin/drush --yes --root=drupal pmu page_cache,big_pipe
       - name: drush en behat_test
         run: docker-compose exec -T php ./vendor/bin/drush --yes --root=drupal en behat_test
       - name: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+ * [#655](https://github.com/jhedstrom/drupalextension/pull/655) Configure Guzzle request options
 ## [5.0.0 rc1]
 ### Fixed
  * [#629](https://github.com/jhedstrom/drupalextension/pull/629) Fix upstream Drupal getText issue.

--- a/README.md
+++ b/README.md
@@ -41,18 +41,25 @@ the [Full documentation](https://behat-drupal-extension.readthedocs.org)
     minimal configuration. Many more options are covered in the
     [Full documentation](https://behat-drupal-extension.readthedocs.org)
 
-  ``` yaml
-  default:
-    suites:
-      default:
-        contexts:
-          - Drupal\DrupalExtension\Context\DrupalContext
-    extensions:
-      Drupal\MinkExtension:
-        browserkit_http: ~
-        base_url: http://example.org/  # Replace with your site's URL
-      Drupal\DrupalExtension:
-        blackbox: ~
+    ``` yaml
+    default:
+      suites:
+        default:
+          contexts:
+            - Drupal\DrupalExtension\Context\DrupalContext
+      extensions:
+        Drupal\MinkExtension:
+          # Guzzle is used as HTTP client. You can configure the Guzzle request
+          # options by setting `browserkit_http.guzzle_request_options`. For
+          # instance the following configuration will disable SSL peer verification:
+          # browserkit_http:
+          #   guzzle_request_options:
+          #     verify: false
+          # See \GuzzleHttp\RequestOptions for all built-in Guzzle request options
+          browserkit_http: ~
+          base_url: http://example.org/  # Replace with your site's URL
+        Drupal\DrupalExtension:
+          blackbox: ~
   ```
 
 1. In the projectdir, run

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -55,3 +55,20 @@ drupal:
         main content: "#main"
       selectors:
         error_message_selector: '.messages--error'
+
+drupal_https:
+  suites:
+    default:
+      contexts:
+        - FeatureContext
+        - Drupal\DrupalExtension\Context\DrupalContext
+        - Drupal\DrupalExtension\Context\MinkContext
+      filters:
+        tags: "@https"
+  extensions:
+    Drupal\MinkExtension:
+      base_url: https://proxy
+    Drupal\DrupalExtension:
+      api_driver: "drupal"
+      drupal:
+        drupal_root: "/var/www/html/drupal"

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -29,7 +29,7 @@ default:
         success_message_selector: '.messages.status'
         warning_message_selector: '.messages.warning'
 
-drupal:
+drupal9:
   suites:
     default:
       contexts:
@@ -42,7 +42,34 @@ drupal:
         - Drupal\DrupalExtension\Context\MailContext
         - Drupal\DrupalExtension\Context\RandomContext
       filters:
-        tags: "~@blackbox&&~@wip"
+        tags: "~@blackbox&&~@wip&&~@d10"
+  extensions:
+    Drupal\MinkExtension:
+      base_url: http://proxy
+      files_path: /var/www/html/fixtures/files
+    Drupal\DrupalExtension:
+      api_driver: "drupal"
+      drupal:
+        drupal_root: "/var/www/html/drupal"
+      region_map:
+        main content: "#main"
+      selectors:
+        error_message_selector: '.messages--error'
+
+drupal10:
+  suites:
+    default:
+      contexts:
+        - FeatureContext
+        - Drupal\DrupalExtension\Context\ConfigContext
+        - Drupal\DrupalExtension\Context\DrupalContext
+        - Drupal\DrupalExtension\Context\MinkContext
+        - Drupal\DrupalExtension\Context\MarkupContext
+        - Drupal\DrupalExtension\Context\MessageContext
+        - Drupal\DrupalExtension\Context\MailContext
+        - Drupal\DrupalExtension\Context\RandomContext
+      filters:
+        tags: "~@blackbox&&~@wip&&~@d9"
   extensions:
     Drupal\MinkExtension:
       base_url: http://proxy

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -68,6 +68,9 @@ drupal_https:
   extensions:
     Drupal\MinkExtension:
       base_url: https://proxy
+      browserkit_http:
+        guzzle_request_options:
+          verify: false
     Drupal\DrupalExtension:
       api_driver: "drupal"
       drupal:

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -45,7 +45,7 @@ drupal:
         tags: "~@blackbox&&~@wip"
   extensions:
     Drupal\MinkExtension:
-      base_url: http://drupal
+      base_url: http://proxy
       files_path: /var/www/html/fixtures/files
     Drupal\DrupalExtension:
       api_driver: "drupal"

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "drupal/coder": "^8.3",
     "drupal/core": "^10",
     "drupal/core-composer-scaffold": "^10",
-    "drush/drush": "^12.4",
+    "drush/drush": "^11.6.0 || ^12.4",
     "php-parallel-lint/php-parallel-lint": "^1.3",
     "phpspec/phpspec": "^4.0 || ^6.0 || ^7.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,9 @@
   "require-dev": {
     "composer/installers": "^2",
     "drupal/coder": "^8.3",
-    "drupal/core": "^9.4 || ^10.0",
-    "drupal/core-composer-scaffold": "^9.4 || ^10.0",
-    "drush/drush": "^11.0",
+    "drupal/core": "^10",
+    "drupal/core-composer-scaffold": "^10",
+    "drush/drush": "^12.4",
     "php-parallel-lint/php-parallel-lint": "^1.3",
     "phpspec/phpspec": "^4.0 || ^6.0 || ^7.0"
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,9 +20,30 @@ services:
       PHP_IDE_CONFIG: "serverName=drupalextension"
     volumes:
       - ./:/var/www/html
+    labels:
+      - "traefik.enable=false"
+    depends_on:
+      - proxy
+
+  proxy:
+    image: traefik:v2.10
+    command:
+      - "--api.insecure=true"
+      - "--providers.docker"
+      - "--entrypoints.http-80.address=:80"
+      - "--entrypoints.http-443.address=:443"
+    ports:
+      - "80:80"
+      - "443:443"
+      # The Web UI (enabled by --api.insecure=true)
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    labels:
+      - "traefik.enable=false"
 
   drupal:
-    image: wodby/nginx:1.16-5.11.3
+    image: wodby/nginx
     depends_on:
       - php
     environment:
@@ -30,14 +51,18 @@ services:
       NGINX_ERROR_LOG_LEVEL: debug
       NGINX_BACKEND_HOST: php
       NGINX_SERVER_ROOT: /var/www/html/drupal
-      NGINX_VHOST_PRESET: drupal9
+      NGINX_VHOST_PRESET: drupal10
     volumes:
       - ./:/var/www/html
-    ports:
-      - "8080:80"
+    labels:
+      - "traefik.http.routers.drupal.rule=Host(`proxy`)"
+      - "traefik.http.routers.drupal.entrypoints=http-80"
+      - "traefik.http.routers.drupal-secure.rule=Host(`proxy`)"
+      - "traefik.http.routers.drupal-secure.tls=true"
+      - "traefik.http.routers.drupal-secure.entrypoints=http-443"
 
   blackbox:
-    image: wodby/nginx:1.16-5.11.3
+    image: wodby/nginx
     environment:
       NGINX_STATIC_OPEN_FILE_CACHE: "off"
       NGINX_ERROR_LOG_LEVEL: debug
@@ -45,8 +70,8 @@ services:
       NGINX_VHOST_PRESET: html
     volumes:
       - ./:/var/www/html
-    ports:
-      - "8081:80"
+    labels:
+      - "traefik.enable=false"
 
   db:
     image: wodby/mariadb:10.3-3.8.4
@@ -56,6 +81,8 @@ services:
       MYSQL_DATABASE: drupal
       MYSQL_USER: drupal
       MYSQL_PASSWORD: drupal
+    labels:
+      - "traefik.enable=false"
 
   node:
     image: node:latest
@@ -67,6 +94,5 @@ services:
     volumes:
       - ./:/home/node/app
     command: "sleep infinity"
-
-volumes:
-  codebase:
+    labels:
+      - "traefik.enable=false"

--- a/features/d8.feature
+++ b/features/d8.feature
@@ -4,6 +4,7 @@ Feature: DrupalContext
   As a developer
   I need to use the step definitions of this context
 
+  @https
   Scenario: Target links within table rows
     Given I am logged in as a user with the "administrator" role
     When I am at "admin/structure/types"

--- a/features/d8.feature
+++ b/features/d8.feature
@@ -9,7 +9,7 @@ Feature: DrupalContext
     When I am at "admin/structure/types"
     And I click "Manage fields" in the "Article" row
     Then I should be on "admin/structure/types/manage/article/fields"
-    And I should see the link "Add field"
+    And I should see the link "Create a new field"
 
   Scenario: Create users with roles
     Given users:

--- a/features/d8.feature
+++ b/features/d8.feature
@@ -4,8 +4,17 @@ Feature: DrupalContext
   As a developer
   I need to use the step definitions of this context
 
+  @d9
+  Scenario: Target links within table rows (Drupal 9)
+    Given I am logged in as a user with the "administrator" role
+    When I am at "admin/structure/types"
+    And I click "Manage fields" in the "Article" row
+    Then I should be on "admin/structure/types/manage/article/fields"
+    And I should see the link "Add field"
+
+  @d10
   @https
-  Scenario: Target links within table rows
+  Scenario: Target links within table rows (Drupal 10)
     Given I am logged in as a user with the "administrator" role
     When I am at "admin/structure/types"
     And I click "Manage fields" in the "Article" row

--- a/features/i18n/es/d8.feature
+++ b/features/i18n/es/d8.feature
@@ -18,7 +18,7 @@ Característica: DrupalContext
     Cuando estoy en la URL "admin/structure/types"
       Y hago click en el enlace "Manage fields" de la fila "Article"
     Entonces debo estar en "admin/structure/types/manage/article/fields"
-      Y debo ver el enlace "Add field"
+      Y debo ver el enlace "Create a new field"
 
   Escenario: Cear usuarios con roles
     Dados usuarios:

--- a/features/i18n/es/d8.feature
+++ b/features/i18n/es/d8.feature
@@ -13,7 +13,16 @@ Característica: DrupalContext
     Cuando hago click en "My account"
     Entonces debo ver el texto "Member for"
 
-  Escenario: Enlaces dentro de filas de tablas
+  @d9
+  Escenario: Enlaces dentro de filas de tablas  (Drupal 9)
+    Dado que estoy conectado como un "administrator"
+    Cuando estoy en la URL "admin/structure/types"
+      Y hago click en el enlace "Manage fields" de la fila "Article"
+    Entonces debo estar en "admin/structure/types/manage/article/fields"
+      Y debo ver el enlace "Add field"
+
+  @d10
+  Escenario: Enlaces dentro de filas de tablas  (Drupal 10)
     Dado que estoy conectado como un "administrator"
     Cuando estoy en la URL "admin/structure/types"
       Y hago click en el enlace "Manage fields" de la fila "Article"


### PR DESCRIPTION
## Problem

Behat tests are failing for logged in users when the site is accessed via HTTPS and SSL peer verification is failing. But with `BrowserTestBase` we're able to run such tests. Testing should not require a valid SSL certificate

## Proposal

Make Guzzle request options configurable

Example:


```yaml
default:
  suites:
    default:
      contexts:
        - FeatureContext
        - Drupal\DrupalExtension\Context\DrupalContext
        - Drupal\DrupalExtension\Context\MinkContext
  extensions:
    Drupal\MinkExtension:
      base_url: https://localhost
      browserkit_http:
        guzzle_request_options:
          verify: false
```

In this example, `browserkit_http.guzzle_request_options` is configured to instantiate the Guzzle underlying HTTP client with the `verify` request option set to `false`, same as `BrowserTestBase:: initMink()` is doing