### PR TITLE
Changed default Drush binary to 'vendor/bin/drush' with automatic path resolution.

### DIFF
--- a/behat.dist.yml
+++ b/behat.dist.yml
@@ -115,7 +115,7 @@ drupal:
       # Drush driver settings.
       drush:
         alias: ~
-        binary: drush
+        binary: vendor/bin/drush
         root: /var/www/html/web
         global_options: ~
       region_map:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       PHP_OPCACHE_PRELOAD_USER: wodby
       # Override PATH to remove vendor/bin so that bare 'drush' does not
       # resolve globally — forces tests to exercise the binary resolution.
-      PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/wodby/.composer/vendor/bin"
+      PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       PHP_EXTENSIONS_DISABLE: "${PHP_EXTENSIONS_DISABLE:-xdebug,xhprof,spx}"
       PHP_XDEBUG_MODE: "${PHP_XDEBUG_MODE:-off}"
       PHP_XDEBUG_CLIENT_HOST: host.docker.internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
       PHP_FPM_GROUP: wodby
       PHP_FPM_CLEAR_ENV: "yes"
       PHP_OPCACHE_PRELOAD_USER: wodby
+      # Override PATH to remove vendor/bin so that bare 'drush' does not
+      # resolve globally — forces tests to exercise the binary resolution.
+      PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/wodby/.composer/vendor/bin"
       PHP_EXTENSIONS_DISABLE: "${PHP_EXTENSIONS_DISABLE:-xdebug,xhprof,spx}"
       PHP_XDEBUG_MODE: "${PHP_XDEBUG_MODE:-off}"
       PHP_XDEBUG_CLIENT_HOST: host.docker.internal

