### PR TITLE
Make it possible to override how to get the log out link

### DIFF
--- a/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
@@ -148,7 +148,7 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
 
         // As a last resort, if a logout link is found, we are logged in. While not
         // perfect, this is how Drupal SimpleTests currently work as well.
-        if ($page->findLink($this->getDrupalText('log_out'))) {
+        if ($this->getLogoutLinkElement()) {
             return true;
         }
 
@@ -156,6 +156,14 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
         // case and updates the userManager to reflect this.
         $this->fastLogout();
         return false;
+    }
+
+    /**
+     * Helper to get the log out link from the page.
+     */
+    public function getLogoutLinkElement()
+    {
+        return $this->getSession()->getPage()->findLink($this->getDrupalText('log_out'));
     }
 
     /**


### PR DESCRIPTION
Similar as in #631, from time to time I find myself running tests that some times have translated text in there and some times not. For example when sharing code between projects. 

A more robust method for me, for checking if the log out link is there or not is to provide a helper method for getting the element, which I then could override to be a consistent selector all the time.

This PR (which should make the code behave completely identically) makes that possible for me (and others)