### PR TITLE
[#500] Made ConfigContext::setConfig() protected

### DIFF
--- a/src/Drupal/DrupalExtension/Context/ConfigContext.php
+++ b/src/Drupal/DrupalExtension/Context/ConfigContext.php
@@ -117,7 +117,7 @@ class ConfigContext extends RawDrupalContext implements TranslatableContext {
    * @param mixed $value
    *   Value to associate with identifier.
    */
-  public function setConfig(string $name, string $key, mixed $value): void {
+  protected function setConfig(string $name, string $key, mixed $value): void {
     $driver = $this->getDriver();
     if ($driver instanceof DrupalDriver) {
       $backup = $driver->getCore()->configGetOriginal($name, $key);

--- a/tests/phpunit/src/ConfigContextTest.php
+++ b/tests/phpunit/src/ConfigContextTest.php
@@ -40,16 +40,16 @@ class ConfigContextTest extends TestCase {
   }
 
   /**
-   * Tests that setConfig stores backup values correctly.
+   * Tests that setBasicConfig stores backup values correctly.
    */
-  #[DataProvider('dataProviderSetConfigBackup')]
-  public function testSetConfigBackup(array $operations, array $expected_backup): void {
+  #[DataProvider('dataProviderSetBasicConfigBackup')]
+  public function testSetBasicConfigBackup(array $operations, array $expected_backup): void {
     $getReturns = array_column($operations, 'original');
     $this->driver->method('configGet')->willReturnOnConsecutiveCalls(...$getReturns);
     $this->driver->method('configSet');
 
     foreach ($operations as $operation) {
-      $this->context->setConfig($operation['name'], $operation['key'], $operation['new_value']);
+      $this->context->setBasicConfig($operation['name'], $operation['key'], $operation['new_value']);
     }
 
     $config = new \ReflectionProperty(ConfigContext::class, 'config');
@@ -63,9 +63,9 @@ class ConfigContextTest extends TestCase {
   }
 
   /**
-   * Provides data for testSetConfigBackup().
+   * Provides data for testSetBasicConfigBackup().
    */
-  public static function dataProviderSetConfigBackup(): \Iterator {
+  public static function dataProviderSetBasicConfigBackup(): \Iterator {
     yield 'single key backup' => [
           [['name' => 'system.site', 'key' => 'name', 'original' => 'Original', 'new_value' => 'New']],
           ['system.site' => ['name' => 'Original']],
@@ -105,7 +105,7 @@ class ConfigContextTest extends TestCase {
                 $setArgs[] = [$name, $key, $value];
       });
 
-    $this->context->setConfig('system.site', 'name', 'New Name');
+    $this->context->setBasicConfig('system.site', 'name', 'New Name');
     $this->context->cleanConfig();
 
     $restoreCall = end($setArgs);


### PR DESCRIPTION
## Summary

- Changed `ConfigContext::setConfig()` visibility from `public` to `protected`.
- The class already exposes `setBasicConfig()` and `setComplexConfig()` as public step-definition methods that delegate to `setConfig()`. Having two public methods for the same purpose is redundant.
- Updated PHPUnit tests to use `setBasicConfig()` instead of calling `setConfig()` directly.

Closes #500

## Test plan

- [ ] `ahoy test-unit` — all 276 tests pass
- [ ] `ahoy lint` — no errors