### PR TITLE
Replaced regex annotation with turnip in `BatchContext::iWaitForTheBatchJobToFinish()`.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -22,7 +22,7 @@
 
 
 <details>
-  <summary><code>@Given /^I wait for the batch job to finish$/</code></summary>
+  <summary><code>@Given I wait for the batch job to finish</code></summary>
 
 <br/>
 Wait for the Batch API to finish

--- a/src/Drupal/DrupalExtension/Context/BatchContext.php
+++ b/src/Drupal/DrupalExtension/Context/BatchContext.php
@@ -23,7 +23,7 @@ class BatchContext extends RawMinkContext
      * Given I wait for the batch job to finish
      * @endcode
      *
-     * @Given /^I wait for the batch job to finish$/
+     * @Given I wait for the batch job to finish
      */
     public function iWaitForTheBatchJobToFinish(): void
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal test step pattern matching by converting from regex-based to literal string matching. No changes to functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->