### PR TITLE
[#534] Fixed stale config cache in cleanConfig() breaking change detection

### DIFF
--- a/src/Drupal/DrupalExtension/Context/ConfigContext.php
+++ b/src/Drupal/DrupalExtension/Context/ConfigContext.php
@@ -37,10 +37,20 @@ class ConfigContext extends RawDrupalContext implements TranslatableContext {
    * @AfterScenario
    */
   public function cleanConfig(): void {
+    $driver = $this->getDriver();
+
     // Revert config that was changed.
     foreach ($this->config as $name => $keyValue) {
+      // Reset the config factory cache so the editable config object is
+      // loaded fresh from storage. Without this, the cached object retains
+      // stale originalData from when setConfig() ran, causing
+      // ConfigCrudEvent::isChanged() to compare against the wrong baseline.
+      if ($driver instanceof DrupalDriver) {
+        \Drupal::configFactory()->reset($name);
+      }
+
       foreach ($keyValue as $key => $value) {
-        $this->getDriver()->configSet($name, $key, $value);
+        $driver->configSet($name, $key, $value);
       }
     }
     $this->config = [];

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -491,6 +491,53 @@ class FeatureContext extends RawDrupalContext {
   }
 
   /**
+   * Clears the config save log used for change detection testing.
+   *
+   * @Given the config save log is cleared
+   */
+  public function testClearConfigSaveLog(): void {
+    \Drupal::state()->delete('behat_test.config_save_log');
+  }
+
+  /**
+   * Asserts the config restore used the correct baseline, not a stale cache.
+   *
+   * When cleanConfig() restores config, the config factory should have a
+   * fresh view of storage. The 'original' value in the save event should
+   * match what was in the DB at restore time (the value set via the form),
+   * not the stale cached value from when setConfig() ran.
+   *
+   * @param string $expected
+   *   The expected original value at restore time.
+   * @param string $name
+   *   The configuration object name.
+   *
+   * @Then the config restore baseline for :name should be :expected
+   */
+  public function testAssertConfigRestoreBaseline(string $name, string $expected): void {
+    $log = \Drupal::state()->get('behat_test.config_save_log', []);
+    $last = NULL;
+    foreach (array_reverse($log) as $entry) {
+      if ($entry['name'] === $name) {
+        $last = $entry;
+        break;
+      }
+    }
+    if ($last === NULL) {
+      throw new ExpectationException(
+        sprintf('Config save log has no entry for "%s".', $name),
+        $this->getSession()->getDriver()
+      );
+    }
+    if ($last['original'] !== $expected) {
+      throw new ExpectationException(
+        sprintf('Config restore for "%s" used baseline "%s" instead of expected "%s". This indicates a stale config cache. Log: %s', $name, $last['original'], $expected, json_encode($log)),
+        $this->getSession()->getDriver()
+      );
+    }
+  }
+
+  /**
    * Deletes the current user from the database and untracking it.
    *
    * Simulates a database reset between scenarios: the user is removed from

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -507,10 +507,10 @@ class FeatureContext extends RawDrupalContext {
    * match what was in the DB at restore time (the value set via the form),
    * not the stale cached value from when setConfig() ran.
    *
-   * @param string $expected
-   *   The expected original value at restore time.
    * @param string $name
    *   The configuration object name.
+   * @param string $expected
+   *   The expected original value at restore time.
    *
    * @Then the config restore baseline for :name should be :expected
    */

--- a/tests/behat/features/config.feature
+++ b/tests/behat/features/config.feature
@@ -32,6 +32,18 @@ Feature: ConfigContext
     Then the "Site name" field should not contain "Temporary Name"
 
   @test-drupal @api
+  Scenario: Assert config cleanup resets cache so change detection works
+    Given I set the configuration item "system.site" with key "name" to "Cache Test Name"
+    And the config save log is cleared
+    When I go to "admin/config/system/site-information"
+    And I fill in "Site name" with "Changed Via Form"
+    And I press "Save configuration"
+
+  @test-drupal @api
+  Scenario: Assert config restore used fresh baseline not stale cache
+    Then the config restore baseline for "system.site" should be "Changed Via Form"
+
+  @test-drupal @api
   Scenario: Assert config backup uses original DB value when overridden in settings.php
     Given I set the configuration item "system.site" with key "name" to "Temporary Override Test"
     When I go to "admin/config/system/site-information"

--- a/tests/behat/fixtures/drupal/modules/behat_test/behat_test.services.yml
+++ b/tests/behat/fixtures/drupal/modules/behat_test/behat_test.services.yml
@@ -2,3 +2,8 @@ services:
   behat_test.config.storage.install:
     class: Drupal\behat_test\Config\BehatTestExtensionInstallStorage
     arguments: ['@config.storage', 'config/install', '', true, '%install_profile%']
+  behat_test.config_save_subscriber:
+    class: Drupal\behat_test\EventSubscriber\ConfigSaveSubscriber
+    arguments: ['@state']
+    tags:
+      - { name: event_subscriber }

--- a/tests/behat/fixtures/drupal/modules/behat_test/src/EventSubscriber/ConfigSaveSubscriber.php
+++ b/tests/behat/fixtures/drupal/modules/behat_test/src/EventSubscriber/ConfigSaveSubscriber.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\behat_test\EventSubscriber;
+
+use Drupal\Core\Config\ConfigCrudEvent;
+use Drupal\Core\Config\ConfigEvents;
+use Drupal\Core\State\StateInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Tracks config save events for testing config change detection.
+ *
+ * Records whether ConfigCrudEvent::isChanged() returns TRUE when config is
+ * saved. Used to verify that cleanConfig() properly resets the config cache
+ * so that change detection works correctly.
+ *
+ * @see https://github.com/jhedstrom/drupalextension/issues/534
+ */
+class ConfigSaveSubscriber implements EventSubscriberInterface {
+
+  public function __construct(
+    protected StateInterface $state,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [ConfigEvents::SAVE => 'onConfigSave'];
+  }
+
+  /**
+   * Records config change detection results.
+   */
+  public function onConfigSave(ConfigCrudEvent $event): void {
+    $config = $event->getConfig();
+    if ($config->getName() !== 'system.site') {
+      return;
+    }
+
+    $log = $this->state->get('behat_test.config_save_log', []);
+    $log[] = [
+      'name' => $config->getName(),
+      'changed' => $event->isChanged('name'),
+      'original' => $config->getOriginal('name'),
+    ];
+    $this->state->set('behat_test.config_save_log', $log);
+  }
+
+}


### PR DESCRIPTION
## Summary

- Added `\Drupal::configFactory()->reset($name)` before each `configSet()` call in `ConfigContext::cleanConfig()`.
- When config is changed via the UI (form submission handled by the web server), the Behat process's config factory cache becomes stale. The cached editable config object retains `originalData` from when `setConfig()` ran, not the actual current DB state. This causes `ConfigCrudEvent::isChanged()` to compare against the wrong baseline, preventing event subscribers from detecting the config revert.
- The `reset()` call clears the factory cache for the config object, forcing a fresh load from storage on the next `getEditable()` call.
- Added a `ConfigSaveSubscriber` to the `behat_test` module that logs config save events with change detection results and the original baseline value.
- Added Behat scenarios that set config, change it via the UI form, and verify the cleanup restore uses the correct storage baseline (not the stale cache).

Closes #534

## Test plan

- [ ] `ahoy provision` then `ahoy test-bdd-drupal -- tests/behat/features/config.feature` — all 8 scenarios pass
- [ ] `ahoy test-unit` — all PHPUnit tests pass