### PR TITLE
[#670] Always create fresh user in role-based login steps

### DIFF
--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -55,30 +55,27 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @Given I am logged in as a/an :role
    */
   public function assertAuthenticatedByRole(string $role): void {
-    // Check if a user with this role is already logged in.
-    if (!$this->loggedInWithRole($role)) {
-      // Create user (and project)
-      $user = (object) [
-        'name' => $this->getRandom()->name(8),
-        'pass' => $this->getRandom()->name(16),
-        'role' => $role,
-      ];
-      $user->mail = $user->name . '@example.com';
+    // Create user (and project)
+    $user = (object) [
+      'name' => $this->getRandom()->name(8),
+      'pass' => $this->getRandom()->name(16),
+      'role' => $role,
+    ];
+    $user->mail = $user->name . '@example.com';
 
-      $this->userCreate($user);
+    $this->userCreate($user);
 
-      $roles = explode(',', $role);
-      $roles = array_map(trim(...), $roles);
-      foreach ($roles as $role) {
-        if (!in_array(strtolower($role), ['authenticated', 'authenticated user'])) {
-          // Only add roles other than 'authenticated user'.
-          $this->getDriver()->userAddRole($user, $role);
-        }
+    $roles = explode(',', $role);
+    $roles = array_map(trim(...), $roles);
+    foreach ($roles as $role) {
+      if (!in_array(strtolower($role), ['authenticated', 'authenticated user'])) {
+        // Only add roles other than 'authenticated user'.
+        $this->getDriver()->userAddRole($user, $role);
       }
-
-      // Login.
-      $this->login($user);
     }
+
+    // Login.
+    $this->login($user);
   }
 
   /**
@@ -93,35 +90,32 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @Given I am logged in as a user with the :role role(s) and I have the following fields:
    */
   public function assertAuthenticatedByRoleWithGivenFields(string $role, TableNode $fields): void {
-    // Check if a user with this role is already logged in.
-    if (!$this->loggedInWithRole($role)) {
-      // Create user (and project)
-      $user = (object) [
-        'name' => $this->getRandom()->name(8),
-        'pass' => $this->getRandom()->name(16),
-        'role' => $role,
-      ];
-      $user->mail = $user->name . '@example.com';
+    // Create user (and project)
+    $user = (object) [
+      'name' => $this->getRandom()->name(8),
+      'pass' => $this->getRandom()->name(16),
+      'role' => $role,
+    ];
+    $user->mail = $user->name . '@example.com';
 
-      // Assign fields to user before creation.
-      foreach ($fields->getRowsHash() as $field => $value) {
-        $user->{$field} = $value;
-      }
-
-      $this->userCreate($user);
-
-      $roles = explode(',', $role);
-      $roles = array_map(trim(...), $roles);
-      foreach ($roles as $role) {
-        if (!in_array(strtolower($role), ['authenticated', 'authenticated user'])) {
-          // Only add roles other than 'authenticated user'.
-          $this->getDriver()->userAddRole($user, $role);
-        }
-      }
-
-      // Login.
-      $this->login($user);
+    // Assign fields to user before creation.
+    foreach ($fields->getRowsHash() as $field => $value) {
+      $user->{$field} = $value;
     }
+
+    $this->userCreate($user);
+
+    $roles = explode(',', $role);
+    $roles = array_map(trim(...), $roles);
+    foreach ($roles as $role) {
+      if (!in_array(strtolower($role), ['authenticated', 'authenticated user'])) {
+        // Only add roles other than 'authenticated user'.
+        $this->getDriver()->userAddRole($user, $role);
+      }
+    }
+
+    // Login.
+    $this->login($user);
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -496,8 +496,13 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    *
    * @return bool
    *   Returns TRUE if the current logged in user has this role (or roles).
+   *
+   * @deprecated in drupalextension:5.3.0 and is removed from
+   *   drupalextension:6.0.0. Role-based login steps no longer check the
+   *   current user's role before creating a new user.
    */
   public function loggedInWithRole($role): bool {
+    @trigger_error("loggedInWithRole() is deprecated in drupalextension:5.3.0 and is removed from drupalextension:6.0.0. Role-based login steps no longer check the current user's role before creating a new user.", E_USER_DEPRECATED);
     return $this->loggedIn() && $this->getUserManager()->currentUserHasRole($role);
   }
 

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -24,6 +24,11 @@ class FeatureContext extends RawDrupalContext {
   use TagTrait;
 
   /**
+   * The previously remembered user name.
+   */
+  protected string $previousUserName = '';
+
+  /**
    * Stop Mink sessions before scenarios that will spawn sub-processes.
    *
    * When a @javascript scenario runs in the parent process, Mink keeps the
@@ -340,6 +345,37 @@ class FeatureContext extends RawDrupalContext {
       $actualTime = \Drupal::state()->get('behat_test.cron_actual_time');
       throw new ExpectationException(
         sprintf('Cron request time drift is %d seconds (request_time=%d, actual_time=%d), expected less than %d.', $drift, $requestTime, $actualTime, $seconds),
+        $this->getSession()->getDriver()
+      );
+    }
+  }
+
+  /**
+   * Stores the current user name for later comparison.
+   *
+   * @Given I remember the current user name
+   */
+  public function testRememberCurrentUserName(): void {
+    $user = $this->getUserManager()->getCurrentUser();
+    if (!$user) {
+      throw new \LogicException('No current user in the user manager.');
+    }
+    $this->previousUserName = $user->name;
+  }
+
+  /**
+   * Asserts the current user name differs from the previously remembered one.
+   *
+   * @Then the current user should be different from the remembered user
+   */
+  public function testAssertDifferentUser(): void {
+    $user = $this->getUserManager()->getCurrentUser();
+    if (!$user) {
+      throw new \LogicException('No current user in the user manager.');
+    }
+    if ($user->name === $this->previousUserName) {
+      throw new ExpectationException(
+        sprintf('Expected a different user but got the same user "%s".', $user->name),
         $this->getSession()->getDriver()
       );
     }

--- a/tests/behat/features/drupal_context.feature
+++ b/tests/behat/features/drupal_context.feature
@@ -29,6 +29,13 @@ Feature: DrupalContext coverage gaps
     Then I should see the link "My account"
 
   @test-drupal @api
+  Scenario: Assert "Given I am logged in as a user with the :role role" always creates a fresh user
+    Given I am logged in as a user with the "authenticated user" role
+    And I remember the current user name
+    When I am logged in as a user with the "authenticated user" role
+    Then the current user should be different from the remembered user
+
+  @test-drupal @api
   Scenario: Assert "Given I am an anonymous user" passes
     Given I am an anonymous user
     When I visit "/user/login"


### PR DESCRIPTION
## Summary

- Removed the `loggedInWithRole()` guard from `assertAuthenticatedByRole()` and `assertAuthenticatedByRoleWithGivenFields()` so they always create a fresh user, matching the behavior of `assertLoggedInWithPermissions()`.
- Deprecated `loggedInWithRole()` in `RawDrupalContext` (deprecated in 5.3.0, removal in 6.0.0).
- Added test scenario verifying a second role-based login creates a different user.

Fixes #670.

## Test plan

- [x] All Behat Drupal API tests pass (119 scenarios)
- [x] All blackbox tests pass (91 scenarios)
- [x] All PHPSpec tests pass (77 examples)
- [x] Lint passes (PHP Parallel Lint, PHPCS, PHPStan, Rector, Gherkin Lint)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication behavior to consistently create fresh user instances when logging in with assigned roles, eliminating conditional logic that could skip user creation.

* **Deprecations**
  * Deprecated authentication method; will be removed in a future release.

* **Tests**
  * Added test scenario verifying fresh user creation on repeated authentication attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->