### PR TITLE
[#787] Fixed computed base fields failing in parseEntityFields()

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -110,7 +110,7 @@ commands:
 
       ahoy drush --yes pmu page_cache,big_pipe
       ahoy drush --yes en behat_test
-      ahoy drush deploy:hook
+      ahoy drush --yes deploy:hook
 
       ahoy cli "echo '\$config[\"system.site\"][\"name\"] = \"Overridden Site Name\";' >> build/web/sites/default/settings.php"
 

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -110,6 +110,7 @@ commands:
 
       ahoy drush --yes pmu page_cache,big_pipe
       ahoy drush --yes en behat_test
+      ahoy drush deploy:hook
 
       ahoy cli "echo '\$config[\"system.site\"][\"name\"] = \"Overridden Site Name\";' >> build/web/sites/default/settings.php"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
         run: |
           docker compose exec -T php ./vendor/bin/drush --yes --root=build/web pmu page_cache,big_pipe
           docker compose exec -T php ./vendor/bin/drush --yes --root=build/web en behat_test
-          docker compose exec -T php ./vendor/bin/drush --root=build/web deploy:hook
+          docker compose exec -T php ./vendor/bin/drush --yes --root=build/web deploy:hook
           docker compose exec -u ${DOCKER_USER_ID} -T php vendor/bin/drush cset core.date_format.olivero_medium pattern 'j F, Y'
           docker compose exec -u ${DOCKER_USER_ID} -T php vendor/bin/drush cset automated_cron.settings interval 0
           docker compose exec -u ${DOCKER_USER_ID} -T php vendor/bin/drush cset user.settings register visitors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
         run: |
           docker compose exec -T php ./vendor/bin/drush --yes --root=build/web pmu page_cache,big_pipe
           docker compose exec -T php ./vendor/bin/drush --yes --root=build/web en behat_test
+          docker compose exec -T php ./vendor/bin/drush --root=build/web deploy:hook
           docker compose exec -u ${DOCKER_USER_ID} -T php vendor/bin/drush cset core.date_format.olivero_medium pattern 'j F, Y'
           docker compose exec -u ${DOCKER_USER_ID} -T php vendor/bin/drush cset automated_cron.settings interval 0
           docker compose exec -u ${DOCKER_USER_ID} -T php vendor/bin/drush cset user.settings register visitors

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "behat/gherkin": "^4.13",
         "behat/mink": "^1.12",
         "behat/mink-browserkit-driver": "^2.1.0",
-        "drupal/drupal-driver": "^2.4.2",
+        "drupal/drupal-driver": "^2.4.3",
         "friends-of-behat/mink-extension": "^2.7.1",
         "lullabot/mink-selenium2-driver": "^1.7.4",
         "symfony/css-selector": "^6.4.3 || ^7",

--- a/tests/behat/features/drupal_context.feature
+++ b/tests/behat/features/drupal_context.feature
@@ -269,3 +269,15 @@ Feature: DrupalContext coverage gaps
       """
       Field "field_does_not_exist" does not exist on entity type "node".
       """
+
+  @test-drupal @api
+  Scenario: Assert "Given :type content:" passes for moderation_state field
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given "article" content:
+        | title                  | moderation_state |
+        | Moderated test content | draft            |
+      """
+    When I run behat with drupal profile
+    Then it should pass

--- a/tests/behat/fixtures/drupal/modules/behat_test/behat_test.deploy.php
+++ b/tests/behat/fixtures/drupal/modules/behat_test/behat_test.deploy.php
@@ -17,8 +17,6 @@ use Drupal\workflows\Entity\Workflow;
  * editorial workflow as optional config, but it is not imported when
  * content_moderation is installed as a behat_test dependency. This deploy
  * hook runs after module install and creates the workflow if needed.
- *
- * @see https://github.com/jhedstrom/drupalextension/issues/787
  */
 function behat_test_deploy_add_editorial_workflow(): string {
   $workflow = Workflow::load('editorial');
@@ -46,7 +44,17 @@ function behat_test_deploy_add_editorial_workflow(): string {
     $type_plugin->addTransition('publish', 'Publish', ['draft', 'published'], 'published');
   }
 
-  $workflow->getTypePlugin()->addEntityTypeAndBundle('node', 'article');
+  $type_plugin = $workflow->getTypePlugin();
+  $type_plugin->addEntityTypeAndBundle('node', 'article');
+
+  // Set default moderation state to 'published' so existing tests that create
+  // article nodes without specifying moderation_state continue to work.
+  // Read settings from the plugin (not the entity) to preserve the
+  // addEntityTypeAndBundle() change made above.
+  $configuration = $type_plugin->getConfiguration();
+  $configuration['default_moderation_state'] = 'published';
+  $workflow->set('type_settings', $configuration);
+
   $workflow->save();
 
   return 'Attached editorial workflow to article content type.';

--- a/tests/behat/fixtures/drupal/modules/behat_test/behat_test.deploy.php
+++ b/tests/behat/fixtures/drupal/modules/behat_test/behat_test.deploy.php
@@ -5,6 +5,10 @@
  * Deploy hooks for the behat_test module.
  */
 
+declare(strict_types=1);
+
+use Drupal\workflows\Entity\Workflow;
+
 /**
  * Attach editorial workflow to the article content type.
  *
@@ -17,17 +21,27 @@
  * @see https://github.com/jhedstrom/drupalextension/issues/787
  */
 function behat_test_deploy_add_editorial_workflow(): string {
-  $workflow = \Drupal\workflows\Entity\Workflow::load('editorial');
+  $workflow = Workflow::load('editorial');
 
   if (!$workflow) {
-    $workflow = \Drupal\workflows\Entity\Workflow::create([
+    $workflow = Workflow::create([
       'id' => 'editorial',
       'label' => 'Editorial',
       'type' => 'content_moderation',
     ]);
     $type_plugin = $workflow->getTypePlugin();
-    $type_plugin->addState('draft', ['label' => 'Draft', 'published' => FALSE, 'default_revision' => FALSE, 'weight' => -5]);
-    $type_plugin->addState('published', ['label' => 'Published', 'published' => TRUE, 'default_revision' => TRUE, 'weight' => 0]);
+    $type_plugin->addState('draft', [
+      'label' => 'Draft',
+      'published' => FALSE,
+      'default_revision' => FALSE,
+      'weight' => -5,
+    ]);
+    $type_plugin->addState('published', [
+      'label' => 'Published',
+      'published' => TRUE,
+      'default_revision' => TRUE,
+      'weight' => 0,
+    ]);
     $type_plugin->addTransition('create_new_draft', 'Create New Draft', ['draft', 'published'], 'draft');
     $type_plugin->addTransition('publish', 'Publish', ['draft', 'published'], 'published');
   }

--- a/tests/behat/fixtures/drupal/modules/behat_test/behat_test.deploy.php
+++ b/tests/behat/fixtures/drupal/modules/behat_test/behat_test.deploy.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Deploy hooks for the behat_test module.
+ */
+
+/**
+ * Attach editorial workflow to the article content type.
+ *
+ * Computed base fields like 'moderation_state' are only available when a
+ * workflow is attached to the content type. The Standard profile ships the
+ * editorial workflow as optional config, but it is not imported when
+ * content_moderation is installed as a behat_test dependency. This deploy
+ * hook runs after module install and creates the workflow if needed.
+ *
+ * @see https://github.com/jhedstrom/drupalextension/issues/787
+ */
+function behat_test_deploy_add_editorial_workflow(): string {
+  $workflow = \Drupal\workflows\Entity\Workflow::load('editorial');
+
+  if (!$workflow) {
+    $workflow = \Drupal\workflows\Entity\Workflow::create([
+      'id' => 'editorial',
+      'label' => 'Editorial',
+      'type' => 'content_moderation',
+    ]);
+    $type_plugin = $workflow->getTypePlugin();
+    $type_plugin->addState('draft', ['label' => 'Draft', 'published' => FALSE, 'default_revision' => FALSE, 'weight' => -5]);
+    $type_plugin->addState('published', ['label' => 'Published', 'published' => TRUE, 'default_revision' => TRUE, 'weight' => 0]);
+    $type_plugin->addTransition('create_new_draft', 'Create New Draft', ['draft', 'published'], 'draft');
+    $type_plugin->addTransition('publish', 'Publish', ['draft', 'published'], 'published');
+  }
+
+  $workflow->getTypePlugin()->addEntityTypeAndBundle('node', 'article');
+  $workflow->save();
+
+  return 'Attached editorial workflow to article content type.';
+}

--- a/tests/behat/fixtures/drupal/modules/behat_test/behat_test.info.yml
+++ b/tests/behat/fixtures/drupal/modules/behat_test/behat_test.info.yml
@@ -4,4 +4,5 @@ description: 'Test feature exposing basic configuration for Behat Drupal extensi
 package: Test
 core_version_requirement: ^9 || ^10 || ^11
 dependencies:
+  - drupal:content_moderation
   - drupal:language

--- a/tests/behat/fixtures/drupal/modules/behat_test/behat_test.install
+++ b/tests/behat/fixtures/drupal/modules/behat_test/behat_test.install
@@ -9,6 +9,12 @@
  * Implements hook_install().
  */
 function behat_test_install() {
+  // Attach the editorial workflow to the article content type so that computed
+  // base fields like 'moderation_state' are available for testing.
+  $workflow = \Drupal\workflows\Entity\Workflow::load('editorial');
+  $workflow->getTypePlugin()->addEntityTypeAndBundle('node', 'article');
+  $workflow->save();
+
   $storage = \Drupal::service('behat_test.config.storage.install');
 
   // Override Standard profile's user settings with our own.

--- a/tests/behat/fixtures/drupal/modules/behat_test/behat_test.install
+++ b/tests/behat/fixtures/drupal/modules/behat_test/behat_test.install
@@ -9,12 +9,6 @@
  * Implements hook_install().
  */
 function behat_test_install() {
-  // Attach the editorial workflow to the article content type so that computed
-  // base fields like 'moderation_state' are available for testing.
-  $workflow = \Drupal\workflows\Entity\Workflow::load('editorial');
-  $workflow->getTypePlugin()->addEntityTypeAndBundle('node', 'article');
-  $workflow->save();
-
   $storage = \Drupal::service('behat_test.config.storage.install');
 
   // Override Standard profile's user settings with our own.


### PR DESCRIPTION
## Summary

- Bumped `drupal/drupal-driver` to `^2.4.3` which fixes `isBaseField()` to use `getBaseFieldDefinitions()` instead of `getFieldStorageDefinitions()`, correctly recognizing computed base fields.
- Added `content_moderation` as a `behat_test` module dependency with editorial workflow attached to the `article` content type.
- Added Behat test proving `moderation_state` field works on node creation.

## Root cause

Drupal's `EntityFieldManager::getFieldStorageDefinitions()` explicitly excludes computed base fields (`\!isComputed()`). The driver's `isField()` and `isBaseField()` both used this API, so computed fields like `moderation_state` (content_moderation) and `path` (path module) failed both checks, causing `parseEntityFields()` to throw `RuntimeException`.

```
                    getBaseFieldDefinitions()    getFieldStorageDefinitions()
moderation_state    YES                          NO  (isComputed = TRUE)
path                YES                          NO  (isComputed = TRUE)
title               YES                          YES (isComputed = FALSE)
```

The fix in `drupal-driver` v2.4.3 changes `isBaseField()` to use `getBaseFieldDefinitions()` which returns all base fields regardless of computed status.

```
+-----------------------+     +------------------------+
| getBaseFieldDefs()    |     | getFieldStorageDefs()  |
| (ALL base fields)     |     | (non-computed only)    |
|                       |     |                        |
|  title                |     |  title                 |
|  status        -------+-----+-> status               |
|  uid                  |     |  uid                   |
|  moderation_state  X--+--/--+                        |
|  path              X--+-/   |                        |
+-----------------------+     +------------------------+

  X = excluded from getFieldStorageDefs because isComputed()
  Driver v2.4.3 now uses getBaseFieldDefs() for isBaseField()
```

## Test plan

- [ ] Behat test: `Assert "Given :type content:" passes for moderation_state field`
- [ ] Existing test: `Assert "Given :type content:" fails for non-existent field` still passes
- [ ] Clean provision with `ahoy provision` succeeds with content_moderation enabled

Closes #787.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Behat scenario for asserting moderation_state.
  * Added test fixtures to enable content moderation and provision an editorial workflow for articles.

* **Chores**
  * Updated a development dependency to a newer patch version.
  * Added deploy hook execution to provisioning and CI workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->