### PR TITLE
Allow creation of entities of any type with base field value parsing

### DIFF
--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -339,6 +339,23 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext
         $this->assertSession()->statusCodeEquals('200');
     }
 
+  /**
+   * Creates entities of a given type provided in a table.
+   *
+   * Example:
+   * | title    | author     | status | created           |
+   * | My title | Joe Editor | 1      | 2014-10-17 8:00am |
+   * | ...      | ...        | ...    | ...               |
+   *
+   * @Given :type entities:
+   */
+    public function createEntities($type, TableNode $entitiesTable)
+    {
+        foreach ($entitiesTable->getHash() as $entityHash) {
+            $entity = (object) $entityHash;
+            $this->entityCreate($type, $entity);
+        }
+    }
 
   /**
    * Creates a term on an existing vocabulary.

--- a/src/Drupal/DrupalExtension/Hook/Scope/AfterEntityCreateScope.php
+++ b/src/Drupal/DrupalExtension/Hook/Scope/AfterEntityCreateScope.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @file
+ * After entity create scope.
+ */
+namespace Drupal\DrupalExtension\Hook\Scope;
+
+use Behat\Testwork\Hook\Scope\HookScope;
+
+/**
+ * Represents an Entity hook scope.
+ */
+final class AfterEntityCreateScope extends BaseEntityScope
+{
+
+  /**
+   * Return the scope name.
+   *
+   * @return string
+   */
+    public function getName()
+    {
+        return self::AFTER;
+    }
+}

--- a/src/Drupal/DrupalExtension/Hook/Scope/BeforeEntityCreateScope.php
+++ b/src/Drupal/DrupalExtension/Hook/Scope/BeforeEntityCreateScope.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @file
+ * Before entity create scope.
+ */
+namespace Drupal\DrupalExtension\Hook\Scope;
+
+use Behat\Testwork\Hook\Scope\HookScope;
+
+/**
+ * Represents an Entity hook scope.
+ */
+final class BeforeEntityCreateScope extends BaseEntityScope
+{
+
+  /**
+   * Return the scope name.
+   *
+   * @return string
+   */
+    public function getName()
+    {
+        return self::BEFORE;
+    }
+}


### PR DESCRIPTION
Resolves #194.

This was built and tested in a D10 environment.  Pairs really well with jhedstrom/DrupalDriver/pull/271.

Opens up stuff like this:

```gherkin
Given "commerce_product_variation" entities:
  | title | type     | field_manufacturer | sku      | field_category | price:number | price:currency_code | status |
  | TNT   | product  | ACME               | TNT-01   | Excavation     | 200          | USD                 | 1      |
  | Anvil | product  | ACME               | ANVIL-01 | Metal          | 450          | USD                 | 1      |
  And "commerce_product" entities:
    | title | type     | variations | stores         | status |
    | TNT   | product  | TNT        | ACME Web Store | 1      |
    | Anvil | product  | Anvil      | ACME Web Store | 1      |
```

Deletes the entities out after scenario in reverse order so as to respect dependent entity setups.

Otherwise pretty much follows the node/term/user creation and cleanup patterns.  But now we can set up entities of _any_ type.