### PR TITLE
Reverse term removal

### DIFF
--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -282,7 +282,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface
     public function cleanTerms()
     {
         // Remove any terms that were created.
-        foreach ($this->terms as $term) {
+        foreach (array_reverse($this->terms) as $term) {
             $this->getDriver()->termDelete($term);
         }
         $this->terms = [];


### PR DESCRIPTION
When using a module like https://www.drupal.org/project/entity_reference_integrity, if a user were to make a term reference another term, test would fail as the current methodology would remove the referenced entity after the referee, which causes the integrity check to fail. This simply reverses the order in which they're removed, resolving this issue.