### PR TITLE
Reformatted configuration trees to use hierarchical indentation and added formatter fences.

### DIFF
--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -97,122 +97,122 @@ class DrupalExtension implements ExtensionInterface {
    */
   public function configure(ArrayNodeDefinition $builder): void {
     // @formatter:off
+    // phpcs:disable
     $builder
       ->children()
-      ->scalarNode('default_driver')
-      ->defaultValue('blackbox')
-      ->info('Use "blackbox" to test remote site. See "api_driver" for easier integration.')
+        ->scalarNode('default_driver')
+          ->defaultValue('blackbox')
+          ->info('Use "blackbox" to test remote site. See "api_driver" for easier integration.')
+        ->end()
+        ->scalarNode('api_driver')
+          ->defaultValue('drush')
+          ->info('Bootstraps drupal through "drupal8" or "drush".')
+        ->end()
+        ->scalarNode('drush_driver')
+          ->defaultValue('drush')
+        ->end()
+        ->arrayNode('region_map')
+          ->info("Targeting content in specific regions can be accomplished once those regions have been defined." . PHP_EOL
+            . '  My region: "#css-selector"' . PHP_EOL
+            . '  Content: "#main .region-content"' . PHP_EOL
+            . '  Right sidebar: "#sidebar-second"' . PHP_EOL)
+          ->useAttributeAsKey('key')
+          ->prototype('variable')->end()
+        ->end()
+        ->arrayNode('text')
+          ->info(
+            'Text strings, such as Log out or the Username field can be altered via behat.yml if they vary from the default values.' . PHP_EOL
+            . '  login_url: "/user"' . PHP_EOL
+            . '  logout_url: "/user/logout"' . PHP_EOL
+            . '  logout_confirm_url: "/user/logout/confirm"' . PHP_EOL
+            . '  log_out: "Sign out"' . PHP_EOL
+            . '  log_in: "Sign in"' . PHP_EOL
+            . '  password_field: "Enter your password"' . PHP_EOL
+            . '  username_field: "Nickname"'
+          )
+          ->ignoreExtraKeys(FALSE)
+          ->addDefaultsIfNotSet()
+          ->children()
+            ->scalarNode('login_url')
+              ->defaultValue('/user')
+            ->end()
+            ->scalarNode('logout_url')
+              ->defaultValue('/user/logout')
+            ->end()
+            ->scalarNode('logout_confirm_url')
+              ->defaultValue('/user/logout/confirm')
+            ->end()
+            ->scalarNode('log_in')
+              ->defaultValue('Log in')
+            ->end()
+            ->scalarNode('log_out')
+              ->defaultValue('Log out')
+            ->end()
+            ->scalarNode('password_field')
+              ->defaultValue('Password')
+            ->end()
+            ->scalarNode('username_field')
+              ->defaultValue('Username')
+            ->end()
+          ->end()
+        ->end()
+        ->arrayNode('selectors')
+          ->ignoreExtraKeys(FALSE)
+          ->addDefaultsIfNotSet()
+          ->children()
+            ->scalarNode('message_selector')->end()
+            ->scalarNode('error_message_selector')->end()
+            ->scalarNode('success_message_selector')->end()
+            ->scalarNode('warning_message_selector')->end()
+            ->scalarNode('login_form_selector')
+              ->defaultValue('form#user-login,form#user-login-form')
+            ->end()
+            ->scalarNode('logged_in_selector')
+              ->defaultValue('body.logged-in,body.user-logged-in')
+            ->end()
+          ->end()
+        ->end()
+        // Drupal drivers.
+        ->arrayNode('blackbox')->end()
+        ->arrayNode('drupal')
+          ->children()
+            ->scalarNode('drupal_root')->end()
+          ->end()
+        ->end()
+        ->arrayNode('drush')
+          ->children()
+            ->scalarNode('alias')->end()
+            ->scalarNode('binary')->defaultValue('drush')->end()
+            ->scalarNode('root')->end()
+            ->scalarNode('global_options')->end()
+          ->end()
+        ->end()
+        // Subcontext paths.
+        ->arrayNode('subcontexts')
+          ->info(
+            'The Drupal Extension is capable of discovering additional step-definitions provided by subcontexts.' . PHP_EOL
+            . 'Module authors can provide these in files following the naming convention of foo.behat.inc. Once that module is enabled, the Drupal Extension will load these.' . PHP_EOL
+            . PHP_EOL
+            . 'Additional subcontexts can be loaded by either placing them in the bootstrap directory (typically features/bootstrap) or by adding them to behat.yml.'
+          )
+          ->addDefaultsIfNotSet()
+          ->children()
+            ->arrayNode('paths')
+              ->info(
+                '- /path/to/additional/subcontexts' . PHP_EOL
+                . '- /another/path'
+              )
+              ->useAttributeAsKey('key')
+              ->prototype('variable')->end()
+            ->end()
+            ->scalarNode('autoload')
+              ->defaultValue(TRUE)
+            ->end()
+          ->end()
+        ->end()
       ->end()
-      ->scalarNode('api_driver')
-      ->defaultValue('drush')
-      ->info('Bootstraps drupal through "drupal8" or "drush".')
-      ->end()
-      ->scalarNode('drush_driver')
-      ->defaultValue('drush')
-      ->end()
-      ->arrayNode('region_map')
-      ->info("Targeting content in specific regions can be accomplished once those regions have been defined." . PHP_EOL
-                      . '  My region: "#css-selector"' . PHP_EOL
-                      . '  Content: "#main .region-content"' . PHP_EOL
-                      . '  Right sidebar: "#sidebar-second"' . PHP_EOL)
-      ->useAttributeAsKey('key')
-      ->prototype('variable')
-      ->end()
-      ->end()
-      ->arrayNode('text')
-      ->info(
-                      'Text strings, such as Log out or the Username field can be altered via behat.yml if they vary from the default values.' . PHP_EOL
-                      . '  login_url: "/user"' . PHP_EOL
-                      . '  logout_url: "/user/logout"' . PHP_EOL
-                      . '  logout_confirm_url: "/user/logout/confirm"' . PHP_EOL
-                      . '  log_out: "Sign out"' . PHP_EOL
-                      . '  log_in: "Sign in"' . PHP_EOL
-                      . '  password_field: "Enter your password"' . PHP_EOL
-                      . '  username_field: "Nickname"'
-                  )
-      ->ignoreExtraKeys(FALSE)
-      ->addDefaultsIfNotSet()
-      ->children()
-      ->scalarNode('login_url')
-      ->defaultValue('/user')
-      ->end()
-      ->scalarNode('logout_url')
-      ->defaultValue('/user/logout')
-      ->end()
-      ->scalarNode('logout_confirm_url')
-      ->defaultValue('/user/logout/confirm')
-      ->end()
-      ->scalarNode('log_in')
-      ->defaultValue('Log in')
-      ->end()
-      ->scalarNode('log_out')
-      ->defaultValue('Log out')
-      ->end()
-      ->scalarNode('password_field')
-      ->defaultValue('Password')
-      ->end()
-      ->scalarNode('username_field')
-      ->defaultValue('Username')
-      ->end()
-      ->end()
-      ->end()
-      ->arrayNode('selectors')
-      ->ignoreExtraKeys(FALSE)
-      ->addDefaultsIfNotSet()
-      ->children()
-      ->scalarNode('message_selector')->end()
-      ->scalarNode('error_message_selector')->end()
-      ->scalarNode('success_message_selector')->end()
-      ->scalarNode('warning_message_selector')->end()
-      ->scalarNode('login_form_selector')
-      ->defaultValue('form#user-login,form#user-login-form')
-      ->end()
-      ->scalarNode('logged_in_selector')
-      ->defaultValue('body.logged-in,body.user-logged-in')
-      ->end()
-      ->end()
-      ->end()
-    // Drupal drivers.
-      ->arrayNode('blackbox')
-      ->end()
-      ->arrayNode('drupal')
-      ->children()
-      ->scalarNode('drupal_root')->end()
-      ->end()
-      ->end()
-      ->arrayNode('drush')
-      ->children()
-      ->scalarNode('alias')->end()
-      ->scalarNode('binary')->defaultValue('drush')->end()
-      ->scalarNode('root')->end()
-      ->scalarNode('global_options')->end()
-      ->end()
-      ->end()
-    // Subcontext paths.
-      ->arrayNode('subcontexts')
-      ->info(
-                      'The Drupal Extension is capable of discovering additional step-definitions provided by subcontexts.' . PHP_EOL
-                      . 'Module authors can provide these in files following the naming convention of foo.behat.inc. Once that module is enabled, the Drupal Extension will load these.' . PHP_EOL
-                      . PHP_EOL
-                      . 'Additional subcontexts can be loaded by either placing them in the bootstrap directory (typically features/bootstrap) or by adding them to behat.yml.'
-                  )
-      ->addDefaultsIfNotSet()
-      ->children()
-      ->arrayNode('paths')
-      ->info(
-                              '- /path/to/additional/subcontexts' . PHP_EOL
-                              . '- /another/path'
-                          )
-      ->useAttributeAsKey('key')
-      ->prototype('variable')->end()
-      ->end()
-      ->scalarNode('autoload')
-      ->defaultValue(TRUE)
-      ->end()
-      ->end()
-      ->end()
-      ->end()
-      ->end();
+    ->end();
+    // phpcs:enable
     // @formatter:on
   }
 

--- a/src/Drupal/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
+++ b/src/Drupal/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
@@ -70,13 +70,15 @@ class BrowserKitFactory extends BrowserKitFactoryOriginal {
    */
   public function configure(ArrayNodeDefinition $builder): void {
     // @formatter:off
+    // phpcs:disable
     $builder
       ->children()
-      ->arrayNode('guzzle_request_options')
-      ->prototype('variable')->end()
-      ->info("Guzzle request options. See \\GuzzleHttp\\RequestOptions. Defaults to ['allow_redirects' => false, 'cookies' => true].")
-      ->end()
+        ->arrayNode('guzzle_request_options')
+          ->prototype('variable')->end()
+          ->info("Guzzle request options. See \\GuzzleHttp\\RequestOptions. Defaults to ['allow_redirects' => false, 'cookies' => true].")
+        ->end()
       ->end();
+    // phpcs:enable
     // @formatter:on
   }
 

--- a/src/Drupal/MinkExtension/ServiceContainer/MinkExtension.php
+++ b/src/Drupal/MinkExtension/ServiceContainer/MinkExtension.php
@@ -36,13 +36,15 @@ class MinkExtension extends BaseMinkExtension {
 
     // Add extended options.
     // @formatter:off
+    // phpcs:disable
     $builder
       ->children()
-      ->scalarNode('ajax_timeout')
-      ->defaultValue(static::AJAX_TIMEOUT)
-      ->info(sprintf('Change the maximum time to wait for AJAX calls to complete. Defaults to %s seconds.', static::AJAX_TIMEOUT))
-      ->end()
+        ->scalarNode('ajax_timeout')
+          ->defaultValue(static::AJAX_TIMEOUT)
+          ->info(sprintf('Change the maximum time to wait for AJAX calls to complete. Defaults to %s seconds.', static::AJAX_TIMEOUT))
+        ->end()
       ->end();
+    // phpcs:enable
     // @formatter:on
   }
 


### PR DESCRIPTION
## Summary

Reformatted all three Symfony Config tree builder blocks to use hierarchical indentation that reflects the actual node nesting. Previously, all `->method()` calls were at the same indentation level, making the tree structure hard to read. Added `// phpcs:disable` / `// phpcs:enable` fences alongside the existing `// @formatter:off` fences to prevent automated code style fixers from flattening the indentation again.

## Changes

**Configuration tree indentation** (`DrupalExtension.php`, `MinkExtension.php`, `BrowserKitFactory.php`)
- Indented child nodes under `->children()` / `->end()` boundaries
- Indented node properties (`->defaultValue()`, `->info()`) under their node definition
- Aligned `->end()` calls with their opening node

**Formatter fences** (all three files)
- Added `// phpcs:disable` / `// phpcs:enable` around each tree block to prevent phpcbf from removing the indentation

## Before / After

```
BEFORE (flat):                    AFTER (hierarchical):

$builder                          $builder
  ->children()                      ->children()
  ->scalarNode('foo')                 ->scalarNode('foo')
  ->defaultValue('bar')                 ->defaultValue('bar')
  ->end()                             ->end()
  ->arrayNode('baz')                  ->arrayNode('baz')
  ->children()                          ->children()
  ->scalarNode('qux')                     ->scalarNode('qux')
  ->end()                                 ->end()
  ->end()                               ->end()
  ->end()                             ->end()
  ->end()                           ->end()
->end();                          ->end();
```
