### PR TITLE
Fixed `RandomContext` not transforming `<?placeholder>` variables in `TableNode` arguments.

### DIFF
--- a/features/random.feature
+++ b/features/random.feature
@@ -22,6 +22,5 @@ Feature: RandomContext functionality
 
   Scenario: Test RandomContext functionality in tables
     Given I am viewing a page:
-      | title          |
-      | <?random_page> |
+      | title | <?random_page> |
     Then I should see the text "<?random_page>"

--- a/src/Drupal/DrupalExtension/Context/RandomContext.php
+++ b/src/Drupal/DrupalExtension/Context/RandomContext.php
@@ -48,6 +48,20 @@ class RandomContext extends RawDrupalContext
     }
 
     /**
+     * Transform random variables in table arguments.
+     *
+     * @Transform table:*
+     */
+    public function transformTable(TableNode $table)
+    {
+        $rows = [];
+        foreach ($table->getRows() as $row) {
+            $rows[] = array_map([$this, 'transformVariables'], $row);
+        }
+        return new TableNode($rows);
+    }
+
+    /**
      * Set values for each random variable found in the current scenario.
      *
      * @BeforeScenario


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table arguments now transform random variables in every cell, improving flexibility in test data handling.
* **Tests**
  * Updated feature scenario table structure (now a one-row, two-column table) to align with the new table-transformation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->