### PR TITLE
[#599] Fixed 'iWaitForAjaxToFinish()' crashing on unstarted session.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -153,6 +153,10 @@ class MinkContext extends MinkExtension implements TranslatableContext {
    * @Given I wait for AJAX to finish
    */
   public function iWaitForAjaxToFinish(mixed $event = NULL): void {
+    if (!$this->getSession()->isStarted()) {
+      return;
+    }
+
     $condition = <<<JS
     (function() {
       function isAjaxing(instance) {

--- a/tests/behat/features/mink_context.feature
+++ b/tests/behat/features/mink_context.feature
@@ -296,3 +296,18 @@ Feature: MinkContext coverage gaps
       """
       Unable to find details
       """
+
+  @test-blackbox @javascript
+  Scenario: Assert "Given I wait for AJAX to finish" passes when session is started
+    Given I am at "form_controls.html"
+    And I wait for AJAX to finish
+
+  @test-blackbox
+  Scenario: Assert "Given I wait for AJAX to finish" passes when session not started
+    Given some behat configuration
+    And scenario steps tagged with "@test-blackbox":
+      """
+      Given I wait for AJAX to finish
+      """
+    When I run behat
+    Then it should pass


### PR DESCRIPTION
Closes #599

## Summary

Fixed `iWaitForAjaxToFinish()` in `MinkContext` crashing when called before a browser session has been started. Previously the method would attempt to evaluate JavaScript unconditionally, causing a fatal error when no session existed. A guard clause now returns early if the session has not been started, making the step safe to use at any point in a scenario.

## Changes

**`src/Drupal/DrupalExtension/Context/MinkContext.php`**
- Added early-return guard at the top of `iWaitForAjaxToFinish()` that checks `$this->getSession()->isStarted()` and returns immediately if the session is not yet active.

**`tests/behat/features/mink_context.feature`**
- Added a positive `@javascript` scenario verifying the step works normally when a session is started.
- Added a negative (subprocess) scenario verifying the step passes without error when no session has been started.

## Before / After

```
Before
──────
iWaitForAjaxToFinish()
  │
  └─▶ evaluateScript(JS)  ◀── crashes if session not started
        │
        └─▶ WebDriver exception / fatal error

After
─────
iWaitForAjaxToFinish()
  │
  ├─ isStarted()? ──No──▶ return   (safe no-op)
  │
  └─▶ evaluateScript(JS)  ◀── only reached when session is active
        │
        └─▶ waits for AJAX (normal path)
```
