### PR TITLE
Fix deprecation notice in PHP 8.4 with function str_getcsv

### DIFF
--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -422,7 +422,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface
             if ($this->getDriver()->isField($entity_type, $field_name)) {
                 // Split up multiple values in multi-value fields.
                 $values = [];
-                foreach (str_getcsv($field_value) as $key => $value) {
+                foreach (str_getcsv($field_value, escape: "\\") as $key => $value) {
                     $value = trim((string) $value);
                     $columns = $value;
                     // Split up field columns if the ' - ' separator is present.


### PR DESCRIPTION
In PHP 8.4 we have this warning:
```
Deprecated: str_getcsv(): the $escape parameter must be provided as its default value will change in /var/www/html/vendor/drupal/drupal-extension/src/Drupal/DrupalExtension/Context/RawDrupalContext.php line 425
```

To avoid this warning, we should explicitly pass the escape parameter.