### PR TITLE
Add Slack community badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 [![GitHub Pull Requests](https://img.shields.io/github/issues-pr/jhedstrom/drupalextension.svg)](https://github.com/jhedstrom/drupalextension/pulls)
 [![Documentation Status](https://readthedocs.org/projects/behat-drupal-extension/badge/?version=master)](https://behat-drupal-extension.readthedocs.org)
 
+[![Join our community](https://img.shields.io/badge/Join%20our%20community-Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://drupal.slack.com/archives/C4T2JHG9K)
 </div>
 
 The Drupal Extension is an integration layer between [Behat](http://behat.org),


### PR DESCRIPTION
Added a badge for community Slack channel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Slack/community badge link to the README for improved project visibility and community engagement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->