### PR TITLE
[#179] Added test for fresh REQUEST_TIME during cron and bumped drupal-driver to ^2.4.2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "behat/gherkin": "^4.13",
         "behat/mink": "^1.12",
         "behat/mink-browserkit-driver": "^2.1.0",
-        "drupal/drupal-driver": "^2.4.1",
+        "drupal/drupal-driver": "^2.4.2",
         "friends-of-behat/mink-extension": "^2.7.1",
         "lullabot/mink-selenium2-driver": "^1.7.4",
         "symfony/css-selector": "^6.4.3 || ^7",

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -305,6 +305,47 @@ class FeatureContext extends RawDrupalContext {
   }
 
   /**
+   * Makes REQUEST_TIME stale by setting it to a past value.
+   *
+   * This simulates what happens during a long-running Behat test suite where
+   * REQUEST_TIME becomes increasingly outdated.
+   *
+   * @Given the request time is :seconds seconds in the past
+   *
+   * @see https://github.com/jhedstrom/drupalextension/issues/179
+   */
+  public function testSetStaleRequestTime(int $seconds): void {
+    $staleTime = time() - $seconds;
+    $_SERVER['REQUEST_TIME'] = $staleTime;
+    \Drupal::request()->server->set('REQUEST_TIME', $staleTime);
+  }
+
+  /**
+   * Asserts that cron ran with a fresh request time.
+   *
+   * Reads the time drift recorded by behat_test_cron() and asserts it is
+   * within the given threshold.
+   *
+   * @Then the cron request time drift should be less than :seconds seconds
+   *
+   * @see https://github.com/jhedstrom/drupalextension/issues/179
+   */
+  public function testAssertCronRequestTimeDrift(int $seconds): void {
+    $drift = \Drupal::state()->get('behat_test.cron_time_drift');
+    if ($drift === NULL) {
+      throw new \RuntimeException('Cron time drift was not recorded. Ensure the behat_test module is enabled.');
+    }
+    if (abs($drift) >= $seconds) {
+      $requestTime = \Drupal::state()->get('behat_test.cron_request_time');
+      $actualTime = \Drupal::state()->get('behat_test.cron_actual_time');
+      throw new ExpectationException(
+        sprintf('Cron request time drift is %d seconds (request_time=%d, actual_time=%d), expected less than %d.', $drift, $requestTime, $actualTime, $seconds),
+        $this->getSession()->getDriver()
+      );
+    }
+  }
+
+  /**
    * Performs a passing assertion step for testing.
    *
    * @When I use a test passing assertion step

--- a/tests/behat/features/api.feature
+++ b/tests/behat/features/api.feature
@@ -31,6 +31,13 @@ Feature: DrupalContext general testing
     Then I should see the link "Cron run completed"
 
   @test-drupal @api
+  Scenario: Assert "I run cron" uses fresh request time
+    Given I am logged in as a user with the "administrator" role
+    And the request time is 60 seconds in the past
+    When I run cron
+    Then the cron request time drift should be less than 5 seconds
+
+  @test-drupal @api
   Scenario: Create many nodes
     Given "page" content:
       | title    |

--- a/tests/behat/fixtures/drupal/modules/behat_test/behat_test.module
+++ b/tests/behat/fixtures/drupal/modules/behat_test/behat_test.module
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Hooks for the behat_test module.
+ */
+
+/**
+ * Implements hook_cron().
+ *
+ * Records the drift between \Drupal::time()->getRequestTime() and the actual
+ * wall-clock time. Used to verify that REQUEST_TIME is refreshed before cron
+ * runs during Behat tests.
+ *
+ * @see https://github.com/jhedstrom/drupalextension/issues/179
+ */
+function behat_test_cron(): void {
+  $request_time = \Drupal::time()->getRequestTime();
+  $actual_time = time();
+  \Drupal::state()->set('behat_test.cron_request_time', $request_time);
+  \Drupal::state()->set('behat_test.cron_actual_time', $actual_time);
+  \Drupal::state()->set('behat_test.cron_time_drift', $actual_time - $request_time);
+}


### PR DESCRIPTION
## Summary

- Fixes #179: `REQUEST_TIME` becomes stale during long-running Behat test suites because it is set once when the PHP process starts.
- Bumped `drupal/drupal-driver` to `^2.4.2` which includes a fix to refresh `$_SERVER['REQUEST_TIME']` and the Symfony Request server bag before running cron.
- Added an integration test that artificially sets `REQUEST_TIME` 60 seconds in the past, runs cron, and asserts the drift is less than 5 seconds.

### Changes

- **`behat_test.module`** — Added `hook_cron()` that records the drift between `\Drupal::time()->getRequestTime()` and `time()` into Drupal state.
- **`FeatureContext.php`** — Added two step definitions: one to make `REQUEST_TIME` stale, and one to assert the recorded drift is within threshold.
- **`api.feature`** — Added scenario: `Assert "I run cron" uses fresh request time`.
- **`composer.json`** — Bumped `drupal/drupal-driver` requirement to `^2.4.2`.

## Test plan

- [ ] Run `ahoy test-bdd-drupal tests/behat/features/api.feature:34` to verify the new scenario passes.
- [ ] Run full `ahoy test-bdd-drupal` to confirm no regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated drupal-driver dependency to version 2.4.2.

* **Tests**
  * Added cron execution timing validation tests to improve reliability verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->