### PR TITLE
Fix php 8.4 deprecation

### DIFF
--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -39,7 +39,7 @@ class DrupalExtension implements ExtensionInterface
    *
    * @param null|ServiceProcessor $processor
    */
-    public function __construct(ServiceProcessor $processor = null)
+    public function __construct(?ServiceProcessor $processor = null)
     {
         $this->processor = $processor ? : new ServiceProcessor();
     }


### PR DESCRIPTION
PHP 8.4 is showing a deprecation warning:

```
PHP Deprecated:  Drupal\DrupalExtension\ServiceContainer\DrupalExtension::__construct(): Implicitly marking parameter $processor as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/vendor/drupal/drupal-extension/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php on line 42
```

I ran a check with rector and it found only one case in the whole codebase.