### PR TITLE
[#676] Separated link assertion from click action in .

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -416,6 +416,20 @@ Then I should see the "Edit" in the "My article" row
 </details>
 
 <details>
+  <summary><code>@Then I should not see the :link in the :rowText row</code></summary>
+
+<br/>
+Asserts a link does not exist in a table row containing given text
+<br/><br/>
+
+```gherkin
+Then I should not see the "Delete" in the "My article" row
+
+```
+
+</details>
+
+<details>
   <summary><code>@Then I should be able to edit a/an :type( content)</code></summary>
 
 <br/>

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -257,6 +257,25 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
   }
 
   /**
+   * Asserts a link does not exist in a table row containing given text.
+   *
+   * This is for administrative pages such as the administer content types
+   * screen found at `admin/structure/types`.
+   *
+   * @code
+   * Then I should not see the "Delete" in the "My article" row
+   * @endcode
+   *
+   * @Then I should not see the :link in the :rowText row
+   */
+  public function assertNotLinkInTableRow(string $link, string $rowText): void {
+    $page = $this->getSession()->getPage();
+    if ($this->getTableRow($page, $rowText)->findLink($link)) {
+      throw new \Exception(sprintf('Found a row containing "%s" with a "%s" link on the page %s', $rowText, $link, $this->getSession()->getCurrentUrl()));
+    }
+  }
+
+  /**
    * Clicks a link in a table row containing given text.
    *
    * This is for administrative pages such as the administer content types

--- a/tests/behat/features/drupal_context.feature
+++ b/tests/behat/features/drupal_context.feature
@@ -146,6 +146,33 @@ Feature: DrupalContext coverage gaps
       """
 
   @test-drupal @api
+  Scenario: Assert "Then I should not see the :link in the :rowText row" passes
+    Given I am logged in as a user with the "administrator" role
+    And "article" content:
+      | title         | status |
+      | Link row test | 1      |
+    When I go to "admin/content"
+    Then I should not see the "Nonexistent link" in the "Link row test" row
+
+  @test-drupal @api
+  Scenario: Assert "Then I should not see the :link in the :rowText row" fails for existing link
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given I am logged in as a user with the "administrator" role
+      And "article" content:
+        | title         | status |
+        | Link row test | 1      |
+      When I go to "admin/content"
+      Then I should not see the "Edit" in the "Link row test" row
+      """
+    When I run behat with drupal profile
+    Then it should fail with an error:
+      """
+      with a "Edit" link
+      """
+
+  @test-drupal @api
   Scenario: Assert "Given I click :link in the :rowText row" fails when link not in row
     Given some behat configuration
     And scenario steps tagged with "@test-drupal @api":


### PR DESCRIPTION
Closes #676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added step to assert a link exists in a table row and a complementary step to assert a link does not exist.

* **Refactor**
  * Separated the click action from visibility verification so clicking and asserting are distinct steps.

* **Documentation**
  * Updated step descriptions and examples to reflect separate click and verification behavior.

* **Tests**
  * Added scenarios covering positive and negative link-assertion cases and related failure expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->