### PR TITLE
[#314] Added parent term resolution in termCreate() with validation and tests.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -491,12 +491,49 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    *   The created term.
    */
   public function termCreate(\stdClass $term) {
+    // Resolve parent term name to tid before dispatching hooks or parsing
+    // fields. This allows users to specify a human-readable parent name in
+    // Gherkin tables and throws early if the parent cannot be found.
+    if (!empty($term->parent)) {
+      $parent = $this->getExistingTerm($term->parent, $term->vocabulary_machine_name);
+
+      if (!$parent instanceof \stdClass) {
+        throw new \RuntimeException(sprintf('Parent term "%s" not found in vocabulary "%s".', $term->parent, $term->vocabulary_machine_name));
+      }
+
+      $term->parent = $parent->tid;
+    }
+
     $this->dispatchHooks('BeforeTermCreateScope', $term);
     $this->parseEntityFields('taxonomy_term', $term, ['vocabulary_machine_name']);
+
     $saved = $this->getDriver()->createTerm($term);
+
     $this->dispatchHooks('AfterTermCreateScope', $saved);
     $this->terms[] = $saved;
+
     return $saved;
+  }
+
+  /**
+   * Returns an existing term created during the test.
+   *
+   * @param string $name
+   *   The term name to search for.
+   * @param string $vocabulary
+   *   The vocabulary machine name.
+   *
+   * @return \stdClass|null
+   *   The term object or NULL if no matching term was found.
+   */
+  protected function getExistingTerm(string $name, string $vocabulary): ?\stdClass {
+    foreach ($this->terms as $term) {
+      if ($term->name === $name && $term->vocabulary_machine_name === $vocabulary) {
+        return $term;
+      }
+    }
+
+    return NULL;
   }
 
   /**

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -428,6 +428,47 @@ class FeatureContext extends RawDrupalContext {
   }
 
   /**
+   * Asserts that a taxonomy term has the expected parent term.
+   *
+   * @param string $vocabulary
+   *   The vocabulary machine name.
+   * @param string $name
+   *   The term name to check.
+   * @param string $parentName
+   *   The expected parent term name.
+   *
+   * @Then the :vocabulary term :name should have parent :parent_name
+   */
+  public function testAssertTermParent(string $vocabulary, string $name, string $parentName): void {
+    $storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+    $terms = $storage->loadByProperties(['name' => $name, 'vid' => $vocabulary]);
+
+    if (empty($terms)) {
+      throw new \RuntimeException(sprintf('Term "%s" not found in vocabulary "%s".', $name, $vocabulary));
+    }
+
+    /** @var \Drupal\Core\Entity\FieldableEntityInterface $term */
+    $term = reset($terms);
+    $parentValues = $term->get('parent')->getValue();
+    $parentTid = (int) ($parentValues[0]['target_id'] ?? 0);
+
+    if ($parentTid === 0) {
+      throw new ExpectationException(sprintf('Term "%s" has no parent, expected "%s".', $name, $parentName), $this->getSession()->getDriver());
+    }
+
+    $parentTerm = $storage->load($parentTid);
+
+    if (!$parentTerm) {
+      throw new ExpectationException(sprintf('Parent term with tid %d not found for term "%s".', $parentTid, $name), $this->getSession()->getDriver());
+    }
+
+    $actualParentName = $parentTerm->label();
+    if ($actualParentName !== $parentName) {
+      throw new ExpectationException(sprintf('Term "%s" has parent "%s", expected "%s".', $name, $actualParentName, $parentName), $this->getSession()->getDriver());
+    }
+  }
+
+  /**
    * Throws a test assertion exception.
    *
    * @Given I throw a test assertion exception :calss with message :message

--- a/tests/behat/features/api.feature
+++ b/tests/behat/features/api.feature
@@ -107,6 +107,33 @@ Feature: DrupalContext general testing
     And I should see "Tag two"
 
   @test-drupal @api
+  Scenario: Create taxonomy terms with parent hierarchy
+    Given "tags" terms:
+      | name          | parent        |
+      | Root term     |               |
+      | Child term    | Root term     |
+      | Grandchild    | Child term    |
+      | Great-grandch | Grandchild    |
+    Then the "tags" term "Child term" should have parent "Root term"
+    And the "tags" term "Grandchild" should have parent "Child term"
+    And the "tags" term "Great-grandch" should have parent "Grandchild"
+
+  @test-drupal @api
+  Scenario: Assert "Given :vocabulary terms:" fails for non-existent parent term
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given "tags" terms:
+        | name   | parent              |
+        | Orphan | NonExistentParent99 |
+      """
+    When I run behat with drupal profile
+    Then it should fail with an exception:
+      """
+      Parent term "NonExistentParent99" not found in vocabulary "tags".
+      """
+
+  @test-drupal @api
   Scenario: Create terms using vocabulary title rather than machine name
     Given "Tags" terms:
       | name    |


### PR DESCRIPTION
Closes #314

## Summary

Added parent term resolution in `termCreate()` so users can specify a human-readable parent term name in Gherkin tables rather than a term ID. When a `parent` field is present, `termCreate()` looks up the named term in the same vocabulary among already-created terms and replaces the name with the corresponding `tid`. A `RuntimeException` is thrown early if the named parent does not exist in the test's term list, giving a clear error message before any driver call is made.

## Changes

### Core logic (`src/Drupal/DrupalExtension/Context/RawDrupalContext.php`)

- `termCreate()` now checks for a `parent` field before dispatching hooks. If present, it calls the new `getExistingTerm()` helper to resolve the name to a `tid`. Throws `\RuntimeException` if the parent is not found.
- Added protected `getExistingTerm(string $name, string $vocabulary): ?\stdClass` that searches `$this->terms` for a previously created term matching both name and vocabulary.

### Test helpers (`tests/behat/bootstrap/FeatureContext.php`)

- Added `testAssertTermParent()` step definition (`Then the :vocabulary term :name should have parent :parent_name`) that loads the term via the entity API, resolves its parent tid, and asserts the parent name matches.

### Behat feature tests (`tests/behat/features/api.feature`)

- Added positive scenario: creates a four-level term hierarchy (`Root term → Child term → Grandchild → Great-grandch`) and asserts each parent relationship.
- Added negative scenario: verifies that specifying a non-existent parent name causes `termCreate()` to throw a `RuntimeException` with a clear message.

## Before / After

```
Before
──────
termCreate($term)
  │
  ├── dispatchHooks('BeforeTermCreateScope', $term)
  ├── parseEntityFields(...)           ← parent passed as-is (name or tid)
  ├── getDriver()->createTerm($term)   ← driver receives raw value; may silently fail
  ├── dispatchHooks('AfterTermCreateScope', $saved)
  └── return $saved

After
─────
termCreate($term)
  │
  ├── [NEW] if $term->parent is set:
  │     ├── getExistingTerm(name, vocabulary)  ← searches $this->terms
  │     ├── throw RuntimeException             ← if parent not found
  │     └── $term->parent = $parent->tid       ← replace name with tid
  │
  ├── dispatchHooks('BeforeTermCreateScope', $term)
  ├── parseEntityFields(...)           ← parent already resolved to tid
  ├── getDriver()->createTerm($term)
  ├── dispatchHooks('AfterTermCreateScope', $saved)
  └── return $saved

getExistingTerm(name, vocabulary) [NEW]
  └── iterates $this->terms → returns \stdClass|null
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for creating taxonomy terms with parent relationships using human-readable parent term names
  * Enhanced error handling with clear messages when parent terms cannot be found

* **Tests**
  * Added test coverage for taxonomy term parent hierarchy scenarios and error cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->