### PR TITLE
Fixed 'setBasicConfig()' storing all values as strings instead of native PHP types.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -64,11 +64,14 @@ Creates a queue item. Defaults inputs if none are available.
   <summary><code>@Given I set the configuration item :name with key :key to :value</code></summary>
 
 <br/>
-Sets basic configuration item. 
+Sets a configuration item. 
 <br/><br/>
 
 ```gherkin
   Given I set the configuration item "system.site" with key "name" to "My Site"
+  Given I set the configuration item "system.performance" with key "css.preprocess" to "false"
+  Given I set the configuration item "system.site" with key "weight_select_max" to "50"
+  Given I set the configuration item "some.config" with key "nullable_key" to "null"
 
 ```
 
@@ -86,6 +89,11 @@ Sets complex configuration.
     | key   | value  |
     | front | /node  |
     | 403   | /error |
+  Given I set the configuration item "some.config" with key "settings" with values:
+    | key     | value                    |
+    | enabled | true                     |
+    | count   | 5                        |
+    | nested  | {"foo": "bar", "baz": 1} |
 
 ```
 

--- a/src/Drupal/DrupalExtension/Context/ConfigContext.php
+++ b/src/Drupal/DrupalExtension/Context/ConfigContext.php
@@ -58,7 +58,11 @@ class ConfigContext extends RawDrupalContext implements TranslatableContext {
   }
 
   /**
-   * Sets basic configuration item.
+   * Sets a configuration item.
+   *
+   * Scalar type coercion is applied automatically so that values like "true",
+   * "false", "null", and numeric strings are stored with their native PHP
+   * types rather than as plain strings.
    *
    * @param string $name
    *   The name of the configuration object.
@@ -69,11 +73,14 @@ class ConfigContext extends RawDrupalContext implements TranslatableContext {
    *
    * @code
    *   Given I set the configuration item "system.site" with key "name" to "My Site"
+   *   Given I set the configuration item "system.performance" with key "css.preprocess" to "false"
+   *   Given I set the configuration item "system.site" with key "weight_select_max" to "50"
+   *   Given I set the configuration item "some.config" with key "nullable_key" to "null"
    * @endcode
    */
   #[Given('I set the configuration item :name with key :key to :value')]
   public function setBasicConfig(string $name, string $key, string $value): void {
-    $this->setConfig($name, $key, $value);
+    $this->setConfig($name, $key, static::coerceValue($value));
   }
 
   /**
@@ -91,20 +98,62 @@ class ConfigContext extends RawDrupalContext implements TranslatableContext {
    *     | key   | value  |
    *     | front | /node  |
    *     | 403   | /error |
+   *   Given I set the configuration item "some.config" with key "settings" with values:
+   *     | key     | value                    |
+   *     | enabled | true                     |
+   *     | count   | 5                        |
+   *     | nested  | {"foo": "bar", "baz": 1} |
    * @endcode
    */
   #[Given('I set the configuration item :name with key :key with values:')]
   public function setComplexConfig(string $name, string $key, TableNode $config_table): void {
     $value = [];
     foreach ($config_table->getHash() as $row) {
-      // Allow json values for extra complexity.
-      $decoded = json_decode($row['value'], TRUE);
-      if ($decoded !== NULL) {
-        $row['value'] = $decoded;
+      $coerced = static::coerceValue($row['value']);
+      // If coercion returned the string unchanged, attempt JSON decode to
+      // support complex nested structures like {"key": "value"} or [1, 2].
+      if (is_string($coerced)) {
+        $decoded = json_decode($coerced, TRUE);
+        if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+          $coerced = $decoded;
+        }
       }
-      $value[$row['key']] = $row['value'];
+      $value[$row['key']] = $coerced;
     }
     $this->setConfig($name, $key, $value);
+  }
+
+  /**
+   * Coerces a string value to its native PHP type.
+   *
+   * Behat always passes step arguments as strings. This method converts
+   * well-known scalar representations to their proper PHP types so that
+   * Drupal configuration receives correctly typed values.
+   *
+   * @param string $value
+   *   The raw string value from a Behat step argument.
+   *
+   * @return mixed
+   *   The coerced value: bool, null, int, float, or the original string.
+   */
+  protected static function coerceValue(string $value): mixed {
+    if ($value === 'true') {
+      return TRUE;
+    }
+
+    if ($value === 'false') {
+      return FALSE;
+    }
+
+    if ($value === 'null') {
+      return NULL;
+    }
+
+    if (is_numeric($value)) {
+      return str_contains($value, '.') ? (float) $value : (int) $value;
+    }
+
+    return $value;
   }
 
   /**

--- a/tests/behat/features/config.feature
+++ b/tests/behat/features/config.feature
@@ -52,3 +52,20 @@ Feature: ConfigContext
   @test-drupal @api
   Scenario: Assert config was restored to original DB value not the settings.php override
     Then the original configuration item "system.site" with key "name" should be "Drush Site-Install"
+
+  @test-drupal @api
+  Scenario: Assert "Given I set the configuration item :name with key :key to :value" passes for boolean value
+    Given I set the configuration item "system.performance" with key "css.preprocess" to "false"
+    When I go to "admin/config/development/performance"
+    Then the "Aggregate CSS files" checkbox should not be checked
+
+  @test-drupal @api
+  Scenario: Assert typed config is restored after scenario
+    Given I set the configuration item "system.performance" with key "css.preprocess" to "false"
+    When I go to "admin/config/development/performance"
+    Then the "Aggregate CSS files" checkbox should not be checked
+
+  @test-drupal @api
+  Scenario: Assert typed config was restored by previous scenario cleanup
+    When I go to "admin/config/development/performance"
+    Then the "Aggregate CSS files" checkbox should be checked

--- a/tests/phpunit/src/ConfigContextTest.php
+++ b/tests/phpunit/src/ConfigContextTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Tests;
 
+use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\MockObject\MockObject;
 use Drupal\Driver\DriverInterface;
 use Drupal\DrupalDriverManagerInterface;
@@ -125,6 +126,93 @@ class ConfigContextTest extends TestCase {
       ->with('system.site', 'name', 'New');
 
     $this->context->setBasicConfig('system.site', 'name', 'New');
+  }
+
+  /**
+   * Tests that setBasicConfig coerces scalar string values to native types.
+   */
+  #[DataProvider('dataProviderSetBasicConfigCoercion')]
+  public function testSetBasicConfigCoercion(string $input, mixed $expected): void {
+    $this->driver->method('configGet')->willReturn('original');
+
+    $actual = NULL;
+    $this->driver->method('configSet')
+      ->willReturnCallback(function (string $name, string $key, mixed $value) use (&$actual): void {
+        $actual = $value;
+      });
+
+    $this->context->setBasicConfig('test.config', 'key', $input);
+    $this->assertSame($expected, $actual);
+  }
+
+  /**
+   * Provides data for testSetBasicConfigCoercion().
+   */
+  public static function dataProviderSetBasicConfigCoercion(): \Iterator {
+    yield 'boolean true' => ['true', TRUE];
+    yield 'boolean false' => ['false', FALSE];
+    yield 'null' => ['null', NULL];
+    yield 'integer' => ['50', 50];
+    yield 'negative integer' => ['-1', -1];
+    yield 'float' => ['3.14', 3.14];
+    yield 'string stays string' => ['My Site', 'My Site'];
+    yield 'string TRUE not coerced' => ['TRUE', 'TRUE'];
+    yield 'string False not coerced' => ['False', 'False'];
+    yield 'string Null not coerced' => ['Null', 'Null'];
+    yield 'empty string stays string' => ['', ''];
+    yield 'path stays string' => ['/node', '/node'];
+  }
+
+  /**
+   * Tests that setComplexConfig coerces table values to native types.
+   */
+  public function testSetComplexConfigCoercion(): void {
+    $this->driver->method('configGet')->willReturn([]);
+
+    $actual = NULL;
+    $this->driver->method('configSet')
+      ->willReturnCallback(function (string $name, string $key, mixed $value) use (&$actual): void {
+        $actual = $value;
+      });
+
+    $table = new TableNode([
+      ['key', 'value'],
+      ['preprocess', 'true'],
+      ['gzip', 'false'],
+      ['max_age', '300'],
+    ]);
+
+    $this->context->setComplexConfig('system.performance', 'css', $table);
+
+    $this->assertSame(['preprocess' => TRUE, 'gzip' => FALSE, 'max_age' => 300], $actual);
+  }
+
+  /**
+   * Tests that setComplexConfig decodes JSON array/object values in table rows.
+   */
+  public function testSetComplexConfigJsonDecode(): void {
+    $this->driver->method('configGet')->willReturn([]);
+
+    $actual = NULL;
+    $this->driver->method('configSet')
+      ->willReturnCallback(function (string $name, string $key, mixed $value) use (&$actual): void {
+        $actual = $value;
+      });
+
+    $table = new TableNode([
+      ['key', 'value'],
+      ['nested', '{"foo": "bar", "baz": 1}'],
+      ['list', '[1, 2, 3]'],
+      ['plain', '/node'],
+    ]);
+
+    $this->context->setComplexConfig('some.config', 'settings', $table);
+
+    $this->assertSame([
+      'nested' => ['foo' => 'bar', 'baz' => 1],
+      'list' => [1, 2, 3],
+      'plain' => '/node',
+    ], $actual);
   }
 
 }


### PR DESCRIPTION
Supersedes https://github.com/jhedstrom/drupalextension/pull/795

## Summary

Behat always passes step arguments as strings, which caused `setBasicConfig()` to store values like `"true"`, `"false"`, `"null"`, and `"50"` as literal strings in Drupal configuration rather than as their native PHP types (`bool`, `null`, `int`). This matters because Drupal's typed config system validates and uses these types directly — storing `"true"` instead of `TRUE` causes boolean config items to behave incorrectly.

This was reported in PR #795, which proposed a separate "JSON value" step definition as a workaround. This fix takes a simpler approach: automatic type coercion is added directly to the existing step definitions so callers get correct types without changing their feature files.

`setComplexConfig()` had a related bug: `json_decode()` returning `null` was used as the failure sentinel, which made it impossible to store an actual `null` value via the table. The fix uses `json_last_error()` to distinguish a decode failure from a `null` result, and restricts JSON-decode fallback to arrays (the only meaningful complex structure for config tables).

## Changes

**`src/Drupal/DrupalExtension/Context/ConfigContext.php`**

- Added `coerceValue()` static helper that converts `"true"` → `TRUE`, `"false"` → `FALSE`, `"null"` → `NULL`, and numeric strings → `int`/`float`; all other strings pass through unchanged. Matching is case-sensitive to avoid surprising coercions on strings like `"True"` or `"FALSE"`.
- `setBasicConfig()` now calls `coerceValue()` before passing the value to `setConfig()`.
- `setComplexConfig()` now calls `coerceValue()` first, then falls back to `json_decode()` only when the value is still a string and decodes to an array (fixing the `null`-as-sentinel bug).

**`tests/phpunit/src/ConfigContextTest.php`**

- Added `testSetBasicConfigCoercion()` with a data provider covering booleans, `null`, integers, floats, plain strings, mixed-case variants that must not be coerced, empty string, and path strings.
- Added `testSetComplexConfigCoercion()` verifying that table rows with `"true"`, `"false"`, and numeric strings are stored with native types.

**`tests/behat/features/config.feature`**

- Added three Behat scenarios: setting a boolean config value, verifying cleanup restores the previous value after a scenario, and verifying the restored value persists into the next scenario.

## Before / After

```
Before:
  Given I set the configuration item "system.performance" with key "css.preprocess" to "false"
  => configSet("system.performance", "css.preprocess", "false")  // string, not bool
  => Drupal typed config may reject or mishandle the value

After:
  Given I set the configuration item "system.performance" with key "css.preprocess" to "false"
  => coerceValue("false") => FALSE (bool)
  => configSet("system.performance", "css.preprocess", FALSE)    // correct native type

setComplexConfig() null sentinel bug:
  Before:  json_decode("null") === null  =>  sentinel fires, value silently dropped
  After:   json_decode("null") === null, but json_last_error() === JSON_ERROR_NONE
           and is_array(null) === false  =>  coerceValue("null") => NULL stored correctly
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Configuration values like "true", "false", "null", and numeric strings are now correctly converted to their native types instead of remaining as text strings.

* **Tests**
  * Added comprehensive test coverage for boolean and typed configuration handling, including verification of configuration restoration after scenarios complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->