### PR TITLE
[#360] Added validation for non-existent entity fields in parseEntityFields().

### DIFF
--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -296,33 +296,85 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   }
 
   /**
-   * Parses the field values and turns them into the format expected by Drupal.
+   * Parses field values from Behat table cells into Drupal's field format.
    *
-   * Multiple values in a single field must be separated by commas. Wrap the
-   * field value in double quotes in case it should contain a comma.
+   * Only configurable fields (those for which the driver's isField() returns
+   * TRUE) are parsed. Base properties like "title" or "status" pass through
+   * unchanged.
    *
-   * Compound field properties are identified using a ':' operator, either in
-   * the column heading or in the cell. If multiple properties are present in a
-   * single cell, they must be separated using ' - ', and values should not
-   * contain ':' or ' - '.
+   * Single value:
+   * @code
+   * | title       | field_color |
+   * | My article  | Red         |
+   * @endcode
+   * Result: field_color = ['Red'].
    *
-   * Possible formats for the values:
-   *   A
-   *   A, B, "a value, containing a comma"
-   *   A - B
-   *   x: A - y: B
-   *   A - B, C - D, "E - F"
-   *   x: A - y: B,  x: C - y: D,  "x: E - y: F"
+   * Multiple values (comma-separated):
+   * @code
+   * | field_tags        |
+   * | Sports, Politics  |
+   * @endcode
+   * Result: field_tags = ['Sports', 'Politics'].
+   * Wrap in double quotes to include a literal comma: "a value, with comma".
    *
-   * See field_handlers.feature for examples of usage.
+   * Compound columns using ' - ' separator (e.g. link field with uri + title):
+   * @code
+   * | field_link                        |
+   * | http://example.com - Example site |
+   * @endcode
+   * Result: field_link = [['http://example.com', 'Example site']].
+   *
+   * Named compound columns using inline 'key: value' syntax:
+   * @code
+   * | field_link                                    |
+   * | uri: http://example.com - title: Example site |
+   * @endcode
+   * Result: field_link = [
+   *   ['uri' => 'http://example.com', 'title' => 'Example site']
+   * ].
+   *
+   * Multi-value compound (comma separates each value set):
+   * @code
+   * | field_link                                                 |
+   * | uri: /about - title: About, uri: /contact - title: Contact |
+   * @endcode
+   * Result: field_link = [
+   *   ['uri' => '/about', 'title' => 'About'],
+   *   ['uri' => '/contact', 'title' => 'Contact'],
+   * ].
+   *
+   * Multicolumn table headers using 'field:column' and ':column' syntax
+   * (useful when compound values contain commas or separators):
+   * @code
+   * | field_link:uri          | :title       |
+   * | http://example.com      | Example site |
+   * @endcode
+   * Result: field_link = [
+   *   ['uri' => 'http://example.com', 'title' => 'Example site']
+   * ].
+   *
+   * Multi-value multicolumn (comma-separated within each cell):
+   * @code
+   * | field_link:uri          | :title              |
+   * | /about, /contact        | About, Contact      |
+   * @endcode
+   * Result: field_link = [
+   *   ['uri' => '/about', 'title' => 'About'],
+   *   ['uri' => '/contact', 'title' => 'Contact'],
+   * ].
+   *
+   * Blank values remove the field from the entity so Drupal applies its
+   * default.
    *
    * @param string $entity_type
-   *   The entity type.
+   *   The entity type (e.g. 'node', 'taxonomy_term', 'user').
    * @param \stdClass $entity
-   *   An object containing the entity properties and fields as properties.
+   *   The entity object. Recognised field properties are replaced in-place
+   *   with structured arrays; other properties are left unchanged.
    *
    * @throws \Exception
-   *   Thrown when a field name is invalid.
+   *   Thrown when a column continuation (':column') appears without a
+   *   preceding 'field:column' header.
    */
   public function parseEntityFields(string $entity_type, \stdClass $entity): void {
     $multicolumnField = '';
@@ -373,6 +425,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
               }
             }
           }
+
           // Use the column name if we are tracking a multicolumn field.
           if ($isMulticolumn) {
             $multicolumnFields[$multicolumnField][$key][$multicolumnColumn] = $columns;
@@ -382,6 +435,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
             $values[] = $columns;
           }
         }
+
         // Replace regular fields inline in the entity after parsing.
         if (!$isMulticolumn) {
           $entity->$fieldName = $values;

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -372,7 +372,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    *   The entity object. Recognised field properties are replaced in-place
    *   with structured arrays; other properties are left unchanged.
    *
-   * @throws \Exception
+   * @throws \RuntimeException
    *   Thrown when a column continuation (':column') appears without a
    *   preceding 'field:column' header.
    */
@@ -395,7 +395,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
       elseif (empty($multicolumnField)) {
         // If a field name starts with a ':' but we are not yet tracking a
         // multicolumn field we don't know to which field this belongs.
-        throw new \Exception('Field name missing for ' . $field);
+        throw new \RuntimeException('Field name missing for ' . $field);
       }
       else {
         // Update the column name if the field name starts with a ':' and we are

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -371,12 +371,17 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    * @param \stdClass $entity
    *   The entity object. Recognised field properties are replaced in-place
    *   with structured arrays; other properties are left unchanged.
+   * @param string[] $ignored_properties
+   *   Property names to skip during validation. Use this for properties that
+   *   are consumed by the driver (e.g. 'role', 'vocabulary_machine_name') but
+   *   are not real Drupal fields.
    *
    * @throws \RuntimeException
    *   Thrown when a column continuation (':column') appears without a
-   *   preceding 'field:column' header.
+   *   preceding 'field:column' header, or when a property is neither a
+   *   configurable field, a base field, nor in the ignored list.
    */
-  public function parseEntityFields(string $entity_type, \stdClass $entity): void {
+  public function parseEntityFields(string $entity_type, \stdClass $entity, array $ignored_properties = []): void {
     $multicolumnField = '';
     $multicolumnColumn = '';
     $multicolumnFields = [];
@@ -445,6 +450,9 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
           }
         }
       }
+      elseif (!$this->getDriver()->isBaseField($entity_type, $fieldName) && !in_array($fieldName, $ignored_properties, TRUE)) {
+        throw new \RuntimeException(sprintf('Field "%s" does not exist on entity type "%s".', $fieldName, $entity_type));
+      }
     }
 
     // Add the multicolumn fields to the entity.
@@ -464,7 +472,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    */
   public function userCreate(\stdClass $user): \stdClass {
     $this->dispatchHooks('BeforeUserCreateScope', $user);
-    $this->parseEntityFields('user', $user);
+    $this->parseEntityFields('user', $user, ['role']);
     $this->getDriver()->userCreate($user);
     $this->dispatchHooks('AfterUserCreateScope', $user);
     $this->userManager->addUser($user);
@@ -479,7 +487,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    */
   public function termCreate(\stdClass $term) {
     $this->dispatchHooks('BeforeTermCreateScope', $term);
-    $this->parseEntityFields('taxonomy_term', $term);
+    $this->parseEntityFields('taxonomy_term', $term, ['vocabulary_machine_name']);
     $saved = $this->getDriver()->createTerm($term);
     $this->dispatchHooks('AfterTermCreateScope', $saved);
     $this->terms[] = $saved;

--- a/tests/behat/features/drupal_context.feature
+++ b/tests/behat/features/drupal_context.feature
@@ -221,3 +221,18 @@ Feature: DrupalContext coverage gaps
       """
       no "Nonexistent button" button
       """
+
+  @test-drupal @api
+  Scenario: Assert "Given :type content:" fails for orphaned multicolumn continuation
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given "article" content:
+        | :orphan |
+        | value   |
+      """
+    When I run behat with drupal profile
+    Then it should fail with an exception:
+      """
+      Field name missing for :orphan
+      """

--- a/tests/behat/features/drupal_context.feature
+++ b/tests/behat/features/drupal_context.feature
@@ -236,3 +236,18 @@ Feature: DrupalContext coverage gaps
       """
       Field name missing for :orphan
       """
+
+  @test-drupal @api
+  Scenario: Assert "Given :type content:" fails for non-existent field
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given "article" content:
+        | title | field_does_not_exist |
+        | test  | some value           |
+      """
+    When I run behat with drupal profile
+    Then it should fail with an exception:
+      """
+      Field "field_does_not_exist" does not exist on entity type "node".
+      """

--- a/tests/phpunit/src/RawDrupalContextTest.php
+++ b/tests/phpunit/src/RawDrupalContextTest.php
@@ -59,7 +59,7 @@ class RawDrupalContextTest extends TestCase {
     }
 
     if ($exception !== NULL) {
-      $this->expectException(\Exception::class);
+      $this->expectException(\RuntimeException::class);
       $this->expectExceptionMessage($exception);
     }
 

--- a/tests/phpunit/src/RawDrupalContextTest.php
+++ b/tests/phpunit/src/RawDrupalContextTest.php
@@ -38,130 +38,140 @@ class RawDrupalContextTest extends TestCase {
   }
 
   /**
-   * Tests parsing simple entity fields.
+   * Tests parsing entity fields.
    */
-  #[DataProvider('dataProviderParseEntityFieldsSimple')]
-  public function testParseEntityFieldsSimple(string $input, array $expected): void {
-    $entity = (object) ['field_test' => $input];
-    $this->context->parseEntityFields('node', $entity);
-    $this->assertSame($expected, $entity->field_test);
+  #[DataProvider('dataProviderParseEntityFields')]
+  public function testParseEntityFields(array $input, array $expected, ?array $fields = NULL, ?string $exception = NULL): void {
+    if ($fields !== NULL) {
+      $driver = $this->createMock(DriverInterface::class);
+      $driver->method('isField')->willReturnCallback(
+        fn(string $entityType, string $fieldName): bool => in_array($fieldName, $fields, TRUE)
+      );
+
+      $drupal = $this->createMock(DrupalDriverManagerInterface::class);
+      $drupal->method('getDriver')->willReturn($driver);
+
+      $context = new RawDrupalContext();
+      $context->setDrupal($drupal);
+    }
+    else {
+      $context = $this->context;
+    }
+
+    if ($exception !== NULL) {
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage($exception);
+    }
+
+    $entity = (object) $input;
+    $context->parseEntityFields('node', $entity);
+    $this->assertSame($expected, (array) $entity);
   }
 
   /**
-   * Provides data for testParseEntityFieldsSimple().
+   * Provides data for testParseEntityFields().
    */
-  public static function dataProviderParseEntityFieldsSimple(): \Iterator {
+  public static function dataProviderParseEntityFields(): \Iterator {
+    // All properties recognized as fields.
     yield 'single value' => [
-      'A',
-          ['A'],
+      ['field_test' => 'A'],
+      ['field_test' => ['A']],
     ];
     yield 'multiple csv values' => [
-      'A, B, C',
-          ['A', 'B', 'C'],
+      ['field_test' => 'A, B, C'],
+      ['field_test' => ['A', 'B', 'C']],
     ];
     yield 'csv with quoted comma' => [
-      'A, "a value, containing a comma"',
-          ['A', 'a value, containing a comma'],
+      ['field_test' => 'A, "a value, containing a comma"'],
+      ['field_test' => ['A', 'a value, containing a comma']],
+    ];
+    yield 'compound separator' => [
+      ['field_test' => 'A - B'],
+      ['field_test' => [['A', 'B']]],
+    ];
+    yield 'inline named columns' => [
+      ['field_test' => 'x: A - y: B'],
+      ['field_test' => [['x' => 'A', 'y' => 'B']]],
+    ];
+    yield 'multi-value compound' => [
+      ['field_test' => 'A - B, C - D'],
+      ['field_test' => [['A', 'B'], ['C', 'D']]],
+    ];
+    yield 'multi-value named columns' => [
+      ['field_test' => 'x: A - y: B, x: C - y: D'],
+      ['field_test' => [['x' => 'A', 'y' => 'B'], ['x' => 'C', 'y' => 'D']]],
+    ];
+    yield 'blank value unsets field' => [
+      ['field_test' => ''],
+      [],
+    ];
+    yield 'multiple fields on one entity' => [
+      ['field_a' => 'X', 'field_b' => 'Y, Z'],
+      ['field_a' => ['X'], 'field_b' => ['Y', 'Z']],
+    ];
+    yield 'multicolumn' => [
+      ['field_test:col_a' => 'value_a', ':col_b' => 'value_b'],
+      ['field_test' => [0 => ['col_a' => 'value_a', 'col_b' => 'value_b']]],
+    ];
+    yield 'multicolumn multiple values' => [
+      ['field_test:col_a' => 'A1, A2', ':col_b' => 'B1, B2'],
+      ['field_test' => [0 => ['col_a' => 'A1', 'col_b' => 'B1'], 1 => ['col_a' => 'A2', 'col_b' => 'B2']]],
+    ];
+    yield 'multicolumn blank values preserved' => [
+      ['field_test:col_a' => '', ':col_b' => ''],
+      ['field_test' => [0 => ['col_a' => '', 'col_b' => '']]],
+    ];
+
+    // Selective field recognition.
+    yield 'non-field property left untouched' => [
+      ['title' => 'Some title'],
+      ['title' => 'Some title'],
+      [],
+    ];
+    yield 'non-field with compound separator untouched' => [
+      ['title' => 'A - B'],
+      ['title' => 'A - B'],
+      [],
+    ];
+    yield 'multiple non-field properties untouched' => [
+      ['title' => 'Foo', 'status' => '1', 'uid' => '5'],
+      ['title' => 'Foo', 'status' => '1', 'uid' => '5'],
+      [],
+    ];
+    yield 'mixed field and non-field properties' => [
+      ['title' => 'Foo', 'field_test' => 'bar'],
+      ['title' => 'Foo', 'field_test' => ['bar']],
+      ['field_test'],
+    ];
+    yield 'field parsed while non-fields preserved' => [
+      ['title' => 'Foo', 'field_a' => 'X - Y', 'field_b' => 'A, B', 'status' => '1'],
+      ['title' => 'Foo', 'field_a' => [['X', 'Y']], 'field_b' => ['A', 'B'], 'status' => '1'],
+      ['field_a', 'field_b'],
+    ];
+    yield 'multicolumn non-field left untouched' => [
+      ['field_test:col_a' => 'value_a', ':col_b' => 'value_b'],
+      ['field_test:col_a' => 'value_a', ':col_b' => 'value_b'],
+      [],
+    ];
+
+    // Exception cases.
+    yield 'orphaned column throws' => [
+      [':orphan' => 'value'],
+      [],
+      NULL,
+      'Field name missing for :orphan',
     ];
   }
 
   /**
-   * Tests parsing entity fields with compound separator.
+   * Tests that entity type is passed correctly to the driver.
    */
-  public function testParseEntityFieldsCompoundSeparator(): void {
-    $entity = (object) ['field_test' => 'A - B'];
-    $this->context->parseEntityFields('node', $entity);
-    $this->assertSame([['A', 'B']], $entity->field_test);
-  }
-
-  /**
-   * Tests parsing entity fields with inline named columns.
-   */
-  public function testParseEntityFieldsInlineNamedColumns(): void {
-    $entity = (object) ['field_test' => 'x: A - y: B'];
-    $this->context->parseEntityFields('node', $entity);
-    $this->assertSame([['x' => 'A', 'y' => 'B']], $entity->field_test);
-  }
-
-  /**
-   * Tests parsing multi-value compound entity fields.
-   */
-  public function testParseEntityFieldsMultiValueCompound(): void {
-    $entity = (object) ['field_test' => 'A - B, C - D'];
-    $this->context->parseEntityFields('node', $entity);
-    $this->assertSame([['A', 'B'], ['C', 'D']], $entity->field_test);
-  }
-
-  /**
-   * Tests parsing multi-value named column entity fields.
-   */
-  public function testParseEntityFieldsMultiValueNamedColumns(): void {
-    $entity = (object) ['field_test' => 'x: A - y: B, x: C - y: D'];
-    $this->context->parseEntityFields('node', $entity);
-    $this->assertSame(
-          [['x' => 'A', 'y' => 'B'], ['x' => 'C', 'y' => 'D']],
-          $entity->field_test
-      );
-  }
-
-  /**
-   * Tests that blank field values are unset.
-   */
-  public function testParseEntityFieldsBlankValueUnsets(): void {
-    $entity = (object) ['field_test' => ''];
-    $this->context->parseEntityFields('node', $entity);
-    $this->assertObjectNotHasProperty('field_test', $entity);
-  }
-
-  /**
-   * Tests parsing multicolumn entity fields.
-   */
-  public function testParseEntityFieldsMulticolumn(): void {
-    $entity = (object) [
-      'field_test:col_a' => 'value_a',
-      ':col_b' => 'value_b',
-    ];
-    $this->context->parseEntityFields('node', $entity);
-    $this->assertSame(
-          [0 => ['col_a' => 'value_a', 'col_b' => 'value_b']],
-          $entity->field_test
-      );
-  }
-
-  /**
-   * Tests parsing multicolumn entity fields with multiple values.
-   */
-  public function testParseEntityFieldsMulticolumnMultipleValues(): void {
-    $entity = (object) [
-      'field_test:col_a' => 'A1, A2',
-      ':col_b' => 'B1, B2',
-    ];
-    $this->context->parseEntityFields('node', $entity);
-    $this->assertSame(
-          [
-            0 => ['col_a' => 'A1', 'col_b' => 'B1'],
-            1 => ['col_a' => 'A2', 'col_b' => 'B2'],
-          ],
-          $entity->field_test
-      );
-  }
-
-  /**
-   * Tests that orphaned columns throw an exception.
-   */
-  public function testParseEntityFieldsOrphanedColumnThrows(): void {
-    $entity = (object) [':orphan' => 'value'];
-    $this->expectException(\Exception::class);
-    $this->expectExceptionMessage('Field name missing for :orphan');
-    $this->context->parseEntityFields('node', $entity);
-  }
-
-  /**
-   * Tests that non-field properties are left untouched.
-   */
-  public function testParseEntityFieldsNonFieldUntouched(): void {
+  public function testParseEntityFieldsPassesEntityType(): void {
     $driver = $this->createMock(DriverInterface::class);
-    $driver->method('isField')->willReturn(FALSE);
+    $driver->expects($this->once())
+      ->method('isField')
+      ->with('taxonomy_term', 'field_test')
+      ->willReturn(TRUE);
 
     $drupal = $this->createMock(DrupalDriverManagerInterface::class);
     $drupal->method('getDriver')->willReturn($driver);
@@ -169,25 +179,8 @@ class RawDrupalContextTest extends TestCase {
     $context = new RawDrupalContext();
     $context->setDrupal($drupal);
 
-    $entity = (object) ['title' => 'Some title'];
-    $context->parseEntityFields('node', $entity);
-    $this->assertSame('Some title', $entity->title);
-  }
-
-  /**
-   * Tests that blank values in multicolumn fields are preserved.
-   */
-  public function testParseEntityFieldsMulticolumnBlankValuePreserved(): void {
-    $entity = (object) [
-      'field_test:col_a' => '',
-      ':col_b' => '',
-    ];
-    $this->context->parseEntityFields('node', $entity);
-    $this->assertObjectHasProperty('field_test', $entity);
-    $this->assertSame(
-          [0 => ['col_a' => '', 'col_b' => '']],
-          $entity->field_test
-      );
+    $entity = (object) ['field_test' => 'value'];
+    $context->parseEntityFields('taxonomy_term', $entity);
   }
 
 }

--- a/tests/phpunit/src/RawDrupalContextTest.php
+++ b/tests/phpunit/src/RawDrupalContextTest.php
@@ -41,11 +41,14 @@ class RawDrupalContextTest extends TestCase {
    * Tests parsing entity fields.
    */
   #[DataProvider('dataProviderParseEntityFields')]
-  public function testParseEntityFields(array $input, array $expected, ?array $fields = NULL, ?string $exception = NULL): void {
+  public function testParseEntityFields(array $input, array $expected, ?array $fields = NULL, ?array $baseFields = NULL, ?string $exception = NULL, array $ignored_properties = []): void {
     if ($fields !== NULL) {
       $driver = $this->createMock(DriverInterface::class);
       $driver->method('isField')->willReturnCallback(
         fn(string $entityType, string $fieldName): bool => in_array($fieldName, $fields, TRUE)
+      );
+      $driver->method('isBaseField')->willReturnCallback(
+        fn(string $entityType, string $fieldName): bool => in_array($fieldName, $baseFields ?? [], TRUE)
       );
 
       $drupal = $this->createMock(DrupalDriverManagerInterface::class);
@@ -64,7 +67,7 @@ class RawDrupalContextTest extends TestCase {
     }
 
     $entity = (object) $input;
-    $context->parseEntityFields('node', $entity);
+    $context->parseEntityFields('node', $entity, $ignored_properties);
     $this->assertSame($expected, (array) $entity);
   }
 
@@ -122,36 +125,42 @@ class RawDrupalContextTest extends TestCase {
       ['field_test' => [0 => ['col_a' => '', 'col_b' => '']]],
     ];
 
-    // Selective field recognition.
-    yield 'non-field property left untouched' => [
+    // Selective field recognition (base fields pass through unchanged).
+    yield 'base field property left untouched' => [
       ['title' => 'Some title'],
       ['title' => 'Some title'],
       [],
+      ['title'],
     ];
-    yield 'non-field with compound separator untouched' => [
+    yield 'base field with compound separator untouched' => [
       ['title' => 'A - B'],
       ['title' => 'A - B'],
       [],
+      ['title'],
     ];
-    yield 'multiple non-field properties untouched' => [
+    yield 'multiple base field properties untouched' => [
       ['title' => 'Foo', 'status' => '1', 'uid' => '5'],
       ['title' => 'Foo', 'status' => '1', 'uid' => '5'],
       [],
+      ['title', 'status', 'uid'],
     ];
-    yield 'mixed field and non-field properties' => [
+    yield 'mixed field and base field properties' => [
       ['title' => 'Foo', 'field_test' => 'bar'],
       ['title' => 'Foo', 'field_test' => ['bar']],
       ['field_test'],
+      ['title'],
     ];
-    yield 'field parsed while non-fields preserved' => [
+    yield 'field parsed while base fields preserved' => [
       ['title' => 'Foo', 'field_a' => 'X - Y', 'field_b' => 'A, B', 'status' => '1'],
       ['title' => 'Foo', 'field_a' => [['X', 'Y']], 'field_b' => ['A', 'B'], 'status' => '1'],
       ['field_a', 'field_b'],
+      ['title', 'status'],
     ];
-    yield 'multicolumn non-field left untouched' => [
-      ['field_test:col_a' => 'value_a', ':col_b' => 'value_b'],
-      ['field_test:col_a' => 'value_a', ':col_b' => 'value_b'],
+    yield 'multicolumn base field left untouched' => [
+      ['title:col_a' => 'value_a', ':col_b' => 'value_b'],
+      ['title:col_a' => 'value_a', ':col_b' => 'value_b'],
       [],
+      ['title'],
     ];
 
     // Exception cases.
@@ -159,7 +168,47 @@ class RawDrupalContextTest extends TestCase {
       [':orphan' => 'value'],
       [],
       NULL,
+      NULL,
       'Field name missing for :orphan',
+    ];
+    yield 'non-existent field throws' => [
+      ['field_does_not_exist' => 'value'],
+      [],
+      [],
+      [],
+      'Field "field_does_not_exist" does not exist on entity type "node".',
+    ];
+    yield 'non-existent field among valid fields throws' => [
+      ['title' => 'Foo', 'field_tags' => 'A', 'field_fake' => 'B'],
+      [],
+      ['field_tags'],
+      ['title'],
+      'Field "field_fake" does not exist on entity type "node".',
+    ];
+    yield 'non-existent multicolumn field throws' => [
+      ['field_fake:col_a' => 'value'],
+      [],
+      [],
+      [],
+      'Field "field_fake" does not exist on entity type "node".',
+    ];
+
+    // Ignored properties.
+    yield 'ignored property passes validation' => [
+      ['role' => 'administrator', 'field_test' => 'A'],
+      ['role' => 'administrator', 'field_test' => ['A']],
+      ['field_test'],
+      [],
+      NULL,
+      ['role'],
+    ];
+    yield 'multiple ignored properties pass validation' => [
+      ['role' => 'editor', 'vocabulary_machine_name' => 'tags'],
+      ['role' => 'editor', 'vocabulary_machine_name' => 'tags'],
+      [],
+      [],
+      NULL,
+      ['role', 'vocabulary_machine_name'],
     ];
   }
 


### PR DESCRIPTION
Closes #360

## Summary

Added field validation to `parseEntityFields()` so that specifying a non-existent field in a Behat step (e.g. `field_does_not_exist`) now throws a `RuntimeException` instead of silently passing through. The method checks both `isField()` (configurable fields) and `isBaseField()` (base fields like `title`, `status`) before rejecting unknown properties. Driver-specific properties (`role` on users, `vocabulary_machine_name` on terms) are passed via an `$ignored_properties` parameter to avoid false positives. Also changed the existing orphaned-column exception from `\Exception` to `\RuntimeException`, rewrote the method's PHPDoc with comprehensive syntax examples, and consolidated the PHPUnit tests into a single data-provider-driven test method.

## Changes

### Field validation (`RawDrupalContext.php`)

- Added `elseif` branch after `isField()` that calls `isBaseField()` — if both return `FALSE` and the field is not in the ignored list, throws `RuntimeException` with message `Field "X" does not exist on entity type "Y".`
- Added `array $ignored_properties = []` parameter to `parseEntityFields()` for driver-consumed properties that aren't real Drupal fields.
- `userCreate()` now passes `['role']` and `termCreate()` passes `['vocabulary_machine_name']` as ignored properties.
- Changed orphaned-column exception from `\Exception` to `\RuntimeException`.
- Rewrote method docblock with `@code` examples covering all supported field value syntaxes.

### Tests (`RawDrupalContextTest.php`)

- Consolidated 11 separate test methods into one `testParseEntityFields()` driven by `dataProviderParseEntityFields()` (23 cases).
- Added test cases for: non-existent field throws, non-existent field among valid fields throws, non-existent multicolumn field throws, ignored properties pass validation.
- Mock setup now includes `isBaseField()` callback for selective field recognition tests.

### Behat integration tests (`drupal_context.feature`)

- Added negative scenario asserting non-existent field throws `RuntimeException`.
- Added negative scenario asserting orphaned multicolumn continuation throws `RuntimeException`.

## Before / After

```
Before                                      After
──────────────────────────────────────────  ──────────────────────────────────────────

Given "page" content:                       Given "page" content:
  | title | field_does_not_exist |            | title | field_does_not_exist |
  | test  | some value           |            | test  | some value           |
         ↓                                           ↓
  Silently ignored by Drupal's               RuntimeException: Field
  entity API — test passes                   "field_does_not_exist" does not
  even though the field is bogus             exist on entity type "node".

┌──────────────────────────┐                ┌──────────────────────────────────────┐
│   parseEntityFields()    │                │       parseEntityFields()            │
│                          │                │                                      │
│  isField()?──yes──parse  │                │  isField()?────yes────parse          │
│      │                   │                │      │                               │
│      no                  │                │      no                              │
│      │                   │                │      │                               │
│      └── pass through    │                │  isBaseField()?──yes── pass through  │
│          (silent)        │                │      │                               │
│                          │                │      no                              │
│                          │                │      │                               │
│                          │                │  ignored?───yes── pass through       │
│                          │                │      │                               │
│                          │                │      no                              │
│                          │                │      │                               │
│                          │                │      └── RuntimeException            │
└──────────────────────────┘                └──────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced field validation with improved error messages for missing or non-existent fields during content creation
  * More robust error handling with clearer exception details

* **Tests**
  * Expanded test coverage for field validation error scenarios and invalid field configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->