### PR TITLE
Fix stale login state leaking between scenarios

### DIFF
--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -199,13 +199,16 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
       }
       $this->getDriver()->processBatch();
       $this->userManager->clearUsers();
-      // If the authentication manager supports logout, no need to check if the user is logged in.
-      if ($this->getAuthenticationManager() instanceof FastLogoutInterface) {
-        $this->logout(TRUE);
-      }
-      elseif ($this->loggedIn()) {
-        $this->logout();
-      }
+    }
+
+    // Always reset auth state, even if no users were created during the
+    // scenario. A scenario may log in as a pre-existing user without calling
+    // userCreate(), leaving stale session state for the next scenario.
+    if ($this->getAuthenticationManager() instanceof FastLogoutInterface) {
+      $this->logout(TRUE);
+    }
+    elseif (!$this->userManager->currentUserIsAnonymous()) {
+      $this->logout();
     }
   }
 

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -469,6 +469,36 @@ class FeatureContext extends RawDrupalContext {
   }
 
   /**
+   * Deletes the current user from the database and untracking it.
+   *
+   * Simulates a database reset between scenarios: the user is removed from
+   * the database and from the tracked users list, but the current user
+   * reference in the user manager is preserved. This makes hasUsers() return
+   * FALSE while a user is still marked as logged in.
+   *
+   * @Given I delete the current user from the database
+   */
+  public function testDeleteCurrentUserFromDatabase(): void {
+    $user = $this->getUserManager()->getCurrentUser();
+
+    if (!$user || empty($user->uid)) {
+      throw new \RuntimeException('No current user to delete.');
+    }
+
+    // Delete the user entity from the database.
+    $account = \Drupal::entityTypeManager()->getStorage('user')->load($user->uid);
+
+    if ($account) {
+      $account->delete();
+    }
+
+    // Remove the user from the tracked list so cleanUsers() won't attempt
+    // to delete it again (which would trigger a PHP warning). The current
+    // user reference is intentionally left set to simulate stale auth state.
+    $this->getUserManager()->removeUser($user->name);
+  }
+
+  /**
    * Throws a test assertion exception.
    *
    * @Given I throw a test assertion exception :calss with message :message

--- a/tests/behat/features/drupal_context.feature
+++ b/tests/behat/features/drupal_context.feature
@@ -56,6 +56,24 @@ Feature: DrupalContext coverage gaps
     Then I should see the text "Log in"
 
   @test-drupal @api
+  Scenario: Assert login state is reset between scenarios
+    Given some behat configuration
+    And a file named "features/stub.feature" with:
+      """
+      Feature: Login state across scenarios
+        @test-drupal @api
+        Scenario: One
+          Given I am logged in as a user with the "authenticated" role
+          And I delete the current user from the database
+
+        @test-drupal @api
+        Scenario: Two
+          Then I should be logged out on the backend
+      """
+    When I run behat with drupal profile
+    Then it should pass
+
+  @test-drupal @api
   Scenario: Assert "Given I am logged in as :name" fails for nonexistent user
     Given some behat configuration
     And scenario steps tagged with "@test-drupal @api":


### PR DESCRIPTION
## Summary

Fixes #641.

The `cleanUsers()` `@AfterScenario` hook only reset auth state (session + user manager) inside the `if (hasUsers())` block. When a scenario logged in as a pre-existing user without calling `userCreate()` — or when the database was reset between scenarios causing the tracked user list to become stale — `hasUsers()` returned `FALSE` and the logout was skipped entirely. This left the user manager's current user reference and the Mink session cookie intact, causing the next scenario to inherit stale login state.

### Before (bug)

```
cleanUsers()
│
├─ hasUsers()? ──NO──> return (auth state LEAKED)
│       │
│      YES
│       │
│       ├─ userDelete() each user
│       ├─ processBatch()
│       ├─ clearUsers()
│       └─ fastLogout() / logout()
│
└─ end
```

### After (fix)

```
cleanUsers()
│
├─ hasUsers()? ──NO──> skip deletion
│       │               │
│      YES              │
│       │               │
│       ├─ userDelete() │
│       ├─ processBatch()
│       └─ clearUsers() │
│                       │
├───────────────────────┘
│
├─ ALWAYS reset auth state:
│   ├─ FastLogout? ──YES──> fastLogout()
│   └─ NO
│       └─ currentUser set? ──YES──> logout()
│                             NO──> skip (already anonymous)
│
└─ end
```

### Changes

- **`RawDrupalContext::cleanUsers()`**: Moved the auth state reset (fast logout or regular logout) outside the `if (hasUsers())` guard so it runs unconditionally after every scenario. The non-fast-logout path now checks `currentUserIsAnonymous()` instead of `loggedIn()` to avoid unnecessary browser interaction when no one is logged in.
- **Behat regression test**: Added a subprocess test with two scenarios — the first logs in and deletes the user from the database (simulating a DB reset), the second verifies the user manager reports anonymous.

## Test plan

- [x] New Behat test fails without the fix (`User is still logged in in the manager`)
- [x] New Behat test passes with the fix
- [x] Full Behat suite passes (218 scenarios)
- [x] PHPUnit passes (270 tests)
- [x] PHPSpec passes (77 examples)
- [x] All lint checks pass