### PR TITLE
[#642] Added double-quote escaping to prevent compound separator splitting entity reference values.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -417,7 +417,12 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
           $value = trim((string) $value);
           $columns = $value;
           // Split up field columns if the ' - ' separator is present.
-          if (str_contains($value, ' - ')) {
+          // Skip splitting if the value was double-quoted in the original
+          // field value, allowing values like "Alpha - Bravo" to pass
+          // through as-is (e.g., entity reference titles with dashes).
+          // @see https://github.com/jhedstrom/drupalextension/issues/642
+          $wasQuoted = str_contains((string) $fieldValue, '"' . $value . '"');
+          if (!$wasQuoted && str_contains($value, ' - ')) {
             $columns = [];
             foreach (explode(' - ', $value) as $column) {
               // Check if it is an inline named column.

--- a/tests/behat/features/field_handlers.feature
+++ b/tests/behat/features/field_handlers.feature
@@ -35,6 +35,41 @@ Feature: FieldHandlers
     And I should see "1000"
     And I should see "Louisalaan 1"
 
+  # Entity reference values containing ' - ' must be double-quoted to prevent
+  # the compound column separator from splitting them.
+  # @see https://github.com/jhedstrom/drupalextension/issues/642
+  @test-drupal @api
+  Scenario: Test entity reference with compound separator in title
+    Given "page" content:
+      | title         |
+      | Alpha - Bravo |
+    When I am viewing a "post" content:
+      | title                | Post with ref     |
+      | field_post_reference | "Alpha - Bravo"   |
+    Then I should see "Alpha - Bravo"
+
+  # Unquoted entity reference values containing ' - ' are still split by the
+  # compound column separator, which breaks the entity query.
+  # @see https://github.com/jhedstrom/drupalextension/issues/642
+  @test-drupal @api
+  Scenario: Assert "Given :type content:" fails for unquoted entity reference title containing compound separator
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given "page" content:
+        | title         |
+        | Alpha - Bravo |
+      When I am viewing a "post" content:
+        | title                | Post with ref |
+        | field_post_reference | Alpha - Bravo |
+      Then I should see "Alpha - Bravo"
+      """
+    When I run behat with drupal profile
+    Then it should fail with a "Drupal\Core\Database\InvalidQueryException" exception:
+      """
+      must have an array compatible operator
+      """
+
   # This is identical to the previous test, but uses human readable names for
   # the field names. This is better from a BDD standpoint. Please have a look at
   # FeatureContext::transformPostContentTable() to see how the mapping between

--- a/tests/phpunit/src/RawDrupalContextTest.php
+++ b/tests/phpunit/src/RawDrupalContextTest.php
@@ -104,6 +104,18 @@ class RawDrupalContextTest extends TestCase {
       ['field_test' => 'x: A - y: B, x: C - y: D'],
       ['field_test' => [['x' => 'A', 'y' => 'B'], ['x' => 'C', 'y' => 'D']]],
     ];
+    yield 'quoted value with compound separator preserved' => [
+      ['field_test' => '"Alpha - Bravo"'],
+      ['field_test' => ['Alpha - Bravo']],
+    ];
+    yield 'quoted multi-value with compound separator preserved' => [
+      ['field_test' => '"Alpha - Bravo", "Charlie - Delta"'],
+      ['field_test' => ['Alpha - Bravo', 'Charlie - Delta']],
+    ];
+    yield 'mixed quoted and unquoted values' => [
+      ['field_test' => '"Alpha - Bravo", C - D'],
+      ['field_test' => ['Alpha - Bravo', ['C', 'D']]],
+    ];
     yield 'blank value unsets field' => [
       ['field_test' => ''],
       [],


### PR DESCRIPTION
Closes #642

## Summary

Entity reference field values containing ` - ` (the compound column separator) were incorrectly split into sub-columns, causing invalid Drupal queries when referencing entities whose titles include dashes. This fix detects double-quoted values in the raw field string and skips the compound separator splitting for those values, allowing titles like `"Alpha - Bravo"` to pass through as a single value.

## Workaround

Wrap entity reference values containing ` - ` in double quotes to prevent the compound separator from splitting them:

```gherkin
Given "page" content:
  | title         |
  | Alpha - Bravo |
When I am viewing a "post" content:
  | title                | Post with ref   |
  | field_post_reference | "Alpha - Bravo" |
Then I should see "Alpha - Bravo"
```

This is consistent with the existing convention for escaping commas in multi-value fields (e.g., `"Tag, three"`).

**Note:** A broader redesign of the inline compound syntax is being explored in #766 to address the root cause of these separator conflicts.

## Changes

### Core fix — `src/Drupal/DrupalExtension/Context/RawDrupalContext.php`

- Added a `$wasQuoted` check in `parseEntityFields()` that detects whether the trimmed value was wrapped in double quotes in the original field value string.
- When the value was quoted, the ` - ` splitting step is skipped entirely, preserving the value as-is (with quotes stripped by the existing `str_getcsv()` pass).

### Behat integration tests — `tests/behat/features/field_handlers.feature`

- Added a positive scenario: creates a `page` node titled `Alpha - Bravo`, then references it from a `post` node using the double-quoted syntax `"Alpha - Bravo"`, and asserts the title is rendered.
- Added a negative scenario: verifies that an unquoted `Alpha - Bravo` reference still fails with `Drupal\Core\Database\InvalidQueryException`, confirming the old behaviour is preserved for unquoted values.

### PHPUnit unit tests — `tests/phpunit/src/RawDrupalContextTest.php`

- Added three new data provider cases to `RawDrupalContextTest`:
  - Quoted single value with compound separator is preserved.
  - Quoted multi-value list where each value contains a separator.
  - Mixed list where one value is quoted (preserved) and another is unquoted (split).

## Before / After

```
Before
──────
Field value: Alpha - Bravo
                   │
          str_contains(' - ')
                   │ true
                   ▼
          explode(' - ', value)
                   │
          ┌────────┴────────┐
          │                 │
        "Alpha"           "Bravo"
          └────────┬────────┘
                   ▼
         columns = ['Alpha', 'Bravo']   ← invalid: splits entity title

After
─────
Field value: "Alpha - Bravo"
                   │
          wasQuoted? (raw contains '"Alpha - Bravo"')
                   │ true
                   ▼
          skip explode
                   │
                   ▼
         columns = 'Alpha - Bravo'      ← correct: passes title through
```
