### PR TITLE
Fixes / updates in contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,3 +51,15 @@ docker compose exec -T php vendor/bin/behat -fprogress --profile=drupal10 --stri
 
 - Check the changes from `composer require` are not included in your submitted PR.
 - Before testing another PHP or Drupal version, revert changes to `composer.json` and remove `composer.lock`, `package-lock.json`, `drupal/`, and `vendor/`.
+
+Run PHPCS to review coding standards:
+```shell
+docker compose exec -T php phpcs --standard=./phpcs-ruleset.xml
+docker compose exec -T php phpcs --standard=./phpcs-drupal-ruleset.xml
+```
+
+Run PHPCBF to fix coding standards:
+```shell
+docker compose exec -T php phpcbf --standard=./phpcs-ruleset.xml
+docker compose exec -T php phpcbf --standard=./phpcs-drupal-ruleset.xml
+```


### PR DESCRIPTION
Update CONTRIBUTING.md

- Replace `docker-compose` with `docker compose`
- Replace "drupal" profile in behat.yml.dist with "drupal10" (30e336900321fac4fe2b3b494b01ff0446f69c94 from #655)

NB: Expecting tests to fail, but that's a separate issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated local development and testing instructions to use the current container CLI syntax.
  * Standardized shell code blocks for clarity.
  * Adjusted test execution examples to target the newer framework profile and updated command flags/user options accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->