### PR TITLE
[#501] Fixed config backup using overridden value instead of original

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -111,6 +111,8 @@ commands:
       ahoy drush --yes pmu page_cache,big_pipe
       ahoy drush --yes en behat_test
 
+      ahoy cli "echo '\$config[\"system.site\"][\"name\"] = \"Overridden Site Name\";' >> build/web/sites/default/settings.php"
+
       ahoy drush cset core.date_format.olivero_medium pattern 'j F, Y'
       ahoy drush cset automated_cron.settings interval 0
       ahoy drush cset user.settings register visitors

--- a/src/Drupal/DrupalExtension/Context/ConfigContext.php
+++ b/src/Drupal/DrupalExtension/Context/ConfigContext.php
@@ -10,6 +10,7 @@ namespace Drupal\DrupalExtension\Context;
 
 use Behat\Behat\Context\TranslatableContext;
 use Behat\Gherkin\Node\TableNode;
+use Drupal\Driver\DrupalDriver;
 
 /**
  * Provides pre-built step definitions for interacting with Drupal config.
@@ -107,8 +108,14 @@ class ConfigContext extends RawDrupalContext implements TranslatableContext {
    *   Value to associate with identifier.
    */
   public function setConfig(string $name, string $key, mixed $value): void {
-    $backup = $this->getDriver()->configGet($name, $key);
-    $this->getDriver()->configSet($name, $key, $value);
+    $driver = $this->getDriver();
+    if ($driver instanceof DrupalDriver) {
+      $backup = $driver->getCore()->configGetOriginal($name, $key);
+    }
+    else {
+      $backup = $driver->configGet($name, $key);
+    }
+    $driver->configSet($name, $key, $value);
     if (!array_key_exists($name, $this->config)) {
       $this->config[$name][$key] = $backup;
       return;

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -469,6 +469,28 @@ class FeatureContext extends RawDrupalContext {
   }
 
   /**
+   * Asserts the original (non-overridden) config value matches the expected.
+   *
+   * @param string $name
+   *   The configuration object name.
+   * @param string $key
+   *   The configuration key.
+   * @param string $expected
+   *   The expected original value.
+   *
+   * @Then the original configuration item :name with key :key should be :expected
+   */
+  public function testAssertOriginalConfigValue(string $name, string $key, string $expected): void {
+    $actual = \Drupal::config($name)->getOriginal($key, FALSE);
+    if ($actual !== $expected) {
+      throw new ExpectationException(
+        sprintf('Expected original config "%s:%s" to be "%s", but got "%s".', $name, $key, $expected, $actual),
+        $this->getSession()->getDriver()
+      );
+    }
+  }
+
+  /**
    * Deletes the current user from the database and untracking it.
    *
    * Simulates a database reset between scenarios: the user is removed from

--- a/tests/behat/features/config.feature
+++ b/tests/behat/features/config.feature
@@ -30,3 +30,13 @@ Feature: ConfigContext
   Scenario: Assert config was restored by previous scenario cleanup
     When I go to "admin/config/system/site-information"
     Then the "Site name" field should not contain "Temporary Name"
+
+  @test-drupal @api
+  Scenario: Assert config backup uses original DB value when overridden in settings.php
+    Given I set the configuration item "system.site" with key "name" to "Temporary Override Test"
+    When I go to "admin/config/system/site-information"
+    Then the "Site name" field should contain "Temporary Override Test"
+
+  @test-drupal @api
+  Scenario: Assert config was restored to original DB value not the settings.php override
+    Then the original configuration item "system.site" with key "name" should be "Drush Site-Install"


### PR DESCRIPTION
## Summary

- Fixed `ConfigContext::setConfig()` backing up the `settings.php`-overridden config value instead of the original DB value.
- When the driver is a `DrupalDriver`, the backup now uses `configGetOriginal()` from the core layer (added in DrupalDriver v2.4.2) to read the raw DB value, bypassing any `settings.php` overrides.
- Falls back to `configGet()` for non-Drupal drivers (unchanged behavior).
- Added a `settings.php` config override during provisioning to enable testing the divergence.
- Added Behat scenarios proving the backup/restore cycle preserves the original DB value.

Closes #501

## Test plan

- [ ] `ahoy provision` (creates the `settings.php` override for `system.site:name`)
- [ ] `ahoy test-bdd-drupal -- tests/behat/features/config.feature` — all 6 scenarios pass
- [ ] `ahoy test-unit` — all PHPUnit tests pass