### PR TITLE
[#791] Fixed 'author' property triggering validation error in node creation.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -291,7 +291,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    */
   public function nodeCreate(\stdClass $node) {
     $this->dispatchHooks(BeforeNodeCreateScope::class, $node);
-    $this->parseEntityFields('node', $node);
+    $this->parseEntityFields('node', $node, ['author']);
     $saved = $this->getDriver()->createNode($node);
     $this->dispatchHooks(AfterNodeCreateScope::class, $saved);
     $this->nodes[] = $saved;

--- a/tests/behat/features/drupal_context.feature
+++ b/tests/behat/features/drupal_context.feature
@@ -281,3 +281,18 @@ Feature: DrupalContext coverage gaps
       """
     When I run behat with drupal profile
     Then it should pass
+
+  @test-drupal @api
+  Scenario: Assert "Given :type content:" passes for author property
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given users:
+        | name     | mail            | status |
+        | Joe User | joe@example.com | 1      |
+      And "article" content:
+        | title          | author   | status |
+        | Article by Joe | Joe User | 1      |
+      """
+    When I run behat with drupal profile
+    Then it should pass


### PR DESCRIPTION
Closes #791

## Summary

When creating nodes via `nodeCreate()`, the `author` property was passed to `parseEntityFields()`, which attempted to resolve it as an entity field. This triggered a validation error because `author` is not a standard Drupal field — it is a convenience property handled separately by the driver. The fix adds `'author'` to the list of ignored properties in the `parseEntityFields()` call, consistent with how `userCreate()` ignores `'role'` and `termCreate()` ignores `'vocabulary_machine_name'`.

## Changes

**`src/Drupal/DrupalExtension/Context/RawDrupalContext.php`**
- Added `['author']` as the third argument to `parseEntityFields()` in `nodeCreate()`, so the `author` property is skipped during field parsing and passed through untouched to the driver.

**`tests/behat/features/drupal_context.feature`**
- Added a Behat scenario that creates a user and then creates an `article` node with the `author` property set to that user's name, asserting that no validation error occurs.

## Before / After

**Before** — `author` passed into `parseEntityFields()`, causing a validation error:

```
nodeCreate($node)
    │
    ├─ dispatchHooks(BeforeNodeCreateScope)
    │
    ├─ parseEntityFields('node', $node)        <── 'author' processed as a field
    │       │                                       FieldHandlerManager tries to
    │       └─ iterates all $node properties        resolve 'author' → validation
    │             including 'author'                error thrown
    │
    ├─ getDriver()->createNode($node)
    └─ dispatchHooks(AfterNodeCreateScope)
```

**After** — `author` is excluded from field parsing and passed through to the driver:

```
nodeCreate($node)
    │
    ├─ dispatchHooks(BeforeNodeCreateScope)
    │
    ├─ parseEntityFields('node', $node, ['author'])   <── 'author' skipped
    │       │
    │       └─ iterates $node properties              Same pattern as:
    │             skipping 'author'                   • userCreate()  → ignores 'role'
    │                                                 • termCreate()  → ignores 'vocabulary_machine_name'
    │
    ├─ getDriver()->createNode($node)    <── 'author' still on $node,
    │                                        driver handles it correctly
    └─ dispatchHooks(AfterNodeCreateScope)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content creation now supports specifying the author property.

* **Tests**
  * Added test coverage for author property handling during content creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->