### PR TITLE
[#693] Converted standard Behat annotations to PHP 8 attributes.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -25,7 +25,7 @@
   <summary><code>@Given I wait for the batch job to finish</code></summary>
 
 <br/>
-Wait for the Batch API to finish
+Wait for the Batch API to finish. 
 <br/><br/>
 
 ```gherkin
@@ -39,15 +39,15 @@ Given I wait for the batch job to finish
   <summary><code>@Given there is an item in the system queue:</code></summary>
 
 <br/>
-Creates a queue item. Defaults inputs if none are available
+Creates a queue item. Defaults inputs if none are available. 
 <br/><br/>
 
 ```gherkin
-Given there is an item in the system queue:
-  | name    | my_queue              |
-  | data    | {"key":"value"}       |
-  | created | 1700000000            |
-  | expire  | 0                     |
+  Given there is an item in the system queue:
+    | name    | my_queue              |
+    | data    | {"key":"value"}       |
+    | created | 1700000000            |
+    | expire  | 0                     |
 
 ```
 
@@ -64,11 +64,11 @@ Given there is an item in the system queue:
   <summary><code>@Given I set the configuration item :name with key :key to :value</code></summary>
 
 <br/>
-Sets basic configuration item
+Sets basic configuration item. 
 <br/><br/>
 
 ```gherkin
-Given I set the configuration item "system.site" with key "name" to "My Site"
+  Given I set the configuration item "system.site" with key "name" to "My Site"
 
 ```
 
@@ -78,14 +78,14 @@ Given I set the configuration item "system.site" with key "name" to "My Site"
   <summary><code>@Given I set the configuration item :name with key :key with values:</code></summary>
 
 <br/>
-Sets complex configuration
+Sets complex configuration. 
 <br/><br/>
 
 ```gherkin
-Given I set the configuration item "system.site" with key "page" with values:
-  | key   | value  |
-  | front | /node  |
-  | 403   | /error |
+  Given I set the configuration item "system.site" with key "page" with values:
+    | key   | value  |
+    | front | /node  |
+    | 403   | /error |
 
 ```
 
@@ -104,7 +104,7 @@ Given I set the configuration item "system.site" with key "page" with values:
 @Then I log out</code></summary>
 
 <br/>
-Assert the user is anonymous or log out
+Assert the user is anonymous or log out. 
 <br/><br/>
 
 ```gherkin
@@ -121,7 +121,7 @@ Then I log out
 @Given I am logged in as a/an :role</code></summary>
 
 <br/>
-Creates and authenticates a user with the given role(s)
+Creates and authenticates a user with the given role(s). 
 <br/><br/>
 
 ```gherkin
@@ -137,13 +137,13 @@ Given I am logged in as an "editor"
   <summary><code>@Given I am logged in as a user with the :role role(s) and I have the following fields:</code></summary>
 
 <br/>
-Creates and authenticates a user with the given role(s) and given fields
+Creates and authenticates a user with the given role(s) and given fields. 
 <br/><br/>
 
 ```gherkin
-Given I am logged in as a user with the "editor" role and I have the following fields:
-  | field_user_name    | John  |
-  | field_user_surname | Smith |
+  Given I am logged in as a user with the "editor" role and I have the following fields:
+    | field_user_name    | John  |
+    | field_user_surname | Smith |
 
 ```
 
@@ -153,7 +153,7 @@ Given I am logged in as a user with the "editor" role and I have the following f
   <summary><code>@Given I am logged in as :name</code></summary>
 
 <br/>
-Log in as an existing user by name
+Log in as an existing user by name. 
 <br/><br/>
 
 ```gherkin
@@ -167,7 +167,7 @@ Given I am logged in as "admin"
   <summary><code>@Given I am logged in as a user with the :permissions permission(s)</code></summary>
 
 <br/>
-Log in as a user with specific permissions
+Log in as a user with specific permissions. 
 <br/><br/>
 
 ```gherkin
@@ -182,7 +182,7 @@ Given I am logged in as a user with the "administer nodes, bypass node access" p
   <summary><code>@Given I click :link in the :rowText row</code></summary>
 
 <br/>
-Clicks a link in a table row containing given text
+Clicks a link in a table row containing given text. 
 <br/><br/>
 
 ```gherkin
@@ -196,7 +196,7 @@ Given I click "Edit" in the "My article" row
   <summary><code>@Given I press :button in the :rowText row</code></summary>
 
 <br/>
-Attempts to find a button in a table row containing giving text
+Attempts to find a button in a table row containing giving text. 
 <br/><br/>
 
 ```gherkin
@@ -210,7 +210,7 @@ Given I press "Remove" in the "My article" row
   <summary><code>@Given the cache has been cleared</code></summary>
 
 <br/>
-Clear the Drupal cache
+Clear the Drupal cache. 
 <br/><br/>
 
 ```gherkin
@@ -224,7 +224,7 @@ Given the cache has been cleared
   <summary><code>@Given I run cron</code></summary>
 
 <br/>
-Run Drupal cron
+Run Drupal cron. 
 <br/><br/>
 
 ```gherkin
@@ -239,7 +239,7 @@ Given I run cron
 @Given a/an :type (content )with the title :title</code></summary>
 
 <br/>
-Creates content of the given type
+Creates content of the given type. 
 <br/><br/>
 
 ```gherkin
@@ -255,7 +255,7 @@ Given a "page" with the title "About us"
   <summary><code>@Given I am viewing my :type (content )with the title :title</code></summary>
 
 <br/>
-Creates content authored by the current user
+Creates content authored by the current user. 
 <br/><br/>
 
 ```gherkin
@@ -270,13 +270,13 @@ Given I am viewing my "article" content with the title "My article"
   <summary><code>@Given :type content:</code></summary>
 
 <br/>
-Creates content of a given type
+Creates content of a given type. 
 <br/><br/>
 
 ```gherkin
-Given "article" content:
-  | title      | status |
-  | My article | 1      |
+  Given "article" content:
+    | title      | status |
+    | My article | 1      |
 
 ```
 
@@ -286,16 +286,16 @@ Given "article" content:
   <summary><code>@Given I am viewing a/an :type( content):</code></summary>
 
 <br/>
-Creates content of the given type and visits it
+Creates content of the given type and visits it. 
 <br/><br/>
 
 ```gherkin
-Given I am viewing an "article":
-  | title | My article     |
-  | body  | Lorem ipsum    |
-Given I am viewing an "article" content:
-  | title | My article     |
-  | body  | Lorem ipsum    |
+  Given I am viewing an "article":
+    | title | My article     |
+    | body  | Lorem ipsum    |
+  Given I am viewing an "article" content:
+    | title | My article     |
+    | body  | Lorem ipsum    |
 
 ```
 
@@ -306,7 +306,7 @@ Given I am viewing an "article" content:
 @Given a/an :vocabulary term with the name :name</code></summary>
 
 <br/>
-Creates a term on an existing vocabulary
+Creates a term on an existing vocabulary. 
 <br/><br/>
 
 ```gherkin
@@ -321,13 +321,13 @@ Given an "categories" term with the name "News"
   <summary><code>@Given users:</code></summary>
 
 <br/>
-Creates multiple users
+Creates multiple users. 
 <br/><br/>
 
 ```gherkin
-Given users:
-  | name     | mail            | roles  |
-  | Joe User | joe@example.com | editor |
+  Given users:
+    | name     | mail            | roles  |
+    | Joe User | joe@example.com | editor |
 
 ```
 
@@ -337,14 +337,14 @@ Given users:
   <summary><code>@Given :vocabulary terms:</code></summary>
 
 <br/>
-Creates one or more terms on an existing vocabulary
+Creates one or more terms on an existing vocabulary. 
 <br/><br/>
 
 ```gherkin
-Given "tags" terms:
-  | name   |
-  | Sports |
-  | News   |
+  Given "tags" terms:
+    | name   |
+    | Sports |
+    | News   |
 
 ```
 
@@ -354,17 +354,17 @@ Given "tags" terms:
   <summary><code>@Given the/these (following )languages are available:</code></summary>
 
 <br/>
-Creates one or more languages
+Creates one or more languages. 
 <br/><br/>
 
 ```gherkin
-Given the following languages are available:
-  | languages |
-  | en        |
-  | fr        |
-Given these languages are available:
-  | languages |
-  | de        |
+  Given the following languages are available:
+    | languages |
+    | en        |
+    | fr        |
+  Given these languages are available:
+    | languages |
+    | de        |
 
 ```
 
@@ -374,7 +374,7 @@ Given these languages are available:
   <summary><code>@Then I should see (the text ):text in the :rowText row</code></summary>
 
 <br/>
-Find text in a table row containing given text
+Find text in a table row containing given text. 
 <br/><br/>
 
 ```gherkin
@@ -389,7 +389,7 @@ Then I should see the text "Edit" in the "My article" row
   <summary><code>@Then I should not see (the text ):text in the :rowText row</code></summary>
 
 <br/>
-Asset text not in a table row containing given text
+Asset text not in a table row containing given text. 
 <br/><br/>
 
 ```gherkin
@@ -404,7 +404,7 @@ Then I should not see the text "Delete" in the "My article" row
   <summary><code>@Then I (should )see the :link in the :rowText row</code></summary>
 
 <br/>
-Asserts a link exists in a table row containing given text
+Asserts a link exists in a table row containing given text. 
 <br/><br/>
 
 ```gherkin
@@ -419,7 +419,7 @@ Then I should see the "Edit" in the "My article" row
   <summary><code>@Then I should not see the :link in the :rowText row</code></summary>
 
 <br/>
-Asserts a link does not exist in a table row containing given text
+Asserts a link does not exist in a table row containing given text. 
 <br/><br/>
 
 ```gherkin
@@ -433,7 +433,7 @@ Then I should not see the "Delete" in the "My article" row
   <summary><code>@Then I should be able to edit a/an :type( content)</code></summary>
 
 <br/>
-Asserts that a given content type is editable
+Asserts that a given content type is editable. 
 <br/><br/>
 
 ```gherkin
@@ -448,7 +448,7 @@ Then I should be able to edit an "article" content
   <summary><code>@Then (I )break</code></summary>
 
 <br/>
-Pauses the scenario until the user presses a key. Useful when debugging a scenario
+Pauses the scenario until the user presses a key. Useful when debugging a scenario. 
 <br/><br/>
 
 ```gherkin
@@ -470,7 +470,7 @@ Then I break
   <summary><code>@Given I run drush :command</code></summary>
 
 <br/>
-Run a Drush command
+Run a Drush command. 
 <br/><br/>
 
 ```gherkin
@@ -484,7 +484,7 @@ Given I run drush "status"
   <summary><code>@Given I run drush :command :arguments</code></summary>
 
 <br/>
-Run a Drush command with arguments
+Run a Drush command with arguments. 
 <br/><br/>
 
 ```gherkin
@@ -498,7 +498,7 @@ Given I run drush "pm:list" "--status=enabled"
   <summary><code>@Then drush output should contain :output</code></summary>
 
 <br/>
-Assert Drush output contains a string
+Assert Drush output contains a string. 
 <br/><br/>
 
 ```gherkin
@@ -512,7 +512,7 @@ Then drush output should contain "Drupal version"
   <summary><code>@Then drush output should match :regex</code></summary>
 
 <br/>
-Assert Drush output matches a regular expression
+Assert Drush output matches a regular expression. 
 <br/><br/>
 
 ```gherkin
@@ -526,7 +526,7 @@ Then drush output should match "/Drupal [0-9]+/"
   <summary><code>@Then drush output should not contain :output</code></summary>
 
 <br/>
-Assert Drush output does not contain a string
+Assert Drush output does not contain a string. 
 <br/><br/>
 
 ```gherkin
@@ -540,7 +540,7 @@ Then drush output should not contain "error"
   <summary><code>@Then print last drush output</code></summary>
 
 <br/>
-Print the last Drush output
+Print the last Drush output. 
 <br/><br/>
 
 ```gherkin
@@ -561,18 +561,18 @@ Then print last drush output
   <summary><code>@When Drupal sends a/an (e)mail:</code></summary>
 
 <br/>
-This is mainly useful for testing this context
+This is mainly useful for testing this context. 
 <br/><br/>
 
 ```gherkin
-When Drupal sends a mail:
-  | to      | user@example.com |
-  | subject | Test mail        |
-  | body    | Hello world      |
-When Drupal sends an email:
-  | to      | user@example.com |
-  | subject | Test email       |
-  | body    | Hello world      |
+  When Drupal sends a mail:
+    | to      | user@example.com |
+    | subject | Test mail        |
+    | body    | Hello world      |
+  When Drupal sends an email:
+    | to      | user@example.com |
+    | subject | Test email       |
+    | body    | Hello world      |
 
 ```
 
@@ -585,7 +585,7 @@ When Drupal sends an email:
 @When I follow the link to :urlFragment from the (e)mail to :to with the subject :subject</code></summary>
 
 <br/>
-Follow a link from an email body
+Follow a link from an email body. 
 <br/><br/>
 
 ```gherkin
@@ -605,19 +605,19 @@ When I follow the link to "user/reset" from the email with the subject "Welcome"
 @Then (a )(an )(e)mail(s) has/have been sent to :to with the subject :subject:</code></summary>
 
 <br/>
-Check all mail sent during the scenario
+Check all mail sent during the scenario. 
 <br/><br/>
 
 ```gherkin
-Then mail has been sent:
-  | to               | body                |
-  | user@example.com | Welcome to the site |
-Then an email has been sent with the subject "Welcome":
-  | to               | body                |
-  | user@example.com | Welcome to the site |
-Then emails have been sent to "user@example.com" with the subject "Welcome":
-  | body                |
-  | Welcome to the site |
+  Then mail has been sent:
+    | to               | body                |
+    | user@example.com | Welcome to the site |
+  Then an email has been sent with the subject "Welcome":
+    | to               | body                |
+    | user@example.com | Welcome to the site |
+  Then emails have been sent to "user@example.com" with the subject "Welcome":
+    | body                |
+    | Welcome to the site |
 
 ```
 
@@ -630,16 +630,16 @@ Then emails have been sent to "user@example.com" with the subject "Welcome":
 @Then (a )(an )new (e)mail(s) is/are sent to :to with the subject :subject:</code></summary>
 
 <br/>
-Check mail sent since the last step that checked mail
+Check mail sent since the last step that checked mail. 
 <br/><br/>
 
 ```gherkin
-Then new mail is sent:
-  | subject   |
-  | Greetings |
-Then a new email is sent to "user@example.com":
-  | subject   |
-  | Greetings |
+  Then new mail is sent:
+    | subject   |
+    | Greetings |
+  Then a new email is sent to "user@example.com":
+    | subject   |
+    | Greetings |
 
 ```
 
@@ -652,7 +652,7 @@ Then a new email is sent to "user@example.com":
 @Then :count (e)mail(s) has/have been sent to :to with the subject :subject</code></summary>
 
 <br/>
-Check all mail sent during the scenario
+Check all mail sent during the scenario. 
 <br/><br/>
 
 ```gherkin
@@ -671,7 +671,7 @@ Then 1 email has been sent with the subject "Welcome"
 @Then :count new (e)mail(s) is/are sent to :to with the subject :subject</code></summary>
 
 <br/>
-Check mail sent since the last step that checked mail
+Check mail sent since the last step that checked mail. 
 <br/><br/>
 
 ```gherkin
@@ -694,7 +694,7 @@ Then 1 new mail is sent to "user@example.com"
 @Then I should see the :button button in the :region( region)</code></summary>
 
 <br/>
-Checks if a button with id|name|title|alt|value exists in a region
+Checks if a button with id|name|title|alt|value exists in a region. 
 <br/><br/>
 
 ```gherkin
@@ -711,7 +711,7 @@ Then I should see the "Submit" button in the "content" region
 @Then I should not see the :button button in the :region( region)</code></summary>
 
 <br/>
-Asserts that a button does not exists in a region
+Asserts that a button does not exists in a region. 
 <br/><br/>
 
 ```gherkin
@@ -727,7 +727,7 @@ Then I should not see the "Delete" button in the "sidebar" region
   <summary><code>@Then I( should) see the :tag element in the :region( region)</code></summary>
 
 <br/>
-Assert an element exists in a region
+Assert an element exists in a region. 
 <br/><br/>
 
 ```gherkin
@@ -742,7 +742,7 @@ Then I should see the "h2" element in the "content" region
   <summary><code>@Then I( should) not see the :tag element in the :region( region)</code></summary>
 
 <br/>
-Assert an element does not exist in a region
+Assert an element does not exist in a region. 
 <br/><br/>
 
 ```gherkin
@@ -757,7 +757,7 @@ Then I should not see the "h2" element in the "sidebar" region
   <summary><code>@Then I( should) see :text in the :tag element in the :region( region)</code></summary>
 
 <br/>
-Assert text in an element within a region
+Assert text in an element within a region. 
 <br/><br/>
 
 ```gherkin
@@ -772,7 +772,7 @@ Then I should see "Welcome" in the "h2" element in the "content" region
   <summary><code>@Then I( should) not see :text in the :tag element in the :region( region)</code></summary>
 
 <br/>
-Assert text is not in an element within a region
+Assert text is not in an element within a region. 
 <br/><br/>
 
 ```gherkin
@@ -787,7 +787,7 @@ Then I should not see "Error" in the "div" element in the "content" region
   <summary><code>@Then I( should) see the :tag element with the :attribute attribute set to :value in the :region( region)</code></summary>
 
 <br/>
-Assert an element with a specific attribute value exists in a region
+Assert an element with a specific attribute value exists in a region. 
 <br/><br/>
 
 ```gherkin
@@ -802,7 +802,7 @@ Then I should see the "a" element with the "href" attribute set to "/about" in t
   <summary><code>@Then I( should) see :text in the :tag element with the :attribute attribute set to :value in the :region( region)</code></summary>
 
 <br/>
-Assert text in an element with a specific attribute value in a region
+Assert text in an element with a specific attribute value in a region. 
 <br/><br/>
 
 ```gherkin
@@ -817,7 +817,7 @@ Then I should see "About" in the "a" element with the "href" attribute set to "/
   <summary><code>@Then I( should) see :text in the :tag element with the :property CSS property set to :value in the :region( region)</code></summary>
 
 <br/>
-Assert text in an element with a specific CSS property value in a region
+Assert text in an element with a specific CSS property value in a region. 
 <br/><br/>
 
 ```gherkin
@@ -839,12 +839,12 @@ Then I should see "Notice" in the "div" element with the "color" CSS property se
   <summary><code>@Given I should not see the error message( containing) :message</code></summary>
 
 <br/>
-Checks if the current page does not contain the given error message
+Checks if the current page does not contain the given error message. 
 <br/><br/>
 
 ```gherkin
-Given I should not see the error message "Access denied"
-Given I should not see the error message containing "Access"
+  Given I should not see the error message "Access denied"
+  Given I should not see the error message containing "Access"
 
 ```
 
@@ -854,12 +854,12 @@ Given I should not see the error message containing "Access"
   <summary><code>@Given I should not see the success message( containing) :message</code></summary>
 
 <br/>
-Checks if the current page does not contain the given set of success message
+Checks if the current page does not contain the given set of success message. 
 <br/><br/>
 
 ```gherkin
-Given I should not see the success message "saved"
-Given I should not see the success message containing "saved"
+  Given I should not see the success message "saved"
+  Given I should not see the success message containing "saved"
 
 ```
 
@@ -869,12 +869,12 @@ Given I should not see the success message containing "saved"
   <summary><code>@Given I should not see the warning message( containing) :message</code></summary>
 
 <br/>
-Checks if the current page does not contain the given set of warning message
+Checks if the current page does not contain the given set of warning message. 
 <br/><br/>
 
 ```gherkin
-Given I should not see the warning message "deprecated"
-Given I should not see the warning message containing "deprecated"
+  Given I should not see the warning message "deprecated"
+  Given I should not see the warning message containing "deprecated"
 
 ```
 
@@ -884,12 +884,12 @@ Given I should not see the warning message containing "deprecated"
   <summary><code>@Then I should see the error message( containing) :message</code></summary>
 
 <br/>
-Checks if the current page contains the given error message
+Checks if the current page contains the given error message. 
 <br/><br/>
 
 ```gherkin
-Then I should see the error message "Username is required"
-Then I should see the error message containing "Username"
+  Then I should see the error message "Username is required"
+  Then I should see the error message containing "Username"
 
 ```
 
@@ -899,14 +899,14 @@ Then I should see the error message containing "Username"
   <summary><code>@Then I should see the following error message(s):</code></summary>
 
 <br/>
-Checks if the current page contains the given set of error messages
+Checks if the current page contains the given set of error messages. 
 <br/><br/>
 
 ```gherkin
-Then I should see the following error messages:
-  | error messages         |
-  | Username is required   |
-  | Password is required   |
+  Then I should see the following error messages:
+    | error messages         |
+    | Username is required   |
+    | Password is required   |
 
 ```
 
@@ -916,13 +916,13 @@ Then I should see the following error messages:
   <summary><code>@Then I should not see the following error messages:</code></summary>
 
 <br/>
-Checks if the current page does not contain the given set error messages
+Checks if the current page does not contain the given set error messages. 
 <br/><br/>
 
 ```gherkin
-Then I should not see the following error messages:
-  | error messages |
-  | Access denied  |
+  Then I should not see the following error messages:
+    | error messages |
+    | Access denied  |
 
 ```
 
@@ -932,12 +932,12 @@ Then I should not see the following error messages:
   <summary><code>@Then I should see the success message( containing) :message</code></summary>
 
 <br/>
-Checks if the current page contains the given success message
+Checks if the current page contains the given success message. 
 <br/><br/>
 
 ```gherkin
-Then I should see the success message "Article has been created"
-Then I should see the success message containing "created"
+  Then I should see the success message "Article has been created"
+  Then I should see the success message containing "created"
 
 ```
 
@@ -947,13 +947,13 @@ Then I should see the success message containing "created"
   <summary><code>@Then I should see the following success messages:</code></summary>
 
 <br/>
-Checks if the current page contains the given set of success messages
+Checks if the current page contains the given set of success messages. 
 <br/><br/>
 
 ```gherkin
-Then I should see the following success messages:
-  | success messages        |
-  | Article has been created |
+  Then I should see the following success messages:
+    | success messages        |
+    | Article has been created |
 
 ```
 
@@ -963,13 +963,13 @@ Then I should see the following success messages:
   <summary><code>@Then I should not see the following success messages:</code></summary>
 
 <br/>
-Checks if the current page does not contain the given set of success messages
+Checks if the current page does not contain the given set of success messages. 
 <br/><br/>
 
 ```gherkin
-Then I should not see the following success messages:
-  | success messages |
-  | Changes saved    |
+  Then I should not see the following success messages:
+    | success messages |
+    | Changes saved    |
 
 ```
 
@@ -979,12 +979,12 @@ Then I should not see the following success messages:
   <summary><code>@Then I should see the warning message( containing) :message</code></summary>
 
 <br/>
-Checks if the current page contains the given warning message
+Checks if the current page contains the given warning message. 
 <br/><br/>
 
 ```gherkin
-Then I should see the warning message "This action cannot be undone"
-Then I should see the warning message containing "cannot be undone"
+  Then I should see the warning message "This action cannot be undone"
+  Then I should see the warning message containing "cannot be undone"
 
 ```
 
@@ -994,13 +994,13 @@ Then I should see the warning message containing "cannot be undone"
   <summary><code>@Then I should see the following warning messages:</code></summary>
 
 <br/>
-Checks if the current page contains the given set of warning messages
+Checks if the current page contains the given set of warning messages. 
 <br/><br/>
 
 ```gherkin
-Then I should see the following warning messages:
-  | warning messages                |
-  | This action cannot be undone    |
+  Then I should see the following warning messages:
+    | warning messages                |
+    | This action cannot be undone    |
 
 ```
 
@@ -1010,13 +1010,13 @@ Then I should see the following warning messages:
   <summary><code>@Then I should not see the following warning messages:</code></summary>
 
 <br/>
-Checks if the current page does not contain the given set of warning messages
+Checks if the current page does not contain the given set of warning messages. 
 <br/><br/>
 
 ```gherkin
-Then I should not see the following warning messages:
-  | warning messages |
-  | deprecated       |
+  Then I should not see the following warning messages:
+    | warning messages |
+    | deprecated       |
 
 ```
 
@@ -1026,12 +1026,12 @@ Then I should not see the following warning messages:
   <summary><code>@Then I should see the message( containing) :message</code></summary>
 
 <br/>
-Checks if the current page contain the given message
+Checks if the current page contain the given message. 
 <br/><br/>
 
 ```gherkin
-Then I should see the message "Changes saved"
-Then I should see the message containing "saved"
+  Then I should see the message "Changes saved"
+  Then I should see the message containing "saved"
 
 ```
 
@@ -1041,12 +1041,12 @@ Then I should see the message containing "saved"
   <summary><code>@Then I should not see the message( containing) :message</code></summary>
 
 <br/>
-Checks if the current page does not contain the given message
+Checks if the current page does not contain the given message. 
 <br/><br/>
 
 ```gherkin
-Then I should not see the message "Access denied"
-Then I should not see the message containing "denied"
+  Then I should not see the message "Access denied"
+  Then I should not see the message containing "denied"
 
 ```
 
@@ -1064,7 +1064,7 @@ Then I should not see the message containing "denied"
 @When I visit :path</code></summary>
 
 <br/>
-Visit a given path, and additionally check for HTTP response code 200
+Visit a given path, and additionally check for HTTP response code 200. 
 <br/><br/>
 
 ```gherkin
@@ -1080,7 +1080,7 @@ When I visit "/node/1"
 @Given I enter :value for :field</code></summary>
 
 <br/>
-Enter a value into a form field
+Enter a value into a form field. 
 <br/><br/>
 
 ```gherkin
@@ -1095,7 +1095,7 @@ Given I enter "My article" for "Title"
   <summary><code>@Given I wait for AJAX to finish</code></summary>
 
 <br/>
-Wait for AJAX to finish
+Wait for AJAX to finish. 
 <br/><br/>
 
 ```gherkin
@@ -1109,11 +1109,11 @@ Given I wait for AJAX to finish
   <summary><code>@Given I press the :char key in the :field field</code></summary>
 
 <br/>
-Press a key in a form field
+Press a key in a form field. 
 <br/><br/>
 
 ```gherkin
-Given I press the "enter" key in the "Search" field
+  Given I press the "enter" key in the "Search" field
 
 ```
 
@@ -1123,7 +1123,7 @@ Given I press the "enter" key in the "Search" field
   <summary><code>@Given I press :button in the :region( region)</code></summary>
 
 <br/>
-Checks if a button with id|name|title|alt|value exists or not and presses the same
+Checks if a button with id|name|title|alt|value exists or not and presses the same. 
 <br/><br/>
 
 ```gherkin
@@ -1139,7 +1139,7 @@ Given I press "Submit" in the "sidebar" region
 @Given I fill in :field with :value in the :region( region)</code></summary>
 
 <br/>
-Fills in a form field with id|name|title|alt|value in the specified region
+Fills in a form field with id|name|title|alt|value in the specified region. 
 <br/><br/>
 
 ```gherkin
@@ -1155,7 +1155,7 @@ Given I fill in "Search" with "test" in the "header" region
   <summary><code>@Given I check :locator in the :region( region)</code></summary>
 
 <br/>
-Checks if a checkbox with id|name|title|alt|value exists or not and checks the same
+Checks if a checkbox with id|name|title|alt|value exists or not and checks the same. 
 <br/><br/>
 
 ```gherkin
@@ -1170,7 +1170,7 @@ Given I check "Published" in the "content" region
   <summary><code>@Given I uncheck :checkbox in the :region( region)</code></summary>
 
 <br/>
-Checks if a checkbox with id|name|title|alt|value exists or not and unchecks the same
+Checks if a checkbox with id|name|title|alt|value exists or not and unchecks the same. 
 <br/><br/>
 
 ```gherkin
@@ -1185,7 +1185,7 @@ Given I uncheck "Promoted" in the "content" region
   <summary><code>@Given I check the box :checkbox</code></summary>
 
 <br/>
-Check a checkbox
+Check a checkbox. 
 <br/><br/>
 
 ```gherkin
@@ -1199,7 +1199,7 @@ Given I check the box "Published"
   <summary><code>@Given I uncheck the box :checkbox</code></summary>
 
 <br/>
-Uncheck a checkbox
+Uncheck a checkbox. 
 <br/><br/>
 
 ```gherkin
@@ -1213,7 +1213,7 @@ Given I uncheck the box "Promoted to front page"
   <summary><code>@When I click :link</code></summary>
 
 <br/>
-Click a link by its text
+Click a link by its text. 
 <br/><br/>
 
 ```gherkin
@@ -1227,7 +1227,7 @@ When I click "Read more"
   <summary><code>@When I press the :button button</code></summary>
 
 <br/>
-Presses button with specified id|name|title|alt|value
+Presses button with specified id|name|title|alt|value. 
 <br/><br/>
 
 ```gherkin
@@ -1241,7 +1241,7 @@ When I press the "Save" button
   <summary><code>@When I follow/click :link in the :region( region)</code></summary>
 
 <br/>
-Follow a link in a specific region
+Follow a link in a specific region. 
 <br/><br/>
 
 ```gherkin
@@ -1258,7 +1258,7 @@ When I click "Read more" in the "content" region
 @When I select the radio button :label</code></summary>
 
 <br/>
-Select a radio button
+Select a radio button. 
 <br/><br/>
 
 ```gherkin
@@ -1273,7 +1273,7 @@ When I select the radio button "Full HTML" with the id "edit-format-full-html"
   <summary><code>@When I :action details labelled :summary</code></summary>
 
 <br/>
-Expand/collapse/toggle a <details> element by <summary> text
+Expand/collapse/toggle a <details> element by <summary> text. 
 <br/><br/>
 
 ```gherkin
@@ -1289,7 +1289,7 @@ When I click details labelled "Advanced settings"
   <summary><code>@Then I should see the link :link</code></summary>
 
 <br/>
-Assert a link is visible on the page
+Assert a link is visible on the page. 
 <br/><br/>
 
 ```gherkin
@@ -1303,7 +1303,7 @@ Then I should see the link "Log out"
   <summary><code>@Then I should not see the link :link</code></summary>
 
 <br/>
-Links are not loaded on the page
+Links are not loaded on the page. 
 <br/><br/>
 
 ```gherkin
@@ -1317,7 +1317,7 @@ Then I should not see the link "Log out"
   <summary><code>@Then I should not visibly see the link :link</code></summary>
 
 <br/>
-Links are loaded but not visually visible (e.g they have display: hidden applied)
+Links are loaded but not visually visible (e.g they have display: hidden applied). 
 <br/><br/>
 
 ```gherkin
@@ -1331,7 +1331,7 @@ Then I should not visibly see the link "Skip to main content"
   <summary><code>@Then I (should )see the heading :heading</code></summary>
 
 <br/>
-Assert a heading is visible on the page
+Assert a heading is visible on the page. 
 <br/><br/>
 
 ```gherkin
@@ -1346,7 +1346,7 @@ Then I should see the heading "Welcome"
   <summary><code>@Then I (should )not see the heading :heading</code></summary>
 
 <br/>
-Assert a heading is not on the page
+Assert a heading is not on the page. 
 <br/><br/>
 
 ```gherkin
@@ -1362,7 +1362,7 @@ Then I should not see the heading "Error"
 @Then I (should ) see the :button button</code></summary>
 
 <br/>
-Assert a button is visible on the page
+Assert a button is visible on the page. 
 <br/><br/>
 
 ```gherkin
@@ -1379,7 +1379,7 @@ Then I should see the "Save" button
 @Then I should not see the :button button</code></summary>
 
 <br/>
-Assert a button is not on the page
+Assert a button is not on the page. 
 <br/><br/>
 
 ```gherkin
@@ -1395,7 +1395,7 @@ Then I should not see the "Delete" button
 @Then I should see the :heading heading in the :region( region)</code></summary>
 
 <br/>
-Find a heading in a specific region
+Find a heading in a specific region. 
 <br/><br/>
 
 ```gherkin
@@ -1411,7 +1411,7 @@ Then I should see the "Latest news" heading in the "sidebar" region
   <summary><code>@Then I should see the link :link in the :region( region)</code></summary>
 
 <br/>
-Assert a link exists in a region
+Assert a link exists in a region. 
 <br/><br/>
 
 ```gherkin
@@ -1426,7 +1426,7 @@ Then I should see the link "About us" in the "footer" region
   <summary><code>@Then I should not see the link :link in the :region( region)</code></summary>
 
 <br/>
-Assert a link does not exist in a region
+Assert a link does not exist in a region. 
 <br/><br/>
 
 ```gherkin
@@ -1441,7 +1441,7 @@ Then I should not see the link "Admin" in the "footer" region
   <summary><code>@Then I should see( the text) :text in the :region( region)</code></summary>
 
 <br/>
-Assert text is visible in a region
+Assert text is visible in a region. 
 <br/><br/>
 
 ```gherkin
@@ -1457,7 +1457,7 @@ Then I should see the text "Welcome" in the "content" region
   <summary><code>@Then I should not see( the text) :text in the :region( region)</code></summary>
 
 <br/>
-Assert text is not visible in a region
+Assert text is not visible in a region. 
 <br/><br/>
 
 ```gherkin
@@ -1473,7 +1473,7 @@ Then I should not see the text "Error" in the "content" region
   <summary><code>@Then I (should )see the text :text</code></summary>
 
 <br/>
-Assert text is visible on the page
+Assert text is visible on the page. 
 <br/><br/>
 
 ```gherkin
@@ -1488,7 +1488,7 @@ Then I should see the text "Welcome to Drupal"
   <summary><code>@Then I should not see the text :text</code></summary>
 
 <br/>
-Assert text is not visible on the page
+Assert text is not visible on the page. 
 <br/><br/>
 
 ```gherkin
@@ -1502,7 +1502,7 @@ Then I should not see the text "Access denied"
   <summary><code>@Then I should get a :code HTTP response</code></summary>
 
 <br/>
-Assert the HTTP response code
+Assert the HTTP response code. 
 <br/><br/>
 
 ```gherkin
@@ -1516,7 +1516,7 @@ Then I should get a 200 HTTP response
   <summary><code>@Then I should not get a :code HTTP response</code></summary>
 
 <br/>
-Assert the HTTP response code is not a specific value
+Assert the HTTP response code is not a specific value. 
 <br/><br/>
 
 ```gherkin

--- a/rector.php
+++ b/rector.php
@@ -38,6 +38,7 @@ return RectorConfig::configure()
         __DIR__ . '/tests/phpunit/**',
     ])
     ->withPhpSets(php82: TRUE)
+    ->withAttributesSets(behat: TRUE)
     ->withPreparedSets(
         deadCode: TRUE,
         codeQuality: TRUE,

--- a/scripts/docs.php
+++ b/scripts/docs.php
@@ -36,6 +36,10 @@
 
 declare(strict_types=1);
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
+
 // Execute the main function only when the script is run directly, not when included.
 // @codeCoverageIgnoreStart
 if (basename((string) $_SERVER['SCRIPT_FILENAME']) === 'docs.php') {
@@ -188,8 +192,15 @@ function extract_info(string $contextDir, array $exclude = [], string $basePath 
         continue;
       }
 
-      $parsedComment = parse_method_comment((string) $method->getDocComment());
-      if ($parsedComment) {
+      $attributeSteps = extract_step_attributes($method);
+      $parsedComment = parse_method_comment((string) $method->getDocComment(), !empty($attributeSteps));
+
+      if (!empty($attributeSteps)) {
+        $methodInfo = $parsedComment ?? ['steps' => [], 'description' => '', 'example' => ''];
+        $methodInfo['steps'] = $attributeSteps;
+        $classInfo['methods'][] = $methodInfo + ['name' => $method->getName()];
+      }
+      elseif ($parsedComment) {
         $classInfo['methods'][] = $parsedComment + ['name' => $method->getName()];
       }
     }
@@ -308,12 +319,15 @@ function parse_class_comment(string $className, string $comment): array {
  *
  * @param string $comment
  *   The comment.
+ * @param bool $allowEmptySteps
+ *   If TRUE, return the parsed data even when no step annotations are found.
+ *   Used when step definitions come from PHP attributes instead of docblocks.
  *
  * @return array<string, array<int, string>|string>|null
  *   Array of 'steps', 'description', and 'example' keys or NULL if steps were
- *   not found in the comment.
+ *   not found in the comment and $allow_empty_steps is FALSE.
  */
-function parse_method_comment(string $comment): ?array {
+function parse_method_comment(string $comment, bool $allowEmptySteps = FALSE): ?array {
   if (empty($comment)) {
     return NULL;
   }
@@ -403,7 +417,42 @@ function parse_method_comment(string $comment): ?array {
     }
   }
 
-  return empty($return['steps']) ? NULL : $return;
+  if (empty($return['steps']) && !$allowEmptySteps) {
+    return NULL;
+  }
+
+  return $return;
+}
+
+/**
+ * Extract step definitions from PHP 8 attributes on a method.
+ *
+ * @param \ReflectionMethod $method
+ *   The method to inspect.
+ *
+ * @return array<int, string>
+ *   Array of step strings in '@Given ...' format, or empty array if no
+ *   step attributes found.
+ */
+function extract_step_attributes(\ReflectionMethod $method): array {
+  $stepMap = [
+    Given::class => '@Given',
+    When::class => '@When',
+    Then::class => '@Then',
+  ];
+
+  $steps = [];
+
+  foreach ($method->getAttributes() as $attribute) {
+    $name = $attribute->getName();
+    if (isset($stepMap[$name])) {
+      $args = $attribute->getArguments();
+      $pattern = $args[0] ?? $args['pattern'] ?? '';
+      $steps[] = $stepMap[$name] . ' ' . $pattern;
+    }
+  }
+
+  return $steps;
 }
 
 /**

--- a/src/Drupal/DrupalExtension/Context/Annotation/Reader.php
+++ b/src/Drupal/DrupalExtension/Context/Annotation/Reader.php
@@ -15,6 +15,9 @@ use Behat\Behat\Context\Annotation\AnnotationReader;
 /**
  * Annotated contexts reader.
  *
+ * @deprecated in drupalextension:5.3.0 and is removed from drupalextension:6.0.0.
+ *   Use PHP 8 attributes from Drupal\DrupalExtension\Hook\Attribute\ instead.
+ *
  * @see \Behat\Behat\Context\Loader\AnnotatedLoader
  */
 class Reader implements AnnotationReader {

--- a/src/Drupal/DrupalExtension/Context/Attribute/HookAttributeReader.php
+++ b/src/Drupal/DrupalExtension/Context/Attribute/HookAttributeReader.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Context\Attribute;
+
+use Behat\Behat\Context\Attribute\AttributeReader;
+use Drupal\DrupalExtension\Hook\Attribute\AfterNodeCreate as AfterNodeCreateAttribute;
+use Drupal\DrupalExtension\Hook\Attribute\AfterTermCreate as AfterTermCreateAttribute;
+use Drupal\DrupalExtension\Hook\Attribute\AfterUserCreate as AfterUserCreateAttribute;
+use Drupal\DrupalExtension\Hook\Attribute\BeforeNodeCreate as BeforeNodeCreateAttribute;
+use Drupal\DrupalExtension\Hook\Attribute\BeforeTermCreate as BeforeTermCreateAttribute;
+use Drupal\DrupalExtension\Hook\Attribute\BeforeUserCreate as BeforeUserCreateAttribute;
+use Drupal\DrupalExtension\Hook\Attribute\DrupalHook;
+use Drupal\DrupalExtension\Hook\Call\AfterNodeCreate;
+use Drupal\DrupalExtension\Hook\Call\AfterTermCreate;
+use Drupal\DrupalExtension\Hook\Call\AfterUserCreate;
+use Drupal\DrupalExtension\Hook\Call\BeforeNodeCreate;
+use Drupal\DrupalExtension\Hook\Call\BeforeTermCreate;
+use Drupal\DrupalExtension\Hook\Call\BeforeUserCreate;
+
+/**
+ * Reads Drupal entity hook attributes from context methods.
+ */
+class HookAttributeReader implements AttributeReader {
+
+  /**
+   * Map of attribute classes to their hook call classes.
+   *
+   * @var array<class-string, class-string>
+   */
+  private const ATTRIBUTE_MAP = [
+    AfterNodeCreateAttribute::class => AfterNodeCreate::class,
+    AfterTermCreateAttribute::class => AfterTermCreate::class,
+    AfterUserCreateAttribute::class => AfterUserCreate::class,
+    BeforeNodeCreateAttribute::class => BeforeNodeCreate::class,
+    BeforeTermCreateAttribute::class => BeforeTermCreate::class,
+    BeforeUserCreateAttribute::class => BeforeUserCreate::class,
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function readCallees(string $contextClass, \ReflectionMethod $method): array {
+    $attributes = $method->getAttributes(DrupalHook::class, \ReflectionAttribute::IS_INSTANCEOF);
+
+    $callees = [];
+    foreach ($attributes as $attribute) {
+      $hookCallClass = self::ATTRIBUTE_MAP[$attribute->getName()] ?? NULL;
+      if ($hookCallClass === NULL) {
+        continue;
+      }
+
+      $hook = $attribute->newInstance();
+      $callable = [$contextClass, $method->getName()];
+      $callees[] = new $hookCallClass($hook->getFilterString(), $callable);
+    }
+
+    return $callees;
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Context/BatchContext.php
+++ b/src/Drupal/DrupalExtension/Context/BatchContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Context;
 
+use Behat\Step\Given;
 use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 
@@ -21,9 +22,8 @@ class BatchContext extends RawMinkContext {
    * @code
    * Given I wait for the batch job to finish
    * @endcode
-   *
-   * @Given I wait for the batch job to finish
    */
+  #[Given('I wait for the batch job to finish')]
   public function iWaitForTheBatchJobToFinish(): void {
     $this->getSession()->wait(180000, 'jQuery("#updateprogress").length === 0');
   }
@@ -40,9 +40,8 @@ class BatchContext extends RawMinkContext {
    *     | created | 1700000000            |
    *     | expire  | 0                     |
    * @endcode
-   *
-   * @Given there is an item in the system queue:
    */
+  #[Given('there is an item in the system queue:')]
   public function thereIsAnItemInTheSystemQueue(TableNode $table): void {
     // Gather the data.
     $fields = $table->getRowsHash();

--- a/src/Drupal/DrupalExtension/Context/ConfigContext.php
+++ b/src/Drupal/DrupalExtension/Context/ConfigContext.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
  */
 namespace Drupal\DrupalExtension\Context;
 
+use Behat\Hook\AfterScenario;
+use Behat\Step\Given;
 use Behat\Behat\Context\TranslatableContext;
 use Behat\Gherkin\Node\TableNode;
 use Drupal\Driver\DrupalDriver;
@@ -33,9 +35,8 @@ class ConfigContext extends RawDrupalContext implements TranslatableContext {
 
   /**
    * Revert any changed config.
-   *
-   * @AfterScenario
    */
+  #[AfterScenario]
   public function cleanConfig(): void {
     $driver = $this->getDriver();
 
@@ -69,9 +70,8 @@ class ConfigContext extends RawDrupalContext implements TranslatableContext {
    * @code
    *   Given I set the configuration item "system.site" with key "name" to "My Site"
    * @endcode
-   *
-   * @Given I set the configuration item :name with key :key to :value
    */
+  #[Given('I set the configuration item :name with key :key to :value')]
   public function setBasicConfig(string $name, string $key, string $value): void {
     $this->setConfig($name, $key, $value);
   }
@@ -92,9 +92,8 @@ class ConfigContext extends RawDrupalContext implements TranslatableContext {
    *     | front | /node  |
    *     | 403   | /error |
    * @endcode
-   *
-   * @Given I set the configuration item :name with key :key with values:
    */
+  #[Given('I set the configuration item :name with key :key with values:')]
   public function setComplexConfig(string $name, string $key, TableNode $config_table): void {
     $value = [];
     foreach ($config_table->getHash() as $row) {

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Context;
 
+use Behat\Step\Given;
+use Behat\Step\Then;
 use Behat\Behat\Context\TranslatableContext;
 use Behat\Mink\Element\Element;
 
@@ -32,11 +34,10 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * Given I am not logged in
    * Then I log out
    * @endcode
-   *
-   * @Given I am an anonymous user
-   * @Given I am not logged in
-   * @Then I log out
    */
+  #[Given('I am an anonymous user')]
+  #[Given('I am not logged in')]
+  #[Then('I log out')]
   public function assertAnonymousUser(): void {
     // Verify the user is logged out.
     $this->logout(TRUE);
@@ -50,10 +51,9 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * Given I am logged in as a user with the "editor, admin" roles
    * Given I am logged in as an "editor"
    * @endcode
-   *
-   * @Given I am logged in as a user with the :role role(s)
-   * @Given I am logged in as a/an :role
    */
+  #[Given('I am logged in as a user with the :role role(s)')]
+  #[Given('I am logged in as a/an :role')]
   public function assertAuthenticatedByRole(string $role): void {
     // Create user (and project)
     $user = (object) [
@@ -86,9 +86,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    *     | field_user_name    | John  |
    *     | field_user_surname | Smith |
    * @endcode
-   *
-   * @Given I am logged in as a user with the :role role(s) and I have the following fields:
    */
+  #[Given('I am logged in as a user with the :role role(s) and I have the following fields:')]
   public function assertAuthenticatedByRoleWithGivenFields(string $role, TableNode $fields): void {
     // Create user (and project)
     $user = (object) [
@@ -124,9 +123,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @code
    * Given I am logged in as "admin"
    * @endcode
-   *
-   * @Given I am logged in as :name
    */
+  #[Given('I am logged in as :name')]
   public function assertLoggedInByName(string $name): void {
     $manager = $this->getUserManager();
 
@@ -144,9 +142,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * Given I am logged in as a user with the "administer nodes" permission
    * Given I am logged in as a user with the "administer nodes, bypass node access" permissions
    * @endcode
-   *
-   * @Given I am logged in as a user with the :permissions permission(s)
    */
+  #[Given('I am logged in as a user with the :permissions permission(s)')]
   public function assertLoggedInWithPermissions(string $permissions): void {
     // Create a temporary role with given permissions.
     $permissions = array_map(trim(...), explode(',', $permissions));
@@ -202,9 +199,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * Then I should see "Edit" in the "My article" row
    * Then I should see the text "Edit" in the "My article" row
    * @endcode
-   *
-   * @Then I should see (the text ):text in the :rowText row
    */
+  #[Then('I should see (the text ):text in the :rowText row')]
   public function assertTextInTableRow(string $text, string $rowText): void {
     $row = $this->getTableRow($this->getSession()->getPage(), $rowText);
     if (!str_contains($row->getText(), $text)) {
@@ -219,9 +215,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * Then I should not see "Delete" in the "My article" row
    * Then I should not see the text "Delete" in the "My article" row
    * @endcode
-   *
-   * @Then I should not see (the text ):text in the :rowText row
    */
+  #[Then('I should not see (the text ):text in the :rowText row')]
   public function assertTextNotInTableRow(string $text, string $rowText): void {
     $row = $this->getTableRow($this->getSession()->getPage(), $rowText);
     if (str_contains($row->getText(), $text)) {
@@ -239,9 +234,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * Then I see the "Edit" in the "My article" row
    * Then I should see the "Edit" in the "My article" row
    * @endcode
-   *
-   * @Then I (should )see the :link in the :rowText row
    */
+  #[Then('I (should )see the :link in the :rowText row')]
   public function assertLinkInTableRow(string $link, string $rowText): void {
     $page = $this->getSession()->getPage();
     if ($this->getTableRow($page, $rowText)->findLink($link)) {
@@ -259,9 +253,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @code
    * Then I should not see the "Delete" in the "My article" row
    * @endcode
-   *
-   * @Then I should not see the :link in the :rowText row
    */
+  #[Then('I should not see the :link in the :rowText row')]
   public function assertNotLinkInTableRow(string $link, string $rowText): void {
     $page = $this->getSession()->getPage();
     if ($this->getTableRow($page, $rowText)->findLink($link)) {
@@ -278,9 +271,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @code
    * Given I click "Edit" in the "My article" row
    * @endcode
-   *
-   * @Given I click :link in the :rowText row
    */
+  #[Given('I click :link in the :rowText row')]
   public function assertClickInTableRow(string $link, string $rowText): void {
     $page = $this->getSession()->getPage();
     if ($linkElement = $this->getTableRow($page, $rowText)->findLink($link)) {
@@ -301,9 +293,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @code
    * Given I press "Remove" in the "My article" row
    * @endcode
-   *
-   * @Given I press :button in the :rowText row
    */
+  #[Given('I press :button in the :rowText row')]
   public function assertPressInTableRow(string $button, string $rowText): void {
     $page = $this->getSession()->getPage();
     if ($buttonElement = $this->getTableRow($page, $rowText)->findButton($button)) {
@@ -320,9 +311,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @code
    * Given the cache has been cleared
    * @endcode
-   *
-   * @Given the cache has been cleared
    */
+  #[Given('the cache has been cleared')]
   public function assertCacheClear(): void {
     $this->getDriver()->clearCache();
   }
@@ -333,9 +323,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @code
    * Given I run cron
    * @endcode
-   *
-   * @Given I run cron
    */
+  #[Given('I run cron')]
   public function assertCron(): void {
     $this->getDriver()->runCron();
   }
@@ -348,10 +337,9 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * Given I am viewing an "article" content with the title "Test article"
    * Given a "page" with the title "About us"
    * @endcode
-   *
-   * @Given I am viewing a/an :type (content )with the title :title
-   * @Given a/an :type (content )with the title :title
    */
+  #[Given('I am viewing a/an :type (content )with the title :title')]
+  #[Given('a/an :type (content )with the title :title')]
   public function createNode(string $type, string $title): void {
     // @todo make this easily extensible.
     $node = (object) [
@@ -370,9 +358,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * Given I am viewing my "article" with the title "My article"
    * Given I am viewing my "article" content with the title "My article"
    * @endcode
-   *
-   * @Given I am viewing my :type (content )with the title :title
    */
+  #[Given('I am viewing my :type (content )with the title :title')]
   public function createMyNode(string $type, string $title): void {
     if ($this->getUserManager()->currentUserIsAnonymous()) {
       throw new \Exception('There is no current logged in user to create a node for.');
@@ -398,9 +385,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    *     | title      | status |
    *     | My article | 1      |
    * @endcode
-   *
-   * @Given :type content:
    */
+  #[Given(':type content:')]
   public function createNodes(string $type, TableNode $nodesTable): void {
     foreach ($nodesTable->getHash() as $nodeHash) {
       $node = (object) $nodeHash;
@@ -420,9 +406,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    *     | title | My article     |
    *     | body  | Lorem ipsum    |
    * @endcode
-   *
-   * @Given I am viewing a/an :type( content):
    */
+  #[Given('I am viewing a/an :type( content):')]
   public function assertViewingNode(string $type, TableNode $fields): void {
     $node = (object) [
       'type' => $type,
@@ -444,9 +429,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * Then I should be able to edit an "article"
    * Then I should be able to edit an "article" content
    * @endcode
-   *
-   * @Then I should be able to edit a/an :type( content)
    */
+  #[Then('I should be able to edit a/an :type( content)')]
   public function assertEditNodeOfType(string $type): void {
     $node = (object) [
       'type' => $type,
@@ -468,10 +452,9 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * Given I am viewing a "tags" term with the name "Sports"
    * Given an "categories" term with the name "News"
    * @endcode
-   *
-   * @Given I am viewing a/an :vocabulary term with the name :name
-   * @Given a/an :vocabulary term with the name :name
    */
+  #[Given('I am viewing a/an :vocabulary term with the name :name')]
+  #[Given('a/an :vocabulary term with the name :name')]
   public function createTerm(string $vocabulary, string $name): void {
     // @todo make this easily extensible.
     $term = (object) [
@@ -493,9 +476,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    *     | name     | mail            | roles  |
    *     | Joe User | joe@example.com | editor |
    * @endcode
-   *
-   * @Given users:
    */
+  #[Given('users:')]
   public function createUsers(TableNode $usersTable): void {
     foreach ($usersTable->getHash() as $userHash) {
       // Split out roles to process after user is created.
@@ -529,9 +511,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    *     | Sports |
    *     | News   |
    * @endcode
-   *
-   * @Given :vocabulary terms:
    */
+  #[Given(':vocabulary terms:')]
   public function createTerms(string $vocabulary, TableNode $termsTable): void {
     foreach ($termsTable->getHash() as $termsHash) {
       $term = (object) $termsHash;
@@ -555,9 +536,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    *     | languages |
    *     | de        |
    * @endcode
-   *
-   * @Given the/these (following )languages are available:
    */
+  #[Given('the/these (following )languages are available:')]
   public function createLanguages(TableNode $langcodesTable): void {
     foreach ($langcodesTable->getHash() as $row) {
       $language = (object) [
@@ -574,9 +554,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * Then break
    * Then I break
    * @endcode
-   *
-   * @Then (I )break
    */
+  #[Then('(I )break')]
   // phpcs:ignore Drupal.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
   public function iPutABreakpoint(): void {
     fwrite(STDOUT, "\033[s \033[93m[Breakpoint] Press \033[1;93m[RETURN]\033[0;93m to continue, or 'q' to quit...\033[0m");

--- a/src/Drupal/DrupalExtension/Context/DrushContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrushContext.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Context;
 
+use Behat\Step\Given;
+use Behat\Step\Then;
 use Behat\Behat\Context\TranslatableContext;
 
 /**
@@ -44,9 +46,8 @@ class DrushContext extends RawDrupalContext implements TranslatableContext {
    * @code
    * Given I run drush "status"
    * @endcode
-   *
-   * @Given I run drush :command
    */
+  #[Given('I run drush :command')]
   public function assertDrushCommand(string $command): void {
     if (!$this->drushOutput = $this->getDriver('drush')->$command()) {
       $this->drushOutput = TRUE;
@@ -59,9 +60,8 @@ class DrushContext extends RawDrupalContext implements TranslatableContext {
    * @code
    * Given I run drush "pm:list" "--status=enabled"
    * @endcode
-   *
-   * @Given I run drush :command :arguments
    */
+  #[Given('I run drush :command :arguments')]
   public function assertDrushCommandWithArgument(string $command, string $arguments): void {
     $this->drushOutput = $this->getDriver('drush')->$command($this->fixStepArgument($arguments));
     if ($this->drushOutput === NULL) {
@@ -75,9 +75,8 @@ class DrushContext extends RawDrupalContext implements TranslatableContext {
    * @code
    * Then drush output should contain "Drupal version"
    * @endcode
-   *
-   * @Then drush output should contain :output
    */
+  #[Then('drush output should contain :output')]
   public function assertDrushOutput(string $output): void {
     if (!str_contains((string) $this->readDrushOutput(), $this->fixStepArgument($output))) {
       throw new \Exception(sprintf("The last drush command output did not contain '%s'.\nInstead, it was:\n\n%s'", $output, $this->drushOutput));
@@ -90,9 +89,8 @@ class DrushContext extends RawDrupalContext implements TranslatableContext {
    * @code
    * Then drush output should match "/Drupal [0-9]+/"
    * @endcode
-   *
-   * @Then drush output should match :regex
    */
+  #[Then('drush output should match :regex')]
   public function assertDrushOutputMatches(string $regex): void {
     if (!preg_match($regex, (string) $this->readDrushOutput())) {
       throw new \Exception(sprintf("The pattern %s was not found anywhere in the drush output.\nOutput:\n\n%s", $regex, $this->drushOutput));
@@ -105,9 +103,8 @@ class DrushContext extends RawDrupalContext implements TranslatableContext {
    * @code
    * Then drush output should not contain "error"
    * @endcode
-   *
-   * @Then drush output should not contain :output
    */
+  #[Then('drush output should not contain :output')]
   public function drushOutputShouldNotContain(string $output): void {
     if (str_contains((string) $this->readDrushOutput(), $this->fixStepArgument($output))) {
       throw new \Exception(sprintf("The last drush command output did contain '%s' although it should not.\nOutput:\n\n%s'", $output, $this->drushOutput));
@@ -120,9 +117,8 @@ class DrushContext extends RawDrupalContext implements TranslatableContext {
    * @code
    * Then print last drush output
    * @endcode
-   *
-   * @Then print last drush output
    */
+  #[Then('print last drush output')]
   public function printLastDrushOutput(): void {
     echo $this->readDrushOutput();
   }

--- a/src/Drupal/DrupalExtension/Context/MailContext.php
+++ b/src/Drupal/DrupalExtension/Context/MailContext.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Context;
 
+use Behat\Hook\BeforeScenario;
+use Behat\Hook\AfterScenario;
+use Behat\Step\When;
+use Behat\Step\Then;
 use Behat\Behat\Hook\Scope\ScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 
@@ -14,9 +18,8 @@ class MailContext extends RawMailContext {
 
   /**
    * By default, prevent mail from being actually sent out during tests.
-   *
-   * @BeforeScenario
    */
+  #[BeforeScenario]
   public function disableMail(ScenarioScope $event): void {
     $tags = array_merge($event->getFeature()->getTags(), $event->getScenario()->getTags());
     if (!in_array('sendmail', $tags) && !in_array('sendemail', $tags)) {
@@ -30,9 +33,8 @@ class MailContext extends RawMailContext {
 
   /**
    * Restore mail sending.
-   *
-   * @AfterScenario
    */
+  #[AfterScenario]
   public function enableMail(ScenarioScope $event): void {
     $tags = array_merge($event->getFeature()->getTags(), $event->getScenario()->getTags());
     if (!in_array('sendmail', $tags) && !in_array('sendemail', $tags)) {
@@ -45,18 +47,16 @@ class MailContext extends RawMailContext {
    *
    * When using the default mail manager service, it is not necessary to use
    * this tag.
-   *
-   * @BeforeScenario @mail,@email
    */
+  #[BeforeScenario('@mail,@email')]
   public function collectMail(): void {
     $this->getMailManager()->startCollectingMail();
   }
 
   /**
    * Stop collecting mail at scenario end.
-   *
-   * @AfterScenario @mail,@email
    */
+  #[AfterScenario('@mail,@email')]
   public function stopCollectingMail(): void {
     $this->getMailManager()->stopCollectingMail();
   }
@@ -74,9 +74,8 @@ class MailContext extends RawMailContext {
    *     | subject | Test email       |
    *     | body    | Hello world      |
    * @endcode
-   *
-   * @When Drupal sends a/an (e)mail:
    */
+  #[When('Drupal sends a/an (e)mail:')]
   public function drupalSendsMail(TableNode $fields): void {
     $mail = [
       'body' => $this->getRandom()->name(255),
@@ -106,12 +105,11 @@ class MailContext extends RawMailContext {
    *     | body                |
    *     | Welcome to the site |
    * @endcode
-   *
-   * @Then (a )(an )(e)mail(s) has/have been sent:
-   * @Then (a )(an )(e)mail(s) has/have been sent to :to:
-   * @Then (a )(an )(e)mail(s) has/have been sent with the subject :subject:
-   * @Then (a )(an )(e)mail(s) has/have been sent to :to with the subject :subject:
    */
+  #[Then('(a )(an )(e)mail(s) has/have been sent:')]
+  #[Then('(a )(an )(e)mail(s) has/have been sent to :to:')]
+  #[Then('(a )(an )(e)mail(s) has/have been sent with the subject :subject:')]
+  #[Then('(a )(an )(e)mail(s) has/have been sent to :to with the subject :subject:')]
   public function mailHasBeenSent(TableNode $expectedMailTable, string $to = '', string $subject = ''): void {
     $expected = $expectedMailTable->getHash();
     $actual = $this->getMail(['to' => $to, 'subject' => $subject]);
@@ -129,12 +127,11 @@ class MailContext extends RawMailContext {
    *     | subject   |
    *     | Greetings |
    * @endcode
-   *
-   * @Then (a )(an )new (e)mail(s) is/are sent:
-   * @Then (a )(an )new (e)mail(s) is/are sent to :to:
-   * @Then (a )(an )new (e)mail(s) is/are sent with the subject :subject:
-   * @Then (a )(an )new (e)mail(s) is/are sent to :to with the subject :subject:
    */
+  #[Then('(a )(an )new (e)mail(s) is/are sent:')]
+  #[Then('(a )(an )new (e)mail(s) is/are sent to :to:')]
+  #[Then('(a )(an )new (e)mail(s) is/are sent with the subject :subject:')]
+  #[Then('(a )(an )new (e)mail(s) is/are sent to :to with the subject :subject:')]
   public function newMailIsSent(TableNode $expectedMailTable, string $to = '', string $subject = ''): void {
     $expected = $expectedMailTable->getHash();
     $actual = $this->getMail(['to' => $to, 'subject' => $subject], TRUE);
@@ -149,12 +146,11 @@ class MailContext extends RawMailContext {
    * Then 2 mails have been sent to "user@example.com"
    * Then 1 email has been sent with the subject "Welcome"
    * @endcode
-   *
-   * @Then :count (e)mail(s) has/have been sent
-   * @Then :count (e)mail(s) has/have been sent to :to
-   * @Then :count (e)mail(s) has/have been sent with the subject :subject
-   * @Then :count (e)mail(s) has/have been sent to :to with the subject :subject
    */
+  #[Then(':count (e)mail(s) has/have been sent')]
+  #[Then(':count (e)mail(s) has/have been sent to :to')]
+  #[Then(':count (e)mail(s) has/have been sent with the subject :subject')]
+  #[Then(':count (e)mail(s) has/have been sent to :to with the subject :subject')]
   public function noMailHasBeenSent(string $count, string $to = '', string $subject = ''): void {
     $actual = $this->getMail(['to' => $to, 'subject' => $subject]);
     $expectedCount = match ($count) {
@@ -172,12 +168,11 @@ class MailContext extends RawMailContext {
    * Then 0 new emails are sent
    * Then 1 new mail is sent to "user@example.com"
    * @endcode
-   *
-   * @Then :count new (e)mail(s) is/are sent
-   * @Then :count new (e)mail(s) is/are sent to :to
-   * @Then :count new (e)mail(s) is/are sent with the subject :subject
-   * @Then :count new (e)mail(s) is/are sent to :to with the subject :subject
    */
+  #[Then(':count new (e)mail(s) is/are sent')]
+  #[Then(':count new (e)mail(s) is/are sent to :to')]
+  #[Then(':count new (e)mail(s) is/are sent with the subject :subject')]
+  #[Then(':count new (e)mail(s) is/are sent to :to with the subject :subject')]
   public function noNewMailIsSent(string $count, string $to = '', string $subject = ''): void {
     $actual = $this->getMail(['to' => $to, 'subject' => $subject], TRUE);
     $expectedCount = match ($count) {
@@ -197,12 +192,11 @@ class MailContext extends RawMailContext {
    * When I follow the link to "user/reset" from the email to "user@example.com"
    * When I follow the link to "user/reset" from the email with the subject "Welcome"
    * @endcode
-   *
-   * @When I follow the link to :urlFragment from the (e)mail
-   * @When I follow the link to :urlFragment from the (e)mail to :to
-   * @When I follow the link to :urlFragment from the (e)mail with the subject :subject
-   * @When I follow the link to :urlFragment from the (e)mail to :to with the subject :subject
    */
+  #[When('I follow the link to :urlFragment from the (e)mail')]
+  #[When('I follow the link to :urlFragment from the (e)mail to :to')]
+  #[When('I follow the link to :urlFragment from the (e)mail with the subject :subject')]
+  #[When('I follow the link to :urlFragment from the (e)mail to :to with the subject :subject')]
   public function followLinkInMail(string $urlFragment, string $to = '', string $subject = ''): void {
     // Get the message.
     $filters = ['to' => $to, 'subject' => $subject];

--- a/src/Drupal/DrupalExtension/Context/MarkupContext.php
+++ b/src/Drupal/DrupalExtension/Context/MarkupContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Context;
 
+use Behat\Step\Then;
 use Behat\MinkExtension\Context\RawMinkContext;
 
 /**
@@ -51,10 +52,9 @@ class MarkupContext extends RawMinkContext {
    * Then I should see the button "Submit" in the "content" region
    * Then I should see the "Submit" button in the "content" region
    * @endcode
-   *
-   * @Then I should see the button :button in the :region( region)
-   * @Then I should see the :button button in the :region( region)
    */
+  #[Then('I should see the button :button in the :region( region)')]
+  #[Then('I should see the :button button in the :region( region)')]
   public function assertRegionButton(string $button, string $region): void {
     $regionObj = $this->getRegion($region);
 
@@ -80,10 +80,9 @@ class MarkupContext extends RawMinkContext {
    * Then I should not see the button "Delete" in the "sidebar" region
    * Then I should not see the "Delete" button in the "sidebar" region
    * @endcode
-   *
-   * @Then I should not see the button :button in the :region( region)
-   * @Then I should not see the :button button in the :region( region)
    */
+  #[Then('I should not see the button :button in the :region( region)')]
+  #[Then('I should not see the :button button in the :region( region)')]
   public function assertNotRegionButton(string $button, string $region): void {
     $regionObj = $this->getRegion($region);
 
@@ -100,9 +99,8 @@ class MarkupContext extends RawMinkContext {
    * Then I see the "h2" element in the "content"
    * Then I should see the "h2" element in the "content" region
    * @endcode
-   *
-   * @Then I( should) see the :tag element in the :region( region)
    */
+  #[Then('I( should) see the :tag element in the :region( region)')]
   public function assertRegionElement(string $tag, string $region): void {
     $regionObj = $this->getRegion($region);
     $elements = $regionObj->findAll('css', $tag);
@@ -119,9 +117,8 @@ class MarkupContext extends RawMinkContext {
    * Then I not see the "h2" element in the "sidebar"
    * Then I should not see the "h2" element in the "sidebar" region
    * @endcode
-   *
-   * @Then I( should) not see the :tag element in the :region( region)
    */
+  #[Then('I( should) not see the :tag element in the :region( region)')]
   public function assertNotRegionElement(string $tag, string $region): void {
     $regionObj = $this->getRegion($region);
     $result = $regionObj->findAll('css', $tag);
@@ -137,9 +134,8 @@ class MarkupContext extends RawMinkContext {
    * Then I see "Welcome" in the "h2" element in the "content"
    * Then I should see "Welcome" in the "h2" element in the "content" region
    * @endcode
-   *
-   * @Then I( should) see :text in the :tag element in the :region( region)
    */
+  #[Then('I( should) see :text in the :tag element in the :region( region)')]
   public function assertRegionElementText(string $text, string $tag, string $region): void {
     $regionObj = $this->getRegion($region);
     $results = $regionObj->findAll('css', $tag);
@@ -160,9 +156,8 @@ class MarkupContext extends RawMinkContext {
    * Then I not see "Error" in the "div" element in the "content"
    * Then I should not see "Error" in the "div" element in the "content" region
    * @endcode
-   *
-   * @Then I( should) not see :text in the :tag element in the :region( region)
    */
+  #[Then('I( should) not see :text in the :tag element in the :region( region)')]
   public function assertNotRegionElementText(string $text, string $tag, string $region): void {
     $regionObj = $this->getRegion($region);
     $results = $regionObj->findAll('css', $tag);
@@ -182,9 +177,8 @@ class MarkupContext extends RawMinkContext {
    * Then I see the "a" element with the "href" attribute set to "/about" in the "footer"
    * Then I should see the "a" element with the "href" attribute set to "/about" in the "footer" region
    * @endcode
-   *
-   * @Then I( should) see the :tag element with the :attribute attribute set to :value in the :region( region)
    */
+  #[Then('I( should) see the :tag element with the :attribute attribute set to :value in the :region( region)')]
   public function assertRegionElementAttribute(string $tag, string $attribute, string $value, string $region): void {
     $regionObj = $this->getRegion($region);
     $elements = $regionObj->findAll('css', $tag);
@@ -220,9 +214,8 @@ class MarkupContext extends RawMinkContext {
    * Then I see "About" in the "a" element with the "href" attribute set to "/about" in the "footer"
    * Then I should see "About" in the "a" element with the "href" attribute set to "/about" in the "footer" region
    * @endcode
-   *
-   * @Then I( should) see :text in the :tag element with the :attribute attribute set to :value in the :region( region)
    */
+  #[Then('I( should) see :text in the :tag element with the :attribute attribute set to :value in the :region( region)')]
   public function assertRegionElementTextAttribute(string $text, string $tag, string $attribute, string $value, string $region): void {
     $regionObj = $this->getRegion($region);
     $elements = $regionObj->findAll('css', $tag);
@@ -259,9 +252,8 @@ class MarkupContext extends RawMinkContext {
    * Then I see "Notice" in the "div" element with the "color" CSS property set to "red" in the "content"
    * Then I should see "Notice" in the "div" element with the "color" CSS property set to "red" in the "content" region
    * @endcode
-   *
-   * @Then I( should) see :text in the :tag element with the :property CSS property set to :value in the :region( region)
    */
+  #[Then('I( should) see :text in the :tag element with the :property CSS property set to :value in the :region( region)')]
   public function assertRegionElementTextCss(string $text, string $tag, string $property, string $value, string $region): void {
     $regionObj = $this->getRegion($region);
     $elements = $regionObj->findAll('css', $tag);

--- a/src/Drupal/DrupalExtension/Context/MessageContext.php
+++ b/src/Drupal/DrupalExtension/Context/MessageContext.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Context;
 
+use Behat\Step\Then;
+use Behat\Step\Given;
 use Behat\Behat\Context\TranslatableContext;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
@@ -30,9 +32,8 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    *   Then I should see the error message "Username is required"
    *   Then I should see the error message containing "Username"
    * @endcode
-   *
-   * @Then I should see the error message( containing) :message
    */
+  #[Then('I should see the error message( containing) :message')]
   public function assertErrorVisible(string $message): void {
     $this->assert(
           $message,
@@ -55,9 +56,8 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    *     | Username is required   |
    *     | Password is required   |
    * @endcode
-   *
-   * @Then I should see the following error message(s):
    */
+  #[Then('I should see the following error message(s):')]
   public function assertMultipleErrors(TableNode $messages): void {
     $this->assertValidMessageTable($messages, 'error messages');
     foreach ($messages->getHash() as $value) {
@@ -77,9 +77,8 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    *   Given I should not see the error message "Access denied"
    *   Given I should not see the error message containing "Access"
    * @endcode
-   *
-   * @Given I should not see the error message( containing) :message
    */
+  #[Given('I should not see the error message( containing) :message')]
   public function assertNotErrorVisible(string $message): void {
     $this->assertNot(
           $message,
@@ -100,9 +99,8 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    *     | error messages |
    *     | Access denied  |
    * @endcode
-   *
-   * @Then I should not see the following error messages:
    */
+  #[Then('I should not see the following error messages:')]
   public function assertNotMultipleErrors(TableNode $messages): void {
     $this->assertValidMessageTable($messages, 'error messages');
     foreach ($messages->getHash() as $value) {
@@ -122,9 +120,8 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    *   Then I should see the success message "Article has been created"
    *   Then I should see the success message containing "created"
    * @endcode
-   *
-   * @Then I should see the success message( containing) :message
    */
+  #[Then('I should see the success message( containing) :message')]
   public function assertSuccessMessage(string $message): void {
     $this->assert(
           $message,
@@ -146,9 +143,8 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    *     | success messages        |
    *     | Article has been created |
    * @endcode
-   *
-   * @Then I should see the following success messages:
    */
+  #[Then('I should see the following success messages:')]
   public function assertMultipleSuccessMessage(TableNode $messages): void {
     $this->assertValidMessageTable($messages, 'success messages');
     foreach ($messages->getHash() as $value) {
@@ -168,9 +164,8 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    *   Given I should not see the success message "saved"
    *   Given I should not see the success message containing "saved"
    * @endcode
-   *
-   * @Given I should not see the success message( containing) :message
    */
+  #[Given('I should not see the success message( containing) :message')]
   public function assertNotSuccessMessage(string $message): void {
     $this->assertNot(
           $message,
@@ -191,9 +186,8 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    *     | success messages |
    *     | Changes saved    |
    * @endcode
-   *
-   * @Then I should not see the following success messages:
    */
+  #[Then('I should not see the following success messages:')]
   public function assertNotMultipleSuccessMessage(TableNode $messages): void {
     $this->assertValidMessageTable($messages, 'success messages');
     foreach ($messages->getHash() as $value) {
@@ -213,9 +207,8 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    *   Then I should see the warning message "This action cannot be undone"
    *   Then I should see the warning message containing "cannot be undone"
    * @endcode
-   *
-   * @Then I should see the warning message( containing) :message
    */
+  #[Then('I should see the warning message( containing) :message')]
   public function assertWarningMessage(string $message): void {
     $this->assert(
           $message,
@@ -237,9 +230,8 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    *     | warning messages                |
    *     | This action cannot be undone    |
    * @endcode
-   *
-   * @Then I should see the following warning messages:
    */
+  #[Then('I should see the following warning messages:')]
   public function assertMultipleWarningMessage(TableNode $messages): void {
     $this->assertValidMessageTable($messages, 'warning messages');
     foreach ($messages->getHash() as $value) {
@@ -259,9 +251,8 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    *   Given I should not see the warning message "deprecated"
    *   Given I should not see the warning message containing "deprecated"
    * @endcode
-   *
-   * @Given I should not see the warning message( containing) :message
    */
+  #[Given('I should not see the warning message( containing) :message')]
   public function assertNotWarningMessage(string $message): void {
     $this->assertNot(
           $message,
@@ -282,9 +273,8 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    *     | warning messages |
    *     | deprecated       |
    * @endcode
-   *
-   * @Then I should not see the following warning messages:
    */
+  #[Then('I should not see the following warning messages:')]
   public function assertNotMultipleWarningMessage(TableNode $messages): void {
     $this->assertValidMessageTable($messages, 'warning messages');
     foreach ($messages->getHash() as $value) {
@@ -304,9 +294,8 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    *   Then I should see the message "Changes saved"
    *   Then I should see the message containing "saved"
    * @endcode
-   *
-   * @Then I should see the message( containing) :message
    */
+  #[Then('I should see the message( containing) :message')]
   public function assertMessage(string $message): void {
     $this->assert(
           $message,
@@ -326,9 +315,8 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    *   Then I should not see the message "Access denied"
    *   Then I should not see the message containing "denied"
    * @endcode
-   *
-   * @Then I should not see the message( containing) :message
    */
+  #[Then('I should not see the message( containing) :message')]
   public function assertNotMessage(string $message): void {
     $this->assertNot(
           $message,

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Context;
 
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Hook\BeforeStep;
+use Behat\Hook\AfterStep;
+use Behat\Step\Then;
 use Behat\Behat\Hook\Scope\BeforeStepScope;
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Behat\Context\TranslatableContext;
@@ -58,11 +63,11 @@ class MinkContext extends MinkExtension implements TranslatableContext {
    * When I visit "/node/1"
    * @endcode
    *
-   * @Given I am at :path
-   * @When I visit :path
    *
    * @throws \Behat\Mink\Exception\UnsupportedDriverActionException
    */
+  #[Given('I am at :path')]
+  #[When('I visit :path')]
   public function assertAtPath(string $path): void {
     $this->getSession()->visit($this->locatePath($path));
 
@@ -82,9 +87,8 @@ class MinkContext extends MinkExtension implements TranslatableContext {
    * @code
    * When I click "Read more"
    * @endcode
-   *
-   * @When I click :link
    */
+  #[When('I click :link')]
   public function assertClick(string $link): void {
     // Use the Mink Extension step definition.
     $this->clickLink($link);
@@ -97,10 +101,9 @@ class MinkContext extends MinkExtension implements TranslatableContext {
    * Given for "Title" I enter "My article"
    * Given I enter "My article" for "Title"
    * @endcode
-   *
-   * @Given for :field I enter :value
-   * @Given I enter :value for :field
    */
+  #[Given('for :field I enter :value')]
+  #[Given('I enter :value for :field')]
   public function assertEnterField(string $field, string $value): void {
     // Use the Mink Extension step definition.
     $this->fillField($field, $value);
@@ -108,9 +111,8 @@ class MinkContext extends MinkExtension implements TranslatableContext {
 
   /**
    * For javascript enabled scenarios, always wait for AJAX before clicking.
-   *
-   * @BeforeStep
    */
+  #[BeforeStep]
   public function beforeJavascriptStep(BeforeStepScope $event): void {
     /** @var \Behat\Behat\Hook\Scope\BeforeStepScope $event */
     // Make sure the feature is registered in case this hook fires before
@@ -128,9 +130,8 @@ class MinkContext extends MinkExtension implements TranslatableContext {
 
   /**
    * For javascript enabled scenarios, always wait for AJAX after clicking.
-   *
-   * @AfterStep
    */
+  #[AfterStep]
   public function afterJavascriptStep(AfterStepScope $event): void {
     if (!$this->hasTag('javascript')) {
       return;
@@ -149,9 +150,8 @@ class MinkContext extends MinkExtension implements TranslatableContext {
    * @code
    * Given I wait for AJAX to finish
    * @endcode
-   *
-   * @Given I wait for AJAX to finish
    */
+  #[Given('I wait for AJAX to finish')]
   public function iWaitForAjaxToFinish(mixed $event = NULL): void {
     if (!$this->getSession()->isStarted()) {
       return;
@@ -203,9 +203,8 @@ JS;
    * @code
    * When I press the "Save" button
    * @endcode
-   *
-   * @When I press the :button button
    */
+  #[When('I press the :button button')]
   public function pressButton(mixed $button) {
     // Wait for any open autocomplete boxes to finish closing.  They block
     // form-submission if they are still open.
@@ -238,9 +237,8 @@ JS;
    * @code
    *   Given I press the "enter" key in the "Search" field
    * @endcode
-   *
-   * @Given I press the :char key in the :field field
    */
+  #[Given('I press the :char key in the :field field')]
   public function pressKey(mixed $char, string $field): void {
     static $keys = [
       'backspace' => 8,
@@ -296,9 +294,8 @@ JS;
    * @code
    * Then I should see the link "Log out"
    * @endcode
-   *
-   * @Then I should see the link :link
    */
+  #[Then('I should see the link :link')]
   public function assertLinkVisible(string $link): void {
     $element = $this->getSession()->getPage();
     $result = $element->findLink($link);
@@ -325,9 +322,8 @@ JS;
    * @code
    * Then I should not see the link "Log out"
    * @endcode
-   *
-   * @Then I should not see the link :link
    */
+  #[Then('I should not see the link :link')]
   public function assertNotLinkVisible(string $link): void {
     $element = $this->getSession()->getPage();
     $result = $element->findLink($link);
@@ -354,9 +350,8 @@ JS;
    * @code
    * Then I should not visibly see the link "Skip to main content"
    * @endcode
-   *
-   * @Then I should not visibly see the link :link
    */
+  #[Then('I should not visibly see the link :link')]
   public function assertNotLinkVisuallyVisible(string $link): void {
     $element = $this->getSession()->getPage();
     $result = $element->findLink($link);
@@ -384,9 +379,8 @@ JS;
    * Then I see the heading "Welcome"
    * Then I should see the heading "Welcome"
    * @endcode
-   *
-   * @Then I (should )see the heading :heading
    */
+  #[Then('I (should )see the heading :heading')]
   public function assertHeading(string $heading): void {
     $element = $this->getSession()->getPage();
     foreach (['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as $tag) {
@@ -407,9 +401,8 @@ JS;
    * Then I not see the heading "Error"
    * Then I should not see the heading "Error"
    * @endcode
-   *
-   * @Then I (should )not see the heading :heading
    */
+  #[Then('I (should )not see the heading :heading')]
   public function assertNotHeading(string $heading): void {
     $element = $this->getSession()->getPage();
     foreach (['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as $tag) {
@@ -430,10 +423,9 @@ JS;
    * Then I should see the button "Save"
    * Then I should see the "Save" button
    * @endcode
-   *
-   * @Then I (should ) see the button :button
-   * @Then I (should ) see the :button button
    */
+  #[Then('I (should ) see the button :button')]
+  #[Then('I (should ) see the :button button')]
   public function assertButton(string $button): void {
     $element = $this->getSession()->getPage();
     $buttonObj = $element->findButton($button);
@@ -449,10 +441,9 @@ JS;
    * Then I should not see the button "Delete"
    * Then I should not see the "Delete" button
    * @endcode
-   *
-   * @Then I should not see the button :button
-   * @Then I should not see the :button button
    */
+  #[Then('I should not see the button :button')]
+  #[Then('I should not see the :button button')]
   public function assertNotButton(string $button): void {
     $element = $this->getSession()->getPage();
     $buttonObj = $element->findButton($button);
@@ -472,9 +463,8 @@ JS;
    * When I follow "Read more" in the "content" region
    * When I click "Read more" in the "content" region
    * @endcode
-   *
-   * @When I follow/click :link in the :region( region)
    */
+  #[When('I follow/click :link in the :region( region)')]
   public function assertRegionLinkFollow(string $link, string $region): void {
     $regionObj = $this->getRegion($region);
 
@@ -501,9 +491,8 @@ JS;
    * Given I press "Submit" in the "sidebar"
    * Given I press "Submit" in the "sidebar" region
    * @endcode
-   *
-   * @Given I press :button in the :region( region)
    */
+  #[Given('I press :button in the :region( region)')]
   public function assertRegionPressButton(string $button, string $region): void {
     $regionObj = $this->getRegion($region);
 
@@ -525,10 +514,9 @@ JS;
    * Given I fill in "test" for "Search" in the "header" region
    * Given I fill in "Search" with "test" in the "header" region
    * @endcode
-   *
-   * @Given I fill in :value for :field in the :region( region)
-   * @Given I fill in :field with :value in the :region( region)
    */
+  #[Given('I fill in :value for :field in the :region( region)')]
+  #[Given('I fill in :field with :value in the :region( region)')]
   public function regionFillField(string $field, string $value, string $region): void {
     $field = $this->fixStepArgument($field);
     $value = $this->fixStepArgument($value);
@@ -551,9 +539,8 @@ JS;
    * Given I check "Published" in the "content"
    * Given I check "Published" in the "content" region
    * @endcode
-   *
-   * @Given I check :locator in the :region( region)
    */
+  #[Given('I check :locator in the :region( region)')]
   public function assertRegionCheckBox(string $locator, string $region): void {
     $regionObj = $this->getRegion($region);
     $regionObj->checkField($locator);
@@ -574,9 +561,8 @@ JS;
    * Given I uncheck "Promoted" in the "content"
    * Given I uncheck "Promoted" in the "content" region
    * @endcode
-   *
-   * @Given I uncheck :checkbox in the :region( region)
    */
+  #[Given('I uncheck :checkbox in the :region( region)')]
   public function assertRegionUncheckBox(string $locator, string $region): void {
     $regionObj = $this->getRegion($region);
     $regionObj->uncheckField($locator);
@@ -593,10 +579,9 @@ JS;
    * Then I should see the heading "Latest news" in the "sidebar" region
    * Then I should see the "Latest news" heading in the "sidebar" region
    * @endcode
-   *
-   * @Then I should see the heading :heading in the :region( region)
-   * @Then I should see the :heading heading in the :region( region)
    */
+  #[Then('I should see the heading :heading in the :region( region)')]
+  #[Then('I should see the :heading heading in the :region( region)')]
   public function assertRegionHeading(string $heading, string $region): void {
     $regionObj = $this->getRegion($region);
 
@@ -624,9 +609,8 @@ JS;
    * Then I should see the link "About us" in the "footer"
    * Then I should see the link "About us" in the "footer" region
    * @endcode
-   *
-   * @Then I should see the link :link in the :region( region)
    */
+  #[Then('I should see the link :link in the :region( region)')]
   public function assertLinkRegion(string $link, string $region): void {
     $regionObj = $this->getRegion($region);
 
@@ -646,9 +630,8 @@ JS;
    * Then I should not see the link "Admin" in the "footer"
    * Then I should not see the link "Admin" in the "footer" region
    * @endcode
-   *
-   * @Then I should not see the link :link in the :region( region)
    */
+  #[Then('I should not see the link :link in the :region( region)')]
   public function assertNotLinkRegion(string $link, string $region): void {
     $regionObj = $this->getRegion($region);
 
@@ -669,9 +652,8 @@ JS;
    * Then I should see "Welcome" in the "content" region
    * Then I should see the text "Welcome" in the "content" region
    * @endcode
-   *
-   * @Then I should see( the text) :text in the :region( region)
    */
+  #[Then('I should see( the text) :text in the :region( region)')]
   public function assertRegionText(string $text, string $region): void {
     $regionObj = $this->getRegion($region);
 
@@ -693,9 +675,8 @@ JS;
    * Then I should not see "Error" in the "content" region
    * Then I should not see the text "Error" in the "content" region
    * @endcode
-   *
-   * @Then I should not see( the text) :text in the :region( region)
    */
+  #[Then('I should not see( the text) :text in the :region( region)')]
   public function assertNotRegionText(string $text, string $region): void {
     $regionObj = $this->getRegion($region);
 
@@ -713,9 +694,8 @@ JS;
    * Then I see the text "Welcome to Drupal"
    * Then I should see the text "Welcome to Drupal"
    * @endcode
-   *
-   * @Then I (should )see the text :text
    */
+  #[Then('I (should )see the text :text')]
   public function assertTextVisible(string $text): void {
     // Use the Mink Extension step definition.
     $this->assertPageContainsText($text);
@@ -727,9 +707,8 @@ JS;
    * @code
    * Then I should not see the text "Access denied"
    * @endcode
-   *
-   * @Then I should not see the text :text
    */
+  #[Then('I should not see the text :text')]
   public function assertNotTextVisible(string $text): void {
     // Use the Mink Extension step definition.
     $this->assertPageNotContainsText($text);
@@ -741,9 +720,8 @@ JS;
    * @code
    * Then I should get a 200 HTTP response
    * @endcode
-   *
-   * @Then I should get a :code HTTP response
    */
+  #[Then('I should get a :code HTTP response')]
   public function assertHttpResponse(int|string $code): void {
     // Use the Mink Extension step definition.
     $this->assertResponseStatus($code);
@@ -755,9 +733,8 @@ JS;
    * @code
    * Then I should not get a 403 HTTP response
    * @endcode
-   *
-   * @Then I should not get a :code HTTP response
    */
+  #[Then('I should not get a :code HTTP response')]
   public function assertNotHttpResponse(int|string $code): void {
     // Use the Mink Extension step definition.
     $this->assertResponseStatusIsNot($code);
@@ -769,9 +746,8 @@ JS;
    * @code
    * Given I check the box "Published"
    * @endcode
-   *
-   * @Given I check the box :checkbox
    */
+  #[Given('I check the box :checkbox')]
   public function assertCheckBox(string $checkbox): void {
     // Use the Mink Extension step definition.
     $this->checkOption($checkbox);
@@ -783,9 +759,8 @@ JS;
    * @code
    * Given I uncheck the box "Promoted to front page"
    * @endcode
-   *
-   * @Given I uncheck the box :checkbox
    */
+  #[Given('I uncheck the box :checkbox')]
   public function assertUncheckBox(string $checkbox): void {
     // Use the Mink Extension step definition.
     $this->uncheckOption($checkbox);
@@ -800,10 +775,9 @@ JS;
    * When I select the radio button "Full HTML"
    * When I select the radio button "Full HTML" with the id "edit-format-full-html"
    * @endcode
-   *
-   * @When I select the radio button :label with the id :id
-   * @When I select the radio button :label
    */
+  #[When('I select the radio button :label with the id :id')]
+  #[When('I select the radio button :label')]
   public function assertSelectRadioById(string $label, string $id = ''): void {
     $element = $this->getSession()->getPage();
     if ($id !== '' && $id !== '0') {
@@ -835,9 +809,8 @@ JS;
    * When I collapse details labelled "Advanced settings"
    * When I click details labelled "Advanced settings"
    * @endcode
-   *
-   * @When I :action details labelled :summary
    */
+  #[When('I :action details labelled :summary')]
   public function iExpandOrCollapseDetailsByLabel(string $action, string $summary): void {
     $page = $this->getSession()->getPage();
 

--- a/src/Drupal/DrupalExtension/Context/RandomContext.php
+++ b/src/Drupal/DrupalExtension/Context/RandomContext.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Context;
 
+use Behat\Transformation\Transform;
+use Behat\Hook\BeforeScenario;
+use Behat\Hook\AfterScenario;
 use Behat\Behat\Hook\Scope\ScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 
@@ -27,9 +30,8 @@ class RandomContext extends RawDrupalContext {
 
   /**
    * Transform random variables.
-   *
-   * @Transform #([^<]*\<\?.*\>[^>]*)#
    */
+  #[Transform('#([^<]*\<\?.*\>[^>]*)#')]
   public function transformVariables(string $message): string|array|null {
     $patterns = [];
     $replacements = [];
@@ -45,9 +47,8 @@ class RandomContext extends RawDrupalContext {
 
   /**
    * Transform random variables in table arguments.
-   *
-   * @Transform table:*
    */
+  #[Transform('table:*')]
   public function transformTable(TableNode $table): TableNode {
     $rows = [];
     foreach ($table->getRows() as $row) {
@@ -58,9 +59,8 @@ class RandomContext extends RawDrupalContext {
 
   /**
    * Set values for each random variable found in the current scenario.
-   *
-   * @BeforeScenario
    */
+  #[BeforeScenario]
   public function beforeScenarioSetVariables(ScenarioScope $scope): void {
     $steps = [];
     if ($scope->getFeature()->hasBackground()) {
@@ -88,9 +88,8 @@ class RandomContext extends RawDrupalContext {
 
   /**
    * Reset variables after the scenario.
-   *
-   * @AfterScenario
    */
+  #[AfterScenario]
   public function afterScenarioResetVariables(ScenarioScope $scope): void {
     $this->values = [];
   }

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Context;
 
+use Behat\Hook\AfterScenario;
 use Drupal\Driver\DrupalDriver;
+use Drupal\DrupalExtension\Hook\Attribute\BeforeNodeCreate;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Behat\Testwork\Hook\HookDispatcher;
 use Behat\Behat\Context\Environment\InitializedContextEnvironment;
@@ -146,9 +148,8 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
 
   /**
    * Massage node values to match the expectations on different Drupal versions.
-   *
-   * @beforeNodeCreate
    */
+  #[BeforeNodeCreate]
   public static function alterNodeParameters(BeforeNodeCreateScope $scope): void {
     $node = $scope->getEntity();
 
@@ -175,9 +176,8 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
 
   /**
    * Remove any created nodes.
-   *
-   * @AfterScenario
    */
+  #[AfterScenario]
   public function cleanNodes(): void {
     // Remove any nodes that were created.
     foreach ($this->nodes as $node) {
@@ -188,9 +188,8 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
 
   /**
    * Remove any created users.
-   *
-   * @AfterScenario
    */
+  #[AfterScenario]
   public function cleanUsers(): void {
     // Remove any users that were created.
     if ($this->userManager->hasUsers()) {
@@ -214,9 +213,8 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
 
   /**
    * Remove any created terms.
-   *
-   * @AfterScenario
    */
+  #[AfterScenario]
   public function cleanTerms(): void {
     // Remove any terms that were created.
     foreach (array_reverse($this->terms) as $term) {
@@ -227,9 +225,8 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
 
   /**
    * Remove any created roles.
-   *
-   * @AfterScenario
    */
+  #[AfterScenario]
   public function cleanRoles(): void {
     // Remove any roles that were created.
     foreach ($this->roles as $role) {
@@ -240,9 +237,8 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
 
   /**
    * Remove any created languages.
-   *
-   * @AfterScenario
    */
+  #[AfterScenario]
   public function cleanLanguages(): void {
     // Delete any languages that were created.
     foreach ($this->languages as $language) {
@@ -254,9 +250,8 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
 
   /**
    * Clear static caches.
-   *
-   * @AfterScenario @api
    */
+  #[AfterScenario('@api')]
   public function clearStaticCaches(): void {
     $this->getDriver()->clearStaticCaches();
   }

--- a/src/Drupal/DrupalExtension/FeatureTrait.php
+++ b/src/Drupal/DrupalExtension/FeatureTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension;
 
+use Behat\Hook\BeforeStep;
 use Behat\Behat\Hook\Scope\BeforeStepScope;
 
 /**
@@ -27,9 +28,8 @@ trait FeatureTrait {
    *
    * This fires on a BeforeStep rather than a BeforeFeature since the latter
    * can only be called statically.
-   *
-   * @BeforeStep
    */
+  #[BeforeStep]
   public function registerFeature(BeforeStepScope $scope): void {
     $this->currentFeature = $scope->getFeature();
   }

--- a/src/Drupal/DrupalExtension/Hook/Attribute/AfterNodeCreate.php
+++ b/src/Drupal/DrupalExtension/Hook/Attribute/AfterNodeCreate.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Hook\Attribute;
+
+/**
+ * Attribute for methods to run after a node is created.
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class AfterNodeCreate implements DrupalHook {
+
+  public function __construct(public ?string $filterString = NULL) {
+  }
+
+  /**
+   * Returns the filter string for this hook.
+   */
+  public function getFilterString(): ?string {
+    return $this->filterString;
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Hook/Attribute/AfterTermCreate.php
+++ b/src/Drupal/DrupalExtension/Hook/Attribute/AfterTermCreate.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Hook\Attribute;
+
+/**
+ * Attribute for methods to run after a term is created.
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class AfterTermCreate implements DrupalHook {
+
+  public function __construct(public ?string $filterString = NULL) {
+  }
+
+  /**
+   * Returns the filter string for this hook.
+   */
+  public function getFilterString(): ?string {
+    return $this->filterString;
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Hook/Attribute/AfterUserCreate.php
+++ b/src/Drupal/DrupalExtension/Hook/Attribute/AfterUserCreate.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Hook\Attribute;
+
+/**
+ * Attribute for methods to run after a user is created.
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class AfterUserCreate implements DrupalHook {
+
+  public function __construct(public ?string $filterString = NULL) {
+  }
+
+  /**
+   * Returns the filter string for this hook.
+   */
+  public function getFilterString(): ?string {
+    return $this->filterString;
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Hook/Attribute/BeforeNodeCreate.php
+++ b/src/Drupal/DrupalExtension/Hook/Attribute/BeforeNodeCreate.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Hook\Attribute;
+
+/**
+ * Attribute for methods to run before a node is created.
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class BeforeNodeCreate implements DrupalHook {
+
+  public function __construct(public ?string $filterString = NULL) {
+  }
+
+  /**
+   * Returns the filter string for this hook.
+   */
+  public function getFilterString(): ?string {
+    return $this->filterString;
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Hook/Attribute/BeforeTermCreate.php
+++ b/src/Drupal/DrupalExtension/Hook/Attribute/BeforeTermCreate.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Hook\Attribute;
+
+/**
+ * Attribute for methods to run before a term is created.
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class BeforeTermCreate implements DrupalHook {
+
+  public function __construct(public ?string $filterString = NULL) {
+  }
+
+  /**
+   * Returns the filter string for this hook.
+   */
+  public function getFilterString(): ?string {
+    return $this->filterString;
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Hook/Attribute/BeforeUserCreate.php
+++ b/src/Drupal/DrupalExtension/Hook/Attribute/BeforeUserCreate.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Hook\Attribute;
+
+/**
+ * Attribute for methods to run before a user is created.
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class BeforeUserCreate implements DrupalHook {
+
+  public function __construct(public ?string $filterString = NULL) {
+  }
+
+  /**
+   * Returns the filter string for this hook.
+   */
+  public function getFilterString(): ?string {
+    return $this->filterString;
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Hook/Attribute/DrupalHook.php
+++ b/src/Drupal/DrupalExtension/Hook/Attribute/DrupalHook.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Hook\Attribute;
+
+/**
+ * Marker interface for Drupal Extension hook attributes.
+ */
+// phpcs:ignore Drupal.Classes.InterfaceName.InterfaceSuffix
+interface DrupalHook {
+
+  /**
+   * Returns the filter string for this hook.
+   */
+  public function getFilterString(): ?string;
+
+}

--- a/src/Drupal/DrupalExtension/ScenarioTrait.php
+++ b/src/Drupal/DrupalExtension/ScenarioTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension;
 
+use Behat\Hook\BeforeScenario;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 
 /**
@@ -24,9 +25,8 @@ trait ScenarioTrait {
 
   /**
    * Register the scenario.
-   *
-   * @BeforeScenario
    */
+  #[BeforeScenario]
   public function registerScenario(BeforeScenarioScope $scope): void {
     $this->currentScenario = $scope->getScenario();
   }

--- a/src/Drupal/DrupalExtension/ServiceContainer/config/services.yml
+++ b/src/Drupal/DrupalExtension/ServiceContainer/config/services.yml
@@ -25,8 +25,9 @@ parameters:
   # Event listeners.
   drupal.listener.drivers.class: Drupal\DrupalExtension\Listener\DriverListener
 
-  # Hook loader.
+  # Hook loaders.
   drupal.context.annotation.reader.class: Drupal\DrupalExtension\Context\Annotation\Reader
+  drupal.context.attribute.reader.class: Drupal\DrupalExtension\Context\Attribute\HookAttributeReader
 
   # Region selector class.
   drupal.context.region_selector.class: Drupal\DrupalExtension\Selector\RegionSelector
@@ -75,6 +76,10 @@ services:
     arguments:
     tags:
       - { name: context.annotation_reader }
+  drupal.context.loader.attribute:
+    class: "%drupal.context.attribute.reader.class%"
+    tags:
+      - { name: context.attribute_reader }
   drupal.listener.driver:
     class: "%drupal.listener.drivers.class%"
     arguments:

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -10,6 +10,9 @@
 
 declare(strict_types=1);
 
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 use Symfony\Component\Yaml\Yaml;
 use DVDoug\Behat\CodeCoverage\Extension;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
@@ -79,8 +82,9 @@ trait BehatCliTrait {
   }
 
   /**
-   * @Given /^scenario steps(?: tagged with "([^"]*)")?:$/
+   * Writes scenario steps to a stub feature file in the working directory.
    */
+  #[Given('/^scenario steps(?: tagged with "([^"]*)")?:$/')]
   public function behatCliWriteScenarioSteps(PyStringNode $content, $tags = ''): void {
     $content = strtr((string) $content, ["'''" => '"""']);
 
@@ -115,8 +119,9 @@ EOL;
   }
 
   /**
-   * @Given some behat configuration
+   * Writes a behat.yml configuration file to the working directory.
    */
+  #[Given('some behat configuration')]
   public function behatCliWriteBehatYml(): void {
     // @note Hardcoded path to the project root.
     $source = '/var/www/html/behat.yml';
@@ -189,8 +194,9 @@ EOL;
   }
 
   /**
-   * @Then it should fail with an error:
+   * Asserts that behat failed with an assertion error matching the given message.
    */
+  #[Then('it should fail with an error:')]
   public function behatCliAssertFailWithError(PyStringNode $message): void {
     $this->itShouldPassOrFailWith('fail', $message);
 
@@ -209,22 +215,25 @@ EOL;
   }
 
   /**
-   * @When I run behat
+   * Runs behat with the default profile.
    */
+  #[When('I run behat')]
   public function behatCliRun(string $profile = 'default'):void {
     $this->behatCliRunWithProfile($profile);
   }
 
   /**
-   * @When I run behat with :profile profile
+   * Runs behat with the given profile.
    */
+  #[When('I run behat with :profile profile')]
   public function behatCliRunWithProfile(string $profile):void {
     $this->iRunBehat('--profile=' . $profile . ' --no-colors');
   }
 
   /**
-   * @Then it should fail with an exception:
+   * Asserts that behat failed with a RuntimeException matching the given message.
    */
+  #[Then('it should fail with an exception:')]
   public function behatCliAssertFailWithException(PyStringNode $message): void {
     $this->behatCliAssertFailWithCustomException('RuntimeException', $message);
 
@@ -234,8 +243,9 @@ EOL;
   }
 
   /**
-   * @Then it should fail with a :exception exception:
+   * Asserts that behat failed with a specific exception class matching the given message.
    */
+  #[Then('it should fail with a :exception exception:')]
   public function behatCliAssertFailWithCustomException(string $exception, PyStringNode $message): void {
     $this->itShouldPassOrFailWith('fail', $message);
 
@@ -255,9 +265,8 @@ EOL;
    *
    * @param \Behat\Gherkin\Node\PyStringNode $text
    *   PyString text instance.
-   *
-   * @Then the output should not contain:
    */
+  #[Then('the output should not contain:')]
   public function behatCliAssertOutputNotContains(PyStringNode $text): void {
     $expected = $this->getExpectedOutput($text);
     $actual = $this->getOutput();

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -2,6 +2,10 @@
 
 declare(strict_types=1);
 
+use Behat\Step\When;
+use Behat\Step\Given;
+use Behat\Transformation\Transform;
+use Behat\Step\Then;
 use Behat\Behat\Hook\Scope\AfterFeatureScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
@@ -9,6 +13,12 @@ use Behat\Hook\AfterFeature;
 use Behat\Hook\BeforeScenario;
 use Behat\Mink\Exception\ExpectationException;
 use Drupal\Core\Database\Database;
+use Drupal\DrupalExtension\Hook\Attribute\AfterNodeCreate;
+use Drupal\DrupalExtension\Hook\Attribute\AfterTermCreate;
+use Drupal\DrupalExtension\Hook\Attribute\AfterUserCreate;
+use Drupal\DrupalExtension\Hook\Attribute\BeforeNodeCreate;
+use Drupal\DrupalExtension\Hook\Attribute\BeforeTermCreate;
+use Drupal\DrupalExtension\Hook\Attribute\BeforeUserCreate;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
 use Drupal\DrupalExtension\Hook\Scope\BeforeNodeCreateScope;
 use Drupal\DrupalExtension\Hook\Scope\EntityScope;
@@ -55,9 +65,8 @@ class FeatureContext extends RawDrupalContext {
    * @code
    * When sleep for 5 seconds
    * @endcode
-   *
-   * @When sleep for :seconds second(s)
    */
+  #[When('sleep for :seconds second(s)')]
   public function testSleepForSeconds(int|string $seconds): void {
     sleep((int) $seconds);
   }
@@ -75,9 +84,8 @@ class FeatureContext extends RawDrupalContext {
 
   /**
    * Clear watchdog table.
-   *
-   * @Given the watchdog is cleared
    */
+  #[Given('the watchdog is cleared')]
   public function testClearWatchdogTable(): void {
     $database = Database::getConnection();
     if ($database->schema()->tableExists('watchdog')) {
@@ -87,9 +95,8 @@ class FeatureContext extends RawDrupalContext {
 
   /**
    * Hook into node creation to test `@beforeNodeCreate`.
-   *
-   * @beforeNodeCreate
    */
+  #[BeforeNodeCreate]
   public static function testAlterNodeParameters(BeforeNodeCreateScope $scope): void {
     parent::alterNodeParameters($scope);
     // @see `tests/behat/features/api.feature`
@@ -103,9 +110,8 @@ class FeatureContext extends RawDrupalContext {
 
   /**
    * Hook into term creation to test `@beforeTermCreate`.
-   *
-   * @beforeTermCreate
    */
+  #[BeforeTermCreate]
   public static function testAlterTermParameters(EntityScope $scope): void {
     // @see `tests/behat/features/api.feature`
     // Change 'Label' to expected 'name'.
@@ -118,9 +124,8 @@ class FeatureContext extends RawDrupalContext {
 
   /**
    * Hook into user creation to test `@beforeUserCreate`.
-   *
-   * @beforeUserCreate
    */
+  #[BeforeUserCreate]
   public static function testAlterUserParameters(EntityScope $scope): void {
     // @see `tests/behat/features/api.feature`
     // Concatenate 'First name' and 'Last name' to form user name.
@@ -140,9 +145,8 @@ class FeatureContext extends RawDrupalContext {
 
   /**
    * Test that a node is returned after node create.
-   *
-   * @afterNodeCreate
    */
+  #[AfterNodeCreate]
   public static function testAfterNodeCreate(EntityScope $scope): void {
     if (!$node = $scope->getEntity()) {
       throw new \Exception('Failed to find a node in @afterNodeCreate hook.');
@@ -151,9 +155,8 @@ class FeatureContext extends RawDrupalContext {
 
   /**
    * Test that a term is returned after term create.
-   *
-   * @afterTermCreate
    */
+  #[AfterTermCreate]
   public static function testAfterTermCreate(EntityScope $scope): void {
     if (!$term = $scope->getEntity()) {
       throw new \Exception('Failed to find a term in @afterTermCreate hook.');
@@ -162,9 +165,8 @@ class FeatureContext extends RawDrupalContext {
 
   /**
    * Test that a user is returned after user create.
-   *
-   * @afterUserCreate
    */
+  #[AfterUserCreate]
   public static function testAfterUserCreate(EntityScope $scope): void {
     if (!$user = $scope->getEntity()) {
       throw new \Exception('Failed to find a user in @afterUserCreate hook.');
@@ -176,9 +178,8 @@ class FeatureContext extends RawDrupalContext {
    *
    * This is used in field_handlers.feature for testing if lengthy field:column
    * combinations can be shortened to more human friendly aliases.
-   *
-   * @Transform table:name,mail,street,city,postcode,country
    */
+  #[Transform('table:name,mail,street,city,postcode,country')]
   public function testTransformUsersTable(TableNode $user_table): TableNode {
     $aliases = [
       'country' => 'field_post_address:country',
@@ -212,9 +213,8 @@ class FeatureContext extends RawDrupalContext {
    *
    * @return \Behat\Gherkin\Node\TableNode
    *   The transformed table.
-   *
-   * @Transform rowtable:title,body,reference,date,links,select,address
    */
+  #[Transform('rowtable:title,body,reference,date,links,select,address')]
   public function testTransformPostContentTable(TableNode $post_table): TableNode {
     $aliases = [
       'reference' => 'field_post_reference',
@@ -248,9 +248,8 @@ class FeatureContext extends RawDrupalContext {
    *
    * See the scenario 'Logging in as a user without an e-mail address' in
    * d10.feature.
-   *
-   * @Given I am logged in as a user with name :name and password :password
    */
+  #[Given('I am logged in as a user with name :name and password :password')]
   public function testAssertAuthenticatedByUsernameAndPassword($name, $password): void {
     $user = (object) [
       'name' => $name,
@@ -262,9 +261,8 @@ class FeatureContext extends RawDrupalContext {
 
   /**
    * Verifies a user is logged in on the backend.
-   *
-   * @Then I should be logged in on the backend
    */
+  #[Then('I should be logged in on the backend')]
   public function testAssertBackendLogin(): void {
     if (!$user = $this->getUserManager()->getCurrentUser()) {
       throw new \LogicException('No current user in the user manager.');
@@ -282,9 +280,8 @@ class FeatureContext extends RawDrupalContext {
 
   /**
    * Verifies there is no user logged in on the backend.
-   *
-   * @Then I should be logged out on the backend
    */
+  #[Then('I should be logged out on the backend')]
   public function testAssertBackendLoggedOut(): void {
     if ($this->getUserManager()->getCurrentUser()) {
       throw new \LogicException('User is still logged in in the manager.');
@@ -302,9 +299,8 @@ class FeatureContext extends RawDrupalContext {
 
   /**
    * Logs out via the logout url rather than fast logout.
-   *
-   * @When I log out via the logout url
    */
+  #[When('I log out via the logout url')]
   public function testLogoutViaUrl(): void {
     $this->logout(FALSE);
   }
@@ -315,10 +311,9 @@ class FeatureContext extends RawDrupalContext {
    * This simulates what happens during a long-running Behat test suite where
    * REQUEST_TIME becomes increasingly outdated.
    *
-   * @Given the request time is :seconds seconds in the past
-   *
    * @see https://github.com/jhedstrom/drupalextension/issues/179
    */
+  #[Given('the request time is :seconds seconds in the past')]
   public function testSetStaleRequestTime(int $seconds): void {
     $staleTime = time() - $seconds;
     $_SERVER['REQUEST_TIME'] = $staleTime;
@@ -331,10 +326,9 @@ class FeatureContext extends RawDrupalContext {
    * Reads the time drift recorded by behat_test_cron() and asserts it is
    * within the given threshold.
    *
-   * @Then the cron request time drift should be less than :seconds seconds
-   *
    * @see https://github.com/jhedstrom/drupalextension/issues/179
    */
+  #[Then('the cron request time drift should be less than :seconds seconds')]
   public function testAssertCronRequestTimeDrift(int $seconds): void {
     $drift = \Drupal::state()->get('behat_test.cron_time_drift');
     if ($drift === NULL) {
@@ -352,9 +346,8 @@ class FeatureContext extends RawDrupalContext {
 
   /**
    * Stores the current user name for later comparison.
-   *
-   * @Given I remember the current user name
    */
+  #[Given('I remember the current user name')]
   public function testRememberCurrentUserName(): void {
     $user = $this->getUserManager()->getCurrentUser();
     if (!$user) {
@@ -365,9 +358,8 @@ class FeatureContext extends RawDrupalContext {
 
   /**
    * Asserts the current user name differs from the previously remembered one.
-   *
-   * @Then the current user should be different from the remembered user
    */
+  #[Then('the current user should be different from the remembered user')]
   public function testAssertDifferentUser(): void {
     $user = $this->getUserManager()->getCurrentUser();
     if (!$user) {
@@ -383,18 +375,16 @@ class FeatureContext extends RawDrupalContext {
 
   /**
    * Performs a passing assertion step for testing.
-   *
-   * @When I use a test passing assertion step
    */
+  #[When('I use a test passing assertion step')]
   public function testPassingAssertionStep(): void {
     // Noop.
   }
 
   /**
    * Performs a failing assertion step for testing.
-   *
-   * @When I use a test failing assertion step
    */
+  #[When('I use a test failing assertion step')]
   public function testFailingAssertionStep(): void {
     throw new ExpectationException('This is a test failing assertion.', $this->getSession()->getDriver());
   }
@@ -404,9 +394,8 @@ class FeatureContext extends RawDrupalContext {
    *
    * @param string $tag
    *   The tag to check.
-   *
-   * @Then the :tag tag should be present
    */
+  #[Then('the :tag tag should be present')]
   public function testAssertTagPresent($tag): void {
     if (!$this->hasTag($tag)) {
       throw new \Exception(sprintf('Expected tag %s was not found in the scenario or feature.', $tag));
@@ -418,9 +407,8 @@ class FeatureContext extends RawDrupalContext {
    *
    * @param string $tag
    *   The tag to check.
-   *
-   * @Then the :tag tag should not be present
    */
+  #[Then('the :tag tag should not be present')]
   public function testAssertTagNotPresent($tag): void {
     if ($this->hasTag($tag)) {
       throw new \Exception(sprintf('Expected tag %s was found in the scenario or feature.', $tag));
@@ -436,9 +424,8 @@ class FeatureContext extends RawDrupalContext {
    *   The term name to check.
    * @param string $parentName
    *   The expected parent term name.
-   *
-   * @Then the :vocabulary term :name should have parent :parent_name
    */
+  #[Then('the :vocabulary term :name should have parent :parent_name')]
   public function testAssertTermParent(string $vocabulary, string $name, string $parentName): void {
     $storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
     $terms = $storage->loadByProperties(['name' => $name, 'vid' => $vocabulary]);
@@ -477,9 +464,8 @@ class FeatureContext extends RawDrupalContext {
    *   The configuration key.
    * @param string $expected
    *   The expected original value.
-   *
-   * @Then the original configuration item :name with key :key should be :expected
    */
+  #[Then('the original configuration item :name with key :key should be :expected')]
   public function testAssertOriginalConfigValue(string $name, string $key, string $expected): void {
     $actual = \Drupal::config($name)->getOriginal($key, FALSE);
     if ($actual !== $expected) {
@@ -492,9 +478,8 @@ class FeatureContext extends RawDrupalContext {
 
   /**
    * Clears the config save log used for change detection testing.
-   *
-   * @Given the config save log is cleared
    */
+  #[Given('the config save log is cleared')]
   public function testClearConfigSaveLog(): void {
     \Drupal::state()->delete('behat_test.config_save_log');
   }
@@ -511,9 +496,8 @@ class FeatureContext extends RawDrupalContext {
    *   The configuration object name.
    * @param string $expected
    *   The expected original value at restore time.
-   *
-   * @Then the config restore baseline for :name should be :expected
    */
+  #[Then('the config restore baseline for :name should be :expected')]
   public function testAssertConfigRestoreBaseline(string $name, string $expected): void {
     $log = \Drupal::state()->get('behat_test.config_save_log', []);
     $last = NULL;
@@ -544,9 +528,8 @@ class FeatureContext extends RawDrupalContext {
    * the database and from the tracked users list, but the current user
    * reference in the user manager is preserved. This makes hasUsers() return
    * FALSE while a user is still marked as logged in.
-   *
-   * @Given I delete the current user from the database
    */
+  #[Given('I delete the current user from the database')]
   public function testDeleteCurrentUserFromDatabase(): void {
     $user = $this->getUserManager()->getCurrentUser();
 
@@ -569,9 +552,8 @@ class FeatureContext extends RawDrupalContext {
 
   /**
    * Throws a test assertion exception.
-   *
-   * @Given I throw a test assertion exception :calss with message :message
    */
+  #[Given('I throw a test assertion exception :calss with message :message')]
   public function throwTestErrorException(string $name, string $message): void {
     if (!class_exists($name)) {
       throw new \RuntimeException(sprintf("Assertion exception class '%s' does not exist.", $name));
@@ -582,9 +564,8 @@ class FeatureContext extends RawDrupalContext {
 
   /**
    * Throws a test runtime exception.
-   *
-   * @Given I throw a test runtime exception with message :message
    */
+  #[Given('I throw a test runtime exception with message :message')]
   public function throwTestRuntimeException(string $message): never {
     throw new \RuntimeException($message);
   }

--- a/tests/phpunit/fixtures/docs/AbstractContext.php
+++ b/tests/phpunit/fixtures/docs/AbstractContext.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Tests\Fixtures;
 
+use Behat\Step\Given;
+
 /**
  * Abstract context for testing.
  */
@@ -12,12 +14,12 @@ abstract class AbstractContext {
   /**
    * Abstract step.
    *
-   * @Given I am abstract
    *
    * @code
    * Given I am abstract
    * @endcode
    */
+  #[Given('I am abstract')]
   public function abstractStep(): void {
   }
 

--- a/tests/phpunit/fixtures/docs/EmptyCommentContext.php
+++ b/tests/phpunit/fixtures/docs/EmptyCommentContext.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Tests\Fixtures;
 
+use Behat\Step\Given;
+
 // phpcs:ignore Drupal.Commenting.DocComment.Empty
 /**
  *
@@ -15,12 +17,12 @@ class EmptyCommentContext {
   /**
    * Test method.
    *
-   * @Given I test empty comment
    *
    * @code
    * Given I test empty comment
    * @endcode
    */
+  #[Given('I test empty comment')]
   public function emptycommentTestMethod(): void {
   }
 

--- a/tests/phpunit/fixtures/docs/FirstContext.php
+++ b/tests/phpunit/fixtures/docs/FirstContext.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Tests\Fixtures;
 
+use Behat\Step\Then;
+
 /**
  * First context for testing.
  */
@@ -12,12 +14,12 @@ class FirstContext {
   /**
    * First method.
    *
-   * @Then the first should pass
    *
    * @code
    * Then the first should pass
    * @endcode
    */
+  #[Then('the first should pass')]
   public function firstAssertFirst(): void {
   }
 

--- a/tests/phpunit/fixtures/docs/InheritedContext.php
+++ b/tests/phpunit/fixtures/docs/InheritedContext.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Tests\Fixtures;
 
+use Behat\Step\Then;
+
 /**
  * Context with inherited methods for testing.
  */
@@ -12,12 +14,12 @@ class InheritedContext extends FirstContext {
   /**
    * Own method.
    *
-   * @Then the inherited should pass
    *
    * @code
    * Then the inherited should pass
    * @endcode
    */
+  #[Then('the inherited should pass')]
   public function inheritedAssertOwn(): void {
   }
 

--- a/tests/phpunit/fixtures/docs/ListDescriptionContext.php
+++ b/tests/phpunit/fixtures/docs/ListDescriptionContext.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Tests\Fixtures;
 
+use Behat\Step\Then;
+
 /**
  * Context with a list in description.
  *
@@ -17,12 +19,12 @@ class ListDescriptionContext {
   /**
    * Step method.
    *
-   * @Then the list should be visible
    *
    * @code
    * Then the list should be visible
    * @endcode
    */
+  #[Then('the list should be visible')]
   public function listAssertVisible(): void {
   }
 

--- a/tests/phpunit/fixtures/docs/MultiMethodContext.php
+++ b/tests/phpunit/fixtures/docs/MultiMethodContext.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Tests\Fixtures;
 
+use Behat\Step\Then;
+use Behat\Step\Given;
+use Behat\Step\When;
+
 /**
  * A context with multiple methods to test sorting.
  */
@@ -12,36 +16,36 @@ class MultiMethodContext {
   /**
    * Then step.
    *
-   * @Then the result should be visible
    *
    * @code
    * Then the result should be visible
    * @endcode
    */
+  #[Then('the result should be visible')]
   public function multimethodAssertResultVisible(): void {
   }
 
   /**
    * Given step.
    *
-   * @Given the following items:
    *
    * @code
    * Given the following items:
    * @endcode
    */
+  #[Given('the following items:')]
   public function multimethodGivenItems(): void {
   }
 
   /**
    * When step.
    *
-   * @When I click on :button
    *
    * @code
    * When I click on "Submit"
    * @endcode
    */
+  #[When('I click on :button')]
   public function multimethodClickButton(): void {
   }
 

--- a/tests/phpunit/fixtures/docs/NoStepAnnotationContext.php
+++ b/tests/phpunit/fixtures/docs/NoStepAnnotationContext.php
@@ -7,9 +7,8 @@ namespace Drupal\DrupalExtension\Tests\Fixtures;
 /**
  * Test fixture for method without step annotations.
  *
- * This is used to test sorting when methods don't have.
- *
- * @Given/@When/@Then annotations.
+ * This is used to test sorting when methods don't have
+ * Given/When/Then annotations.
  */
 class NoStepAnnotationContext {
 

--- a/tests/phpunit/fixtures/docs/SampleContext.php
+++ b/tests/phpunit/fixtures/docs/SampleContext.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Tests\Fixtures;
 
+use Behat\Step\Then;
+
 /**
  * Sample context for testing.
  */
@@ -12,12 +14,12 @@ class SampleContext {
   /**
    * Test method.
    *
-   * @Then the test should pass
    *
    * @code
    * Then the test should pass
    * @endcode
    */
+  #[Then('the test should pass')]
   public function sampleAssertTest(): void {
   }
 

--- a/tests/phpunit/fixtures/docs/SecondContext.php
+++ b/tests/phpunit/fixtures/docs/SecondContext.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Tests\Fixtures;
 
+use Behat\Step\Then;
+
 /**
  * Second context for testing.
  */
@@ -12,12 +14,12 @@ class SecondContext {
   /**
    * Second method.
    *
-   * @Then the second should pass
    *
    * @code
    * Then the second should pass
    * @endcode
    */
+  #[Then('the second should pass')]
   public function secondAssertSecond(): void {
   }
 

--- a/tests/phpunit/src/DocsTest.php
+++ b/tests/phpunit/src/DocsTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\TestCase;
 #[CoversFunction('render_validation_tree')]
 #[CoversFunction('replace_content')]
 #[CoversFunction('extract_info')]
+#[CoversFunction('extract_step_attributes')]
 #[CoversFunction('parse_class_comment')]
 #[CoversFunction('find_source_file')]
 #[CoversFunction('regex_to_turnip')]


### PR DESCRIPTION
Closes #693

## Summary

Converted all Behat annotation-based step and hook registrations across all context
classes to PHP 8 native attributes (`#[Given]`, `#[When]`, `#[Then]`, `#[BeforeScenario]`,
`#[AfterScenario]`, `#[BeforeStep]`, `#[AfterStep]`). This removes the dependency on
docblock annotations for step discovery and brings the extension in line with modern
PHP 8+ idioms. The existing `Annotation\Reader` class is deprecated but retained for
backwards compatibility until 6.0.0. A new `HookAttributeReader` class and six
`Hook\Attribute` classes were added to support Drupal-specific entity hook attributes
(`BeforeNodeCreate`, `AfterNodeCreate`, etc.) via PHP attributes.

## Changes

### New PHP attribute infrastructure
- `src/Drupal/DrupalExtension/Context/Attribute/HookAttributeReader.php` — New
  `AttributeReader` implementation that maps Drupal hook attributes to their
  corresponding hook call classes
- `src/Drupal/DrupalExtension/Hook/Attribute/DrupalHook.php` — Marker interface
  for Drupal Extension hook attributes
- `src/Drupal/DrupalExtension/Hook/Attribute/BeforeNodeCreate.php` — PHP attribute
- `src/Drupal/DrupalExtension/Hook/Attribute/AfterNodeCreate.php` — PHP attribute
- `src/Drupal/DrupalExtension/Hook/Attribute/BeforeTermCreate.php` — PHP attribute
- `src/Drupal/DrupalExtension/Hook/Attribute/AfterTermCreate.php` — PHP attribute
- `src/Drupal/DrupalExtension/Hook/Attribute/BeforeUserCreate.php` — PHP attribute
- `src/Drupal/DrupalExtension/Hook/Attribute/AfterUserCreate.php` — PHP attribute

### Context classes converted (annotations → attributes)
- `BatchContext.php` — 2 step definitions
- `ConfigContext.php` — 2 step definitions, 1 hook
- `DrupalContext.php` — 17 step definitions
- `DrushContext.php` — 5 step definitions
- `MailContext.php` — 4 hooks, 4 multi-alias step definitions
- `MarkupContext.php` — 10 step definitions
- `MessageContext.php` — step definitions
- `MinkContext.php` — step definitions, 2 lifecycle hooks (`BeforeStep`, `AfterStep`)
- `RandomContext.php` — step definitions
- `RawDrupalContext.php` — hook registrations

### Traits and supporting files
- `FeatureTrait.php` and `ScenarioTrait.php` — `@BeforeScenario` hooks converted
- `tests/behat/bootstrap/BehatCliTrait.php` — all step definitions converted
- `tests/behat/bootstrap/FeatureContext.php` — all step definitions converted
- `tests/phpunit/fixtures/docs/*.php` — doc generator fixtures updated

### Deprecation and service registration
- `Context/Annotation/Reader.php` — marked as deprecated for removal in 6.0.0
- `ServiceContainer/config/services.yml` — registered `HookAttributeReader` as
  a `context.attribute_reader` tagged service alongside the existing annotation reader

### Documentation
- `STEPS.md` — regenerated with consistent indentation in Gherkin examples and
  trailing full stops on step descriptions
- `scripts/docs.php` — updated to read step patterns from PHP 8 attributes in
  addition to docblock annotations
- `rector.php` — updated Rector config to cover the new attribute namespace

## Before / After

```
BEFORE: Step/hook registration via docblock annotations
┌─────────────────────────────────────────────────────────┐
│ DrupalContext.php                                        │
│  /**                                                     │
│   * @Given I am logged in as :name                       │
│   */                                                     │
│  public function assertLoggedInByName(...) { ... }       │
└──────────────────────────┬──────────────────────────────┘
                           │ parsed at runtime by
                           ▼
┌─────────────────────────────────────────────────────────┐
│ Context\Annotation\Reader (AnnotationReader)             │
│  reads docblock tags: @Given, @When, @Then               │
│  reads hook tags: @BeforeScenario, @AfterScenario, ...   │
└─────────────────────────────────────────────────────────┘

AFTER: Step/hook registration via PHP 8 native attributes
┌─────────────────────────────────────────────────────────┐
│ DrupalContext.php                                        │
│  #[Given('I am logged in as :name')]                     │
│  public function assertLoggedInByName(...) { ... }       │
└─────────┬───────────────────────────────────────────────┘
          │                        │
          ▼                        ▼
┌──────────────────┐   ┌──────────────────────────────────┐
│ Behat built-in   │   │ Context\Attribute\               │
│ AttributeReader  │   │   HookAttributeReader            │
│                  │   │                                  │
│ Handles:         │   │ Handles Drupal-specific hooks:   │
│  #[Given]        │   │  #[BeforeNodeCreate]             │
│  #[When]         │   │  #[AfterNodeCreate]              │
│  #[Then]         │   │  #[BeforeTermCreate]             │
│  #[BeforeStep]   │   │  #[AfterTermCreate]              │
│  #[AfterStep]    │   │  #[BeforeUserCreate]             │
│  #[BeforeScen.]  │   │  #[AfterUserCreate]              │
│  #[AfterScen.]   │   │                                  │
└──────────────────┘   └──────────────────────────────────┘

Context\Annotation\Reader retained but deprecated (→ removed in 6.0.0)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Modernized Behat step and hook registration system for improved code maintainability and alignment with current PHP standards
  * Updated documentation formatting for consistency
  * Enhanced configuration to support modern annotation patterns across the extension

<!-- end of auto-generated comment: release notes by coderabbit.ai -->