### PR TITLE
Allow scalar and special values to be set.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/ConfigContext.php
+++ b/src/Drupal/DrupalExtension/Context/ConfigContext.php
@@ -108,6 +108,43 @@ class ConfigContext extends RawDrupalContext implements TranslatableContext {
   }
 
   /**
+   * Sets a configuration item from a JSON-encoded value.
+   *
+   * Unlike setBasicConfig() which only accepts strings, this step accepts any
+   * JSON-encodable value, making it possible to store booleans, integers,
+   * null, and arrays directly in configuration.
+   *
+   * @param string $name
+   *   The name of the configuration object.
+   * @param string $key
+   *   Identifier to store value in configuration.
+   * @param string $value
+   *   A JSON-encoded scalar or string. Must be valid JSON. Due to how behat
+   *   handles arguments, [] and {} should not be used as value here, because
+   *   they would be wrongly converted in a variable. Use ::setComplexConfig
+   *   instead.
+   *
+   * @throws \InvalidArgumentException
+   *   When $value is not valid JSON.
+   *
+   * @code
+   *   Given I set the configuration item "system.performance" with key "css.preprocess" to JSON value false
+   *   Given I set the configuration item "system.site" with key "weight_select_max" to JSON value 100
+   *   Given I set the configuration item "system.site" with key "weight_select_max" to JSON value null
+   * @endcode
+   */
+  #[Given('I set the configuration item :name with key :key to JSON value :value')]
+  public function setTypedConfig(string $name, string $key, string $value): void {
+    try {
+      $decoded = json_decode($value, TRUE, flags: JSON_THROW_ON_ERROR);
+    }
+    catch (\JsonException $e) {
+      throw new \InvalidArgumentException(sprintf('"%s" is not valid JSON: %s', $value, $e->getMessage()));
+    }
+    $this->setConfig($name, $key, $decoded);
+  }
+
+  /**
    * Sets a value in a configuration object.
    *
    * @param string $name

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -416,6 +416,39 @@ class FeatureContext extends RawDrupalContext {
   }
 
   /**
+   * Asserts the live config value matches a JSON-decoded expected value.
+   *
+   * Uses strict equality so the PHP type is checked, not just the string
+   * representation. This is the companion assertion for setTypedConfig().
+   *
+   * @param string $name
+   *   The configuration object name.
+   * @param string $key
+   *   The configuration key (dot-notation supported, e.g. "css.preprocess").
+   * @param string $expected
+   *   A JSON-encoded expected value (e.g. false, 100, null, []).
+   */
+  #[Then('the configuration item :name with key :key should be JSON :expected')]
+  public function testAssertConfigJsonValue(string $name, string $key, string $expected): void {
+    $expectedDecoded = json_decode($expected, TRUE, flags: JSON_THROW_ON_ERROR);
+    $actual = \Drupal::config($name)->get($key);
+    if ($actual !== $expectedDecoded) {
+      throw new ExpectationException(
+        sprintf(
+          'Expected config "%s.%s" to be %s (%s) but got %s (%s).',
+          $name,
+          $key,
+          json_encode($expectedDecoded),
+          gettype($expectedDecoded),
+          json_encode($actual),
+          gettype($actual),
+        ),
+        $this->getSession()->getDriver()
+      );
+    }
+  }
+
+  /**
    * Asserts that a taxonomy term has the expected parent term.
    *
    * @param string $vocabulary

--- a/tests/behat/features/config.feature
+++ b/tests/behat/features/config.feature
@@ -52,3 +52,23 @@ Feature: ConfigContext
   @test-drupal @api
   Scenario: Assert config was restored to original DB value not the settings.php override
     Then the original configuration item "system.site" with key "name" should be "Drush Site-Install"
+
+  @test-drupal @api
+  Scenario: Assert typed config can be set to JSON scalar values
+    Given I set the configuration item "system.performance" with key "css.preprocess" to JSON value false
+    Then the configuration item "system.performance" with key "css.preprocess" should be JSON false
+    Given I set the configuration item "system.performance" with key "css.preprocess" to JSON value true
+    Then the configuration item "system.performance" with key "css.preprocess" should be JSON true
+    Given I set the configuration item "system.site" with key "weight_select_max" to JSON value 50
+    Then the configuration item "system.site" with key "weight_select_max" should be JSON 50
+    Given I set the configuration item "system.site" with key "weight_select_max" to JSON value null
+    Then the configuration item "system.site" with key "weight_select_max" should be JSON null
+
+  @test-drupal @api
+  Scenario: Assert typed config is restored after scenario
+    Given I set the configuration item "system.performance" with key "css.preprocess" to JSON value false
+    Then the configuration item "system.performance" with key "css.preprocess" should be JSON false
+
+  @test-drupal @api
+  Scenario: Assert typed config was restored by previous scenario cleanup
+    Then the configuration item "system.performance" with key "css.preprocess" should be JSON true


### PR DESCRIPTION
Ok, so we started having issues after updating to the latest version of Drupal extension, mainly due to https://github.com/jhedstrom/drupalextension/pull/779
In that MR, following the suggestion of https://github.com/jhedstrom/drupalextension/issues/500 , the `setConfig` was converted to a protected method with the argument that the `setBasicConfig` and `setComplexConfig` would suffice to properly cover the changes done by `setConfig`, thus there is no point having 2 (3) public methods doing the same thing.
However,
1. `::setBasicConfig` accepts only string $value, so booleans, integers, null etc are problematic here :/ 
2. `::setComplexConfig` accepts a TableNode and while JSON is supported, the table structure disallows to set direct values :/ so `page: false` is not really possible, because you would have something like 
```yaml
page:
  foo: bar
```
For example, I do not see how I can set my `antibot.settings` key `enabled` to FALSE. 

Proposed resolution: I would say, revert the change of visibility, but respecting previous decisions (and because it is a bit easy to be honest as we are accustomed with these steps due to our project), to have an extra step that allows explicit JSON values to be passed.
I have provided an example step (the step definition name could be better to be honest, but that is just a raw version).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended configuration testing capabilities to support multiple data types including booleans, numbers, and null values.
  * Added new test scenarios verifying typed configuration can be properly set, validated, and reset between test iterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->