### PR TITLE
Upgrade symfony/http-client to compatibility with Symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "behat/mink-selenium2-driver": "~1.1",
     "drupal/drupal-driver": "^2.2.1 || dev-master",
     "friends-of-behat/mink-extension": "^2.7.1",
-    "symfony/http-client": "~4.4 || ^5 || ^6",
+    "symfony/http-client": "~4.4 || ^5 || ^6 || ^7",
     "webflo/drupal-finder": "^1.2"
   },
   "require-dev": {


### PR DESCRIPTION
In a previous PR, the deps from Symfony were updated, but http-client is forcing to stay in Symfony 6, which prevents to go to Drupal 11.