### PR TITLE
[#238] Added table header validation tests and improved error message in 'assertValidMessageTable()'.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/MessageContext.php
+++ b/src/Drupal/DrupalExtension/Context/MessageContext.php
@@ -361,7 +361,7 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
     $actualHeader = reset($headerRow);
     if (strtolower(trim($actualHeader)) !== $expected_header) {
       $capitalizedHeader = ucfirst($expected_header);
-      throw new \RuntimeException(sprintf("The list of %s should have the header '%s'.", $expected_header, $capitalizedHeader));
+      throw new \RuntimeException(sprintf("The list of %s should have the header '%s', but found '%s'.", $expected_header, $capitalizedHeader, $actualHeader));
     }
   }
 

--- a/tests/behat/features/messages.feature
+++ b/tests/behat/features/messages.feature
@@ -162,6 +162,111 @@ Feature: MessageContext
       | This should not be here |
 
   @test-drupal @api
+  Scenario: Assert "Then I should see the following error messages:" passes
+    Given I am on "/user/login"
+    When I fill in "a fake user" for "Username"
+    And I fill in "a fake password" for "Password"
+    And I press "Log in"
+    Then I should see the following error messages:
+      | error messages                    |
+      | Unrecognized username or password |
+
+  @test-drupal @api
+  Scenario: Assert "Then I should see the following error messages:" fails when error not present
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given I am on "/user/login"
+      Then I should see the following error messages:
+        | error messages            |
+        | This error does not exist |
+      """
+    When I run behat with drupal profile
+    Then it should fail with an error:
+      """
+      does not contain any error messages
+      """
+
+  @test-drupal @api
+  Scenario: Assert "Then I should not see the following error messages:" fails when error is present
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given I am on "/user/login"
+      When I fill in "a fake user" for "Username"
+      And I fill in "a fake password" for "Password"
+      And I press "Log in"
+      Then I should not see the following error messages:
+        | error messages                   |
+        | Unrecognized username or password |
+      """
+    When I run behat with drupal profile
+    Then it should fail with an error:
+      """
+      contains the error message 'Unrecognized username or password'
+      """
+
+  @test-drupal @api
+  Scenario: Assert "Then I should see the following warning messages:" fails when warning not present
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given I am on "/user/login"
+      Then I should see the following warning messages:
+        | warning messages              |
+        | This warning does not exist   |
+      """
+    When I run behat with drupal profile
+    Then it should fail with an error:
+      """
+      does not contain any warning messages
+      """
+
+  @test-drupal @api
+  Scenario: Assert "Then I should not see the following warning messages:" passes when not present
+    Given I am on "/user/login"
+    Then I should not see the following warning messages:
+      | warning messages        |
+      | This should not be here |
+
+  @test-drupal @api
+  Scenario: Assert "Then I should see the following error messages:" fails for missing header
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given I am on "/user/login"
+      When I fill in "a fake user" for "Username"
+      And I fill in "a fake password" for "Password"
+      And I press "Log in"
+      Then I should see the following error messages:
+        | Unrecognized username or password |
+      """
+    When I run behat with drupal profile
+    Then it should fail with an exception:
+      """
+      should have the header 'Error messages', but found 'Unrecognized username or password'
+      """
+
+  @test-drupal @api
+  Scenario: Assert "Then I should see the following success messages:" fails for multi-column table
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given I am logged in as a user with the "administrator" role
+      And I am viewing an "article" with the title "Multi column test"
+      When I click "Edit"
+      And I press "Save"
+      Then I should see the following success messages:
+        | success messages | extra column |
+        | has been updated | extra value  |
+      """
+    When I run behat with drupal profile
+    Then it should fail with an exception:
+      """
+      should only contain 1 column
+      """
+
+  @test-drupal @api
   Scenario: Assert "Then I should not see the error message :message" passes when not present
     Given I am on "/user/login"
     Then I should not see the error message "logged in"

--- a/tests/phpunit/src/MessageContextTest.php
+++ b/tests/phpunit/src/MessageContextTest.php
@@ -80,7 +80,7 @@ class MessageContextTest extends TestCase {
           ['Something went wrong'],
     ]);
     $this->expectException(\RuntimeException::class);
-    $this->expectExceptionMessage("should have the header 'Error messages'");
+    $this->expectExceptionMessage("should have the header 'Error messages', but found 'Wrong header'");
     $this->assertValidMessageTable->invoke($this->context, $table, 'error messages');
   }
 


### PR DESCRIPTION
Closes #238

## Summary

Added comprehensive Behat integration tests for the `assertValidMessageTable()` validation logic in `MessageContext`, covering both positive and negative scenarios for error, warning, and success message step definitions. The error message thrown when a table header is missing or wrong was also improved to include the actual header found, making failures easier to diagnose.

## Changes

### `MessageContext.php` — Improved error message
- Updated the header validation error to include the actual header value found, so test output shows both what was expected and what was present.

### `messages.feature` — New integration test scenarios
- Added positive test: `"Then I should see the following error messages:"` passes when error is present.
- Added negative test: fails when the expected error message is not present.
- Added negative test: `"Then I should not see the following error messages:"` fails when error is present.
- Added negative test: `"Then I should see the following warning messages:"` fails when warning is not present.
- Added positive test: `"Then I should not see the following warning messages:"` passes when no warnings.
- Added negative test: fails for missing/wrong table header (validates the improved error message).
- Added negative test: fails for multi-column table input.

### `MessageContextTest.php` — Updated unit test assertion
- Updated expected exception message to match the new format that includes the actual header found.

## Before / After

```
Before — header mismatch error message:
┌────────────────────────────────────────────────────────────────┐
│ RuntimeException:                                              │
│ "The list of error messages should have the header            │
│  'Error messages'."                                           │
│                                                               │
│  (no information about what was actually found)               │
└────────────────────────────────────────────────────────────────┘

After — header mismatch error message:
┌────────────────────────────────────────────────────────────────┐
│ RuntimeException:                                              │
│ "The list of error messages should have the header            │
│  'Error messages', but found 'Wrong header'."                 │
│                                                               │
│  (actual value included for faster debugging)                 │
└────────────────────────────────────────────────────────────────┘
```

```
Before — test coverage for table-based message steps:
┌──────────────────────────────────────────────────┐
│ messages.feature                                 │
│                                                  │
│  single-cell / single-message steps  ✓ covered  │
│  table-based message steps           ✗ missing  │
└──────────────────────────────────────────────────┘

After — test coverage for table-based message steps:
┌──────────────────────────────────────────────────┐
│ messages.feature                                 │
│                                                  │
│  single-cell / single-message steps  ✓ covered  │
│  table-based message steps           ✓ covered  │
│    error messages — positive         ✓           │
│    error messages — negative         ✓           │
│    warning messages — negative       ✓           │
│    warning messages — not-see pass   ✓           │
│    bad header detection              ✓           │
│    multi-column rejection            ✓           │
└──────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting in message validation to display both expected and actual header values, making troubleshooting failures clearer.

* **Tests**
  * Expanded test scenarios for message assertions, including header validation and multi-column table handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->