### PR TITLE
Switched to use Drupal 11 by default.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ Testing is performed automatically in Github Actions when a PR is submitted. To 
 
 Configure your local test environment:
 ```shell
-export PHP_VERSION=8.2
-export DRUPAL_VERSION=10
+export PHP_VERSION=8.3
+export DRUPAL_VERSION=11
 export DOCKER_USER_ID=${UID}
 ```
 
@@ -46,6 +46,19 @@ Execute specific tests, eg just PHPUnit's Drupal7FieldHandlerTest:
 ```shell
 docker compose exec -T php vendor/bin/behat -fprogress --profile=drupal10 --strict --tags=@random
 ```
+
+## Testing with Drupal 10
+
+To test against Drupal 10 instead of the default Drupal 11, use PHP 8.2, 8.3,
+or 8.4 and set the following environment variables:
+```shell
+export PHP_VERSION=8.2
+export DRUPAL_VERSION=10
+```
+
+Then follow the same steps as above. Before switching between Drupal versions,
+revert changes to `composer.json` and remove `composer.lock`, `package-lock.json`,
+`drupal/`, and `vendor/`.
 
 ## Before submitting a change
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ sites.
 
 [![ci](https://github.com/jhedstrom/drupalextension/actions/workflows/ci.yml/badge.svg)](https://github.com/jhedstrom/drupalextension/actions/workflows/ci.yml)
 
-The Drupal Extension 5.x supports Drupal 9 and 10, utilizes Behat 3.2+ and runs
+The Drupal Extension 5.x supports Drupal 10 and 11, utilizes Behat 3.22+ and runs
 on:
 
-- PHP 7.4, 8.0, 8.1 with Drupal 9
-- PHP 8.1 with Drupal 10.
+- PHP 8.2, 8.3, 8.4 with Drupal 10
+- PHP 8.3, 8.4 with Drupal 11.
 
 [![Latest Stable Version](https://poser.pugx.org/drupal/drupal-extension/v/stable.svg)](https://packagist.org/packages/drupal/drupal-extension)
 [![Total Downloads](https://poser.pugx.org/drupal/drupal-extension/downloads.svg)](https://packagist.org/packages/drupal/drupal-extension)

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
     "require-dev": {
         "composer/installers": "^2.3",
         "drupal/coder": "^8.3.27",
-        "drupal/core": "^10",
-        "drupal/core-composer-scaffold": "^10",
+        "drupal/core": "^11",
+        "drupal/core-composer-scaffold": "^11",
         "drush/drush": "^12.4 || ^13.7",
         "ergebnis/composer-normalize": "^2.50",
         "grasmash/yaml-cli": "^3.2.1",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated supported Drupal versions to include Drupal 10 and 11 with revised PHP compatibility (PHP 8.2–8.4).
  * Bumped testing tool requirement (Behat) to a newer minimum.
  * Added guidance for testing against Drupal 10.

* **Chores**
  * Updated development environment defaults to Drupal 11 and PHP 8.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->