### PR TITLE
Issue #557: iWaitForAjaxToFinish fails

### DIFF
--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -147,7 +147,7 @@ class MinkContext extends MinkExtension implements TranslatableContext
       return (
         // Assert no AJAX request is running (via jQuery or Drupal) and no
         // animation is running.
-        (typeof jQuery === 'undefined' || jQuery.hasOwnProperty('active') === false || (jQuery.active === 0 && jQuery(':animated').length === 0)) &&
+        (typeof jQuery === 'undefined' || jQuery.hasOwnProperty('active') === false || (jQuery.active <= 0 && jQuery(':animated').length === 0)) &&
         d7_not_ajaxing && d8_not_ajaxing
       );
     }());


### PR DESCRIPTION
jQuery.active internal value may have negative value in some cases causing inconsistent test results, as jquery supposedly increments the value when an ajax request starts and decrements it when it finishes, it should not influence the identification of active ajax requests