### PR TITLE
Added tests for attribute/annotation inheritance and changelog warning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
  * [#781](https://github.com/jhedstrom/drupalextension/pull/781) - Simplified code.
  * [#780](https://github.com/jhedstrom/drupalextension/pull/780) - Converted standard Behat annotations to PHP 8 attributes.
+   > [!WARNING]
+   > If you extend any of the bundled context classes and override step or hook
+   > methods, you must switch your overrides from docblock annotations (`@Given`,
+   > `@When`, `@Then`, `@BeforeScenario`, etc.) to PHP 8 attributes (`#[Given]`,
+   > `#[When]`, `#[Then]`, `#[BeforeScenario]`, etc.). Behat resolves both the
+   > parent attribute and the child annotation independently, which causes a
+   > `RedundantStepException` for step definitions and duplicate execution for
+   > hooks. To safely override a method, either re-declare the step/hook using
+   > only the PHP 8 attribute on the child (and remove it from the parent by not
+   > registering the parent context), or override the method without any
+   > annotation or attribute to inherit the parent's definition.
  * [#779](https://github.com/jhedstrom/drupalextension/pull/779) - Changed `ConfigContext::setConfig()` visibility from public to protected.
  * [#771](https://github.com/jhedstrom/drupalextension/pull/771) - Reformatted configuration trees to use hierarchical indentation and added formatter fences.
  * [#768](https://github.com/jhedstrom/drupalextension/pull/768) - Removed Drupal 6 and 7 driver support.

--- a/tests/behat/features/behatcli/behat_inheritance.feature
+++ b/tests/behat/features/behatcli/behat_inheritance.feature
@@ -1,0 +1,230 @@
+@smoke
+Feature: Step definition inheritance with attributes and annotations
+
+  Tests for step definition resolution when a child context class extends
+  a parent that uses PHP 8 attributes for step definitions.
+
+  Covers the following override scenarios:
+  - Child overrides with attribute only — fails (redundant with parent).
+  - Child overrides with docblock annotation only — fails (redundant with parent).
+  - Child overrides with both attribute and annotation — fails (redundant).
+  - Child overrides method without any step definition — parent step still found.
+  - Child does not override (inherits parent method) — passes.
+
+  Background:
+    Given a file named "features/bootstrap/ParentContext.php" with:
+      """
+      <?php
+
+      use Behat\Behat\Context\Context;
+      use Behat\Step\Given;
+
+      class ParentContext implements Context {
+
+          #[Given('I perform the test action')]
+          public function iPerformTheTestAction(): void {
+          }
+
+      }
+      """
+
+  @test-blackbox
+  Scenario: Assert child with attribute-only override fails for redundant step
+    Given a file named "features/bootstrap/ChildContext.php" with:
+      """
+      <?php
+
+      use Behat\Step\Given;
+
+      class ChildContext extends ParentContext {
+
+          #[Given('I perform the test action')]
+          public function iPerformTheTestAction(): void {
+          }
+
+      }
+      """
+    And a file named "behat.yml" with:
+      """
+      default:
+        suites:
+          default:
+            contexts:
+              - ChildContext
+      """
+    And a file named "features/test.feature" with:
+      """
+      Feature: Test
+        Scenario: Test
+          Given I perform the test action
+      """
+    When I run "behat --no-colors"
+    Then it should fail with:
+      """
+      Step "I perform the test action" is already defined in
+      """
+
+  @test-blackbox
+  Scenario: Assert child with annotation-only override fails for redundant step
+    Given a file named "features/bootstrap/ChildContext.php" with:
+      """
+      <?php
+
+      class ChildContext extends ParentContext {
+
+          /**
+           * @Given I perform the test action
+           */
+          public function iPerformTheTestAction(): void {
+          }
+
+      }
+      """
+    And a file named "behat.yml" with:
+      """
+      default:
+        suites:
+          default:
+            contexts:
+              - ChildContext
+      """
+    And a file named "features/test.feature" with:
+      """
+      Feature: Test
+        Scenario: Test
+          Given I perform the test action
+      """
+    When I run "behat --no-colors"
+    Then it should fail with:
+      """
+      Step "I perform the test action" is already defined in
+      """
+
+  @test-blackbox
+  Scenario: Assert child with both attribute and annotation fails for redundant step
+    Given a file named "features/bootstrap/ChildContext.php" with:
+      """
+      <?php
+
+      use Behat\Step\Given;
+
+      class ChildContext extends ParentContext {
+
+          /**
+           * @Given I perform the test action
+           */
+          #[Given('I perform the test action')]
+          public function iPerformTheTestAction(): void {
+          }
+
+      }
+      """
+    And a file named "behat.yml" with:
+      """
+      default:
+        suites:
+          default:
+            contexts:
+              - ChildContext
+      """
+    And a file named "features/test.feature" with:
+      """
+      Feature: Test
+        Scenario: Test
+          Given I perform the test action
+      """
+    When I run "behat --no-colors"
+    Then it should fail with:
+      """
+      Step "I perform the test action" is already defined in
+      """
+
+  @test-blackbox
+  Scenario: Assert child override without step definition inherits parent step
+    Given a file named "features/bootstrap/ChildContext.php" with:
+      """
+      <?php
+
+      class ChildContext extends ParentContext {
+
+          public function iPerformTheTestAction(): void {
+          }
+
+      }
+      """
+    And a file named "behat.yml" with:
+      """
+      default:
+        suites:
+          default:
+            contexts:
+              - ChildContext
+      """
+    And a file named "features/test.feature" with:
+      """
+      Feature: Test
+        Scenario: Test
+          Given I perform the test action
+      """
+    When I run "behat --no-colors"
+    Then it should pass
+
+  @test-blackbox
+  Scenario: Assert child override with inheritdoc inherits parent step
+    Given a file named "features/bootstrap/ChildContext.php" with:
+      """
+      <?php
+
+      class ChildContext extends ParentContext {
+
+          /**
+           * {@inheritdoc}
+           */
+          public function iPerformTheTestAction(): void {
+          }
+
+      }
+      """
+    And a file named "behat.yml" with:
+      """
+      default:
+        suites:
+          default:
+            contexts:
+              - ChildContext
+      """
+    And a file named "features/test.feature" with:
+      """
+      Feature: Test
+        Scenario: Test
+          Given I perform the test action
+      """
+    When I run "behat --no-colors"
+    Then it should pass
+
+  @test-blackbox
+  Scenario: Assert inherited step from parent attribute passes without override
+    Given a file named "features/bootstrap/ChildContext.php" with:
+      """
+      <?php
+
+      class ChildContext extends ParentContext {
+
+      }
+      """
+    And a file named "behat.yml" with:
+      """
+      default:
+        suites:
+          default:
+            contexts:
+              - ChildContext
+      """
+    And a file named "features/test.feature" with:
+      """
+      Feature: Test
+        Scenario: Test
+          Given I perform the test action
+      """
+    When I run "behat --no-colors"
+    Then it should pass


### PR DESCRIPTION
## Summary

Added Behat tests documenting how PHP 8 attribute-based step definitions behave
under class inheritance, covering six override scenarios. Also added a WARNING
admonition to the CHANGELOG.md entry for the v5.3.0 attributes migration,
advising consumers who extend bundled context classes to update any overriding
methods to avoid `RedundantStepException`.

## Changes

### `tests/behat/features/behatcli/behat_inheritance.feature` (new)

Six blackbox scenarios using a `ParentContext` that defines a step via
`#[Given(...)]` attribute and a `ChildContext` with varying override strategies:

| Scenario | Child override strategy | Expected outcome |
|---|---|---|
| 1 | Re-declares step with `#[Given]` attribute | Fails — `RedundantStepException` |
| 2 | Re-declares step with `@Given` docblock annotation | Fails — `RedundantStepException` |
| 3 | Re-declares step with both attribute and annotation | Fails — `RedundantStepException` |
| 4 | Overrides method with no annotation or attribute | Passes — inherits parent step |
| 5 | Overrides method with `{@inheritdoc}` only | Passes — inherits parent step |
| 6 | No override at all (plain inheritance) | Passes — inherits parent step |

### `CHANGELOG.md`

Added a `> [!WARNING]` GitHub Markdown admonition under the v5.3.0
`#[780]` attributes migration entry. Explains that extending context classes
and adding any step annotation or attribute to an overriding method will cause
Behat to register both the parent attribute and the child definition, producing
a `RedundantStepException` (for steps) or duplicate execution (for hooks).
Describes the two safe override patterns: re-declare using only the PHP 8
attribute, or override without any annotation or attribute.

## Before / After

```
Before — consumer extending a bundled context (annotations era):

  ParentContext                         ChildContext
  ┌──────────────────────────────┐      ┌──────────────────────────────────┐
  │ /**                          │      │ /**                              │
  │  * @Given I do the thing     │ ◄─── │  * @Given I do the thing        │
  │  */                          │      │  */                              │
  │ public function doThing()    │      │ public function doThing()        │
  └──────────────────────────────┘      └──────────────────────────────────┘
  One definition registered             One definition registered
  (parent annotation shadowed           (child annotation wins)
   by child — fine in Behat)


After v5.3.0 — parent now uses PHP 8 attribute; child still uses annotation:

  ParentContext                         ChildContext
  ┌──────────────────────────────┐      ┌──────────────────────────────────┐
  │ #[Given('I do the thing')]   │      │ /**                              │
  │ public function doThing()    │ ◄─── │  * @Given I do the thing        │
  └──────────────────────────────┘      │  */                              │
  Attribute registered ─────────────►  │ public function doThing()        │
                                        └──────────────────────────────────┘
                                        Annotation also registered
                                        ─────────────────────────────────
                                        TWO definitions → RedundantStepException


Safe override patterns after v5.3.0:

  Option A — no annotation/attribute on override:

  ChildContext
  ┌────────────────────────────────────┐
  │ public function doThing(): void {} │  ← parent #[Given] still inherited
  └────────────────────────────────────┘

  Option B — no override at all:

  ChildContext
  ┌────────────────────────────────────┐
  │ (method not redeclared)            │  ← parent #[Given] inherited directly
  └────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration guidance for Behat context overrides using PHP 8 attributes, including warnings about potential conflicts and duplicate execution.

* **Tests**
  * Added test coverage for Behat context inheritance scenarios with PHP 8 attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->