### PR TITLE
Simplified coverage directory cleanup commands.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -229,7 +229,7 @@ commands:
   test-coverage:
     usage: Run all tests with coverage and merge reports.
     cmd: |
-      ahoy cli "rm -rf .logs/coverage/phpunit .logs/coverage/behat .logs/coverage/behat_cli/phpcov 2>/dev/null; mkdir -p .logs/coverage/phpunit .logs/coverage/behat .logs/coverage/behat_cli/phpcov || true"
+      ahoy cli "rm -rf .logs/coverage && mkdir -p .logs/coverage/phpunit .logs/coverage/behat .logs/coverage/behat_cli/phpcov"
 
       ahoy title "Running PHPUnit with coverage"
       ahoy cli "php -d pcov.enabled=1 -d pcov.directory=. vendor/bin/phpunit -c phpunit.xml"
@@ -245,7 +245,7 @@ commands:
   test-unit-coverage:
     usage: Run PHPUnit tests with coverage.
     cmd: |
-      ahoy cli "rm -rf .logs/coverage/phpunit 2>/dev/null; mkdir -p .logs/coverage/phpunit || true"
+      ahoy cli "rm -rf .logs/coverage && mkdir -p .logs/coverage/phpunit"
 
       ahoy title "Running PHPUnit with coverage"
       ahoy cli "php -d pcov.enabled=1 -d pcov.directory=. vendor/bin/phpunit -c phpunit.xml $@"
@@ -255,7 +255,7 @@ commands:
   test-bdd-coverage:
     usage: Run all Behat tests with coverage and merge reports.
     cmd: |
-      ahoy cli "rm -rf .logs/coverage/behat .logs/coverage/behat_cli/phpcov 2>/dev/null; mkdir -p .logs/coverage/behat .logs/coverage/behat_cli/phpcov || true"
+      ahoy cli "rm -rf .logs/coverage && mkdir -p .logs/coverage/behat .logs/coverage/behat_cli/phpcov"
 
       # If no arguments are passed, run in strict mode. If any arguments are passed, do not use strict mode to allow running specific tests.
       STRICT=""; if [ -z "$1" ]; then STRICT="--strict"; fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,10 @@ jobs:
       - name: Run PHPSpec tests
         run: docker compose exec -T php vendor/bin/phpspec run -f pretty --no-interaction
 
+      - name: Clean coverage directory
+        if: ${{ matrix.coverage }}
+        run: docker compose exec -T php bash -c 'rm -rf .logs/coverage && mkdir -p .logs/coverage/phpunit .logs/coverage/behat .logs/coverage/behat_cli/phpcov'
+
       - name: Run PHPUnit tests
         if: ${{ matrix.coverage }}
         run: docker compose exec -T php php -d pcov.enabled=1 -d pcov.directory=. vendor/bin/phpunit -c phpunit.xml
@@ -178,7 +182,6 @@ jobs:
       - name: Run Behat tests with coverage
         if: ${{ matrix.coverage }}
         run: |
-          docker compose exec -T php bash -c 'rm -rf .logs/coverage/behat .logs/coverage/behat_cli/phpcov 2>/dev/null; mkdir -p .logs/coverage/behat .logs/coverage/behat_cli/phpcov || true'
           docker compose exec -T php php -d pcov.enabled=1 -d pcov.directory=src vendor/bin/behat --strict
           docker compose exec -T php php -d pcov.enabled=1 -d pcov.directory=src vendor/bin/behat --profile=drupal --strict
 


### PR DESCRIPTION
# Simplified coverage directory cleanup commands.

## Summary

The coverage directory cleanup commands in `.ahoy.yml` and `.github/workflows/ci.yml` used error-suppression flags (`2>/dev/null`) and fallback chains (`|| true`) to handle the case where the directory might not exist. These have been replaced with a single `rm -rf .logs/coverage` followed by `mkdir -p` for the required subdirectories, which is cleaner and more predictable. In the CI workflow, directory cleanup is now extracted into a dedicated step that runs before PHPUnit, rather than being inlined into the Behat run step.

## Changes

**`.ahoy.yml`**
- `test-coverage`: Replaced selective subdirectory removal with full `.logs/coverage` wipe before recreating needed subdirectories.
- `test-unit-coverage`: Same simplification — removes entire `.logs/coverage` and recreates only the `phpunit` subdirectory.
- `test-bdd-coverage`: Same pattern — wipes and recreates `behat` and `behat_cli/phpcov` subdirectories.

**`.github/workflows/ci.yml`**
- Added a dedicated "Clean coverage directory" step (runs only when `matrix.coverage` is set) before PHPUnit, which performs the full wipe and recreation.
- Removed the inline cleanup command from the "Run Behat tests with coverage" step, which previously used the same error-suppressed pattern.

## Before / After

```
Before (ahoy.yml cleanup commands):
┌─────────────────────────────────────────────────────────────────────┐
│ rm -rf .logs/coverage/phpunit 2>/dev/null;                          │
│ mkdir -p .logs/coverage/phpunit || true                             │
└─────────────────────────────────────────────────────────────────────┘

After:
┌─────────────────────────────────────────────────────────────────────┐
│ rm -rf .logs/coverage && mkdir -p .logs/coverage/phpunit            │
└─────────────────────────────────────────────────────────────────────┘

Before (ci.yml Behat step):
┌──────────────────────────────────────────────────────────────────────────────┐
│ - name: Run Behat tests with coverage                                        │
│   run: |                                                                     │
│     docker compose exec -T php bash -c                                       │
│       'rm -rf .logs/coverage/behat ... 2>/dev/null; mkdir -p ... || true'   │
│     docker compose exec -T php php ... vendor/bin/behat --strict            │
└──────────────────────────────────────────────────────────────────────────────┘

After:
┌──────────────────────────────────────────────────────────────────────────────┐
│ - name: Clean coverage directory          ← new dedicated step               │
│   if: ${{ matrix.coverage }}                                                 │
│   run: docker compose exec -T php bash -c                                    │
│     'rm -rf .logs/coverage && mkdir -p ...'                                  │
│                                                                              │
│ - name: Run Behat tests with coverage     ← cleanup removed from here        │
│   run: |                                                                     │
│     docker compose exec -T php php ... vendor/bin/behat --strict            │
└──────────────────────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build and test infrastructure: Streamlined coverage directory cleanup across test commands for consistency.
  * Enhanced error visibility: Removed silent failure handling to ensure build failures are properly reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->