--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -187,7 +187,7 @@ class DrupalExtension implements ExtensionInterface {
         ->arrayNode('drush')
           ->children()
             ->scalarNode('alias')->end()
-            ->scalarNode('binary')->defaultValue('drush')->end()
+            ->scalarNode('binary')->defaultValue('vendor/bin/drush')->end()
             ->scalarNode('root')->end()
             ->scalarNode('global_options')->end()
           ->end()

--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -259,7 +259,8 @@ class DrupalExtension implements ExtensionInterface {
       $config['drush']['alias'] ??= FALSE;
       $container->setParameter('drupal.driver.drush.alias', $config['drush']['alias']);
 
-      $config['drush']['binary'] ??= 'drush';
+      $config['drush']['binary'] ??= 'vendor/bin/drush';
+      $config['drush']['binary'] = self::resolveBinaryPath($config['drush']['binary']);
       $container->setParameter('drupal.driver.drush.binary', $config['drush']['binary']);
 
       $config['drush']['root'] ??= FALSE;
@@ -268,6 +269,45 @@ class DrupalExtension implements ExtensionInterface {
       // Set global arguments.
       $this->setDrushOptions($container, $config);
     }
+  }
+
+  /**
+   * Resolve a relative binary path to an absolute path.
+   *
+   * Probes the current working directory and its parent to locate the binary.
+   * This ensures the path remains valid after the Drupal API driver changes
+   * the working directory to DRUPAL_ROOT via chdir().
+   *
+   * Absolute paths and binaries without a directory separator (bare commands
+   * like 'drush' that resolve via $PATH) are returned as-is.
+   */
+  public static function resolveBinaryPath(string $binary): string {
+    // Absolute paths need no resolution.
+    if (str_starts_with($binary, '/')) {
+      return $binary;
+    }
+
+    // Bare command names (no directory separator) resolve via $PATH.
+    if (!str_contains($binary, '/')) {
+      return $binary;
+    }
+
+    $cwd = (string) getcwd();
+
+    // Probe current working directory.
+    $candidate = $cwd . '/' . $binary;
+    if (file_exists($candidate)) {
+      return $candidate;
+    }
+
+    // Probe parent directory (handles cwd being one level deep,
+    // e.g. Drupal root inside a project).
+    $candidate = dirname($cwd) . '/' . $binary;
+    if (file_exists($candidate)) {
+      return $candidate;
+    }
+
+    return $binary;
   }
 
   /**

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -185,16 +185,13 @@ EOL;
 
     // Resolve the drush binary to an absolute path so subprocess tests
     // can find it regardless of their working directory.
-    foreach (['default', 'drupal', 'drupal_https'] as $profile) {
-      if (!isset($yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush'])) {
-        continue;
-      }
-
-      $binary = $yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush']['binary'] ?? 'vendor/bin/drush';
-      if (!str_starts_with((string) $binary, '/') && str_contains((string) $binary, '/')) {
-        $resolved = realpath($binary);
-        if ($resolved !== FALSE) {
-          $yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush']['binary'] = $resolved;
+    // The source behat.yml is at /var/www/html, so resolve relative to that.
+    $projectRoot = dirname($source);
+    $drushBinary = $projectRoot . '/vendor/bin/drush';
+    if (file_exists($drushBinary)) {
+      foreach (['default', 'drupal', 'drupal_https'] as $profile) {
+        if (isset($yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush'])) {
+          $yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush']['binary'] = $drushBinary;
         }
       }
     }

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -186,7 +186,7 @@ EOL;
     // Resolve the drush binary to an absolute path so subprocess tests
     // can find it regardless of their working directory.
     foreach (['default', 'drupal', 'drupal_https'] as $profile) {
-      if (!isset($yaml[$profile]['extensions']['Drupal\DrupalExtension'])) {
+      if (!isset($yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush'])) {
         continue;
       }
 

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -186,7 +186,7 @@ EOL;
     // Resolve the drush binary to an absolute path so subprocess tests
     // can find it regardless of their working directory.
     foreach (['default', 'drupal', 'drupal_https'] as $profile) {
-      if (!isset($yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush'])) {
+      if (!isset($yaml[$profile]['extensions']['Drupal\DrupalExtension'])) {
         continue;
       }
 

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -183,6 +183,22 @@ EOL;
       unset($yaml['default']['extensions'][Extension::class]);
     }
 
+    // Resolve the drush binary to an absolute path so subprocess tests
+    // can find it regardless of their working directory.
+    foreach (['default', 'drupal', 'drupal_https'] as $profile) {
+      if (!isset($yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush'])) {
+        continue;
+      }
+
+      $binary = $yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush']['binary'] ?? 'vendor/bin/drush';
+      if (!str_starts_with((string) $binary, '/') && str_contains((string) $binary, '/')) {
+        $resolved = realpath($binary);
+        if ($resolved !== FALSE) {
+          $yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush']['binary'] = $resolved;
+        }
+      }
+    }
+
     $content = Yaml::dump($yaml, 4, 2);
 
     $filename = 'behat.yml';

--- a/tests/phpunit/src/DrupalExtensionResolveBinaryTest.php
+++ b/tests/phpunit/src/DrupalExtensionResolveBinaryTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Tests;
+
+use Drupal\DrupalExtension\ServiceContainer\DrupalExtension;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests DrupalExtension::resolveBinaryPath().
+ */
+#[CoversMethod(DrupalExtension::class, 'resolveBinaryPath')]
+class DrupalExtensionResolveBinaryTest extends TestCase {
+
+  /**
+   * Temporary directory for test fixtures.
+   */
+  private static string $fixtureDir;
+
+  /**
+   * Original working directory to restore after tests.
+   */
+  private string $originalCwd;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function setUpBeforeClass(): void {
+    self::$fixtureDir = sys_get_temp_dir() . '/drupalext_test_' . getmypid();
+
+    mkdir(self::$fixtureDir . '/project/vendor/bin', 0777, TRUE);
+    touch(self::$fixtureDir . '/project/vendor/bin/drush');
+    chmod(self::$fixtureDir . '/project/vendor/bin/drush', 0755);
+
+    mkdir(self::$fixtureDir . '/project/web', 0777, TRUE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function tearDownAfterClass(): void {
+    $iterator = new \RecursiveIteratorIterator(
+      new \RecursiveDirectoryIterator(self::$fixtureDir, \FilesystemIterator::SKIP_DOTS),
+      \RecursiveIteratorIterator::CHILD_FIRST
+    );
+
+    foreach ($iterator as $file) {
+      $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+    }
+
+    rmdir(self::$fixtureDir);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    $this->originalCwd = (string) getcwd();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    chdir($this->originalCwd);
+  }
+
+  /**
+   * Tests that absolute paths are returned as-is.
+   */
+  public function testAbsolutePathReturnedAsIs(): void {
+    $this->assertSame('/usr/local/bin/drush', DrupalExtension::resolveBinaryPath('/usr/local/bin/drush'));
+  }
+
+  /**
+   * Tests that bare command names (no directory separator) are returned as-is.
+   */
+  public function testBareCommandReturnedAsIs(): void {
+    $this->assertSame('drush', DrupalExtension::resolveBinaryPath('drush'));
+  }
+
+  /**
+   * Tests that a relative path is resolved from the current working directory.
+   */
+  public function testResolvesFromCwd(): void {
+    chdir(self::$fixtureDir . '/project');
+
+    $this->assertSame(
+      self::$fixtureDir . '/project/vendor/bin/drush',
+      DrupalExtension::resolveBinaryPath('vendor/bin/drush')
+    );
+  }
+
+  /**
+   * Tests that a relative path is resolved from the parent directory.
+   */
+  public function testResolvesFromParentDir(): void {
+    chdir(self::$fixtureDir . '/project/web');
+
+    $this->assertSame(
+      self::$fixtureDir . '/project/vendor/bin/drush',
+      DrupalExtension::resolveBinaryPath('vendor/bin/drush')
+    );
+  }
+
+  /**
+   * Tests that an unresolvable relative path is returned as-is.
+   */
+  public function testUnresolvableReturnedAsIs(): void {
+    chdir(self::$fixtureDir);
+
+    $this->assertSame('some/nonexistent/binary', DrupalExtension::resolveBinaryPath('some/nonexistent/binary'));
+  }
+
+}


### PR DESCRIPTION
Thanks to @mxr576 for raising this in #664.

## Summary

Changed the default Drush binary from `drush` (which resolves via `$PATH` and can pick up a globally installed Drush with a different version) to `vendor/bin/drush` (the Composer-managed project-local binary). Added automatic path resolution that probes the current working directory and its parent to convert the relative path to an absolute path at config load time — this ensures the binary remains reachable after the Drupal API driver calls `chdir(DRUPAL_ROOT)`. Removed `vendor/bin` from the Docker container `$PATH` so tests actually exercise the resolution logic instead of silently falling back to a global binary.

## Changes

**`ServiceContainer/DrupalExtension.php`**
- Changed config tree default from `drush` to `vendor/bin/drush`
- Changed `loadDrush()` fallback from `drush` to `vendor/bin/drush`
- Added `resolveBinaryPath()` — probes cwd and parent directory for relative paths, resolves to absolute

**`docker-compose.yml`**
- Removed `/var/www/html/vendor/bin` and `/var/www/html/bin` from the PHP container's `$PATH` so bare `drush` no longer resolves globally

**`behat.dist.yml`**
- Updated the example `binary` value from `drush` to `vendor/bin/drush`

**`tests/behat/bootstrap/BehatCliTrait.php`**
- Added drush binary resolution in `behatCliWriteBehatYml()` — resolves relative binary paths to absolute when copying config to subprocess working directories

**`tests/phpunit/src/DrupalExtensionResolveBinaryTest.php`**
- 5 unit tests for `resolveBinaryPath()`: absolute path, bare command, resolve from cwd, resolve from parent, unresolvable fallback

## Before / After

### Config (behat.yml)

```
Before                              After
──────────────────────────────      ──────────────────────────────
Drupal\DrupalExtension:             Drupal\DrupalExtension:
  drush:                              drush:
    binary: drush  (default)            binary: vendor/bin/drush  (default)
```

### Binary resolution flow

```
Before                              After
──────────────────────────────      ──────────────────────────────
binary = "drush"                    binary = "vendor/bin/drush"
    │                                   │
    ▼                                   ▼
resolve via $PATH                   resolveBinaryPath()
    │                                   │
    ▼                                   ├─ absolute? → use as-is
/usr/bin/drush  (global!)               ├─ bare cmd? → use as-is
    │                                   ├─ {cwd}/vendor/bin/drush exists?
    ▼                                   │     → /var/www/html/vendor/bin/drush ✓
wrong version, silent breakage          └─ {cwd}/../vendor/bin/drush exists?
                                              → check parent dir
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default Drush binary path configuration and resolution logic for improved command discovery
  * Enhanced Docker container PATH environment variable for more reliable binary execution
  * Improved runtime path resolution for Drush commands across different project contexts

* **Tests**
  * Added comprehensive test coverage for binary path resolution behavior, including absolute paths, relative paths, and parent directory resolution scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->