### PR TITLE
Replaced regex annotation with Turnip in `BatchContext::iWaitForTheBatchJobToFinish()`.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -22,7 +22,7 @@
 
 
 <details>
-  <summary><code>@Given /^I wait for the batch job to finish$/</code></summary>
+  <summary><code>@Given I wait for the batch job to finish</code></summary>
 
 <br/>
 Wait for the Batch API to finish

--- a/src/Drupal/DrupalExtension/Context/BatchContext.php
+++ b/src/Drupal/DrupalExtension/Context/BatchContext.php
@@ -23,7 +23,7 @@ class BatchContext extends RawMinkContext
      * Given I wait for the batch job to finish
      * @endcode
      *
-     * @Given /^I wait for the batch job to finish$/
+     * @Given I wait for the batch job to finish
      */
     public function iWaitForTheBatchJobToFinish(): void
     {


### PR DESCRIPTION
## Summary

Replaced the regex-style Behat annotation in `BatchContext::iWaitForTheBatchJobToFinish()` with a plain Turnip-style annotation. The old annotation used the legacy `/^I wait for the batch job to finish$/` regex format; the new annotation uses the simpler `I wait for the batch job to finish` Turnip format, which is the preferred style in modern Behat. The generated `STEPS.md` documentation was updated to reflect this change.

## Changes

**`src/Drupal/DrupalExtension/Context/BatchContext.php`**
- Changed `@Given /^I wait for the batch job to finish$/` to `@Given I wait for the batch job to finish` — switches from regex to Turnip annotation style.

**`STEPS.md`**
- Updated the auto-generated step summary to display the Turnip-style annotation instead of the regex form.

## Before / After

```
Before:
  BatchContext::iWaitForTheBatchJobToFinish()
  ┌─────────────────────────────────────────────────────┐
  │ @Given /^I wait for the batch job to finish$/       │  ← regex annotation
  └─────────────────────────────────────────────────────┘

After:
  BatchContext::iWaitForTheBatchJobToFinish()
  ┌─────────────────────────────────────────────────────┐
  │ @Given I wait for the batch job to finish           │  ← Turnip annotation
  └─────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test step definition format for batch job completion testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->