### PR TITLE
[#662] Added drag-and-drop step definition for MinkContext.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -1246,6 +1246,20 @@ When I press the "Save" button
 </details>
 
 <details>
+  <summary><code>@When I drag element :source onto element :target</code></summary>
+
+<br/>
+Drag and drop one element onto another. 
+<br/><br/>
+
+```gherkin
+When I drag element "#draggable" onto element "#droppable"
+
+```
+
+</details>
+
+<details>
   <summary><code>@When I follow/click :link in the :region( region)</code></summary>
 
 <br/>

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -12,6 +12,7 @@ use Behat\Step\Then;
 use Behat\Behat\Hook\Scope\BeforeStepScope;
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Behat\Context\TranslatableContext;
+use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\MinkExtension\Context\MinkContext as MinkExtension;
 use Drupal\DrupalExtension\RegionTrait;
@@ -265,6 +266,31 @@ JS;
     $driver->keyDown($element->getXpath(), $char);
     $driver->keyUp($element->getXpath(), $char);
   }
+
+  /**
+   * Drag and drop one element onto another.
+   *
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
+   *
+   * @Given I drag element :dragged onto element :target
+   */
+    public function dragElementOntoAnother($dragged, $target)
+    {
+        $session = $this->getSession();
+        $driver = $session->getDriver();
+
+        $draggedElement = $session->getPage()->find('css', $dragged);
+        if (empty($draggedElement)) {
+            throw new ElementNotFoundException($driver, 'dragged element', 'css selector', $dragged);
+        }
+
+        $targetElement = $session->getPage()->find('css', $target);
+        if (empty($targetElement)) {
+            throw new ElementNotFoundException($driver, 'target element', 'css selector', $target);
+        }
+
+        $draggedElement->dragTo($targetElement);
+    }
 
   /**
    * Assert a link is visible on the page.

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -270,27 +270,29 @@ JS;
   /**
    * Drag and drop one element onto another.
    *
-   * @throws \Behat\Mink\Exception\ElementNotFoundException
+   * @code
+   * When I drag element "#draggable" onto element "#droppable"
+   * @endcode
    *
-   * @Given I drag element :dragged onto element :target
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
    */
-    public function dragElementOntoAnother($dragged, $target)
-    {
-        $session = $this->getSession();
-        $driver = $session->getDriver();
+  #[When('I drag element :source onto element :target')]
+  public function dragElementOntoAnother(string $source, string $target): void {
+    $page = $this->getSession()->getPage();
+    $driver = $this->getSession()->getDriver();
 
-        $draggedElement = $session->getPage()->find('css', $dragged);
-        if (empty($draggedElement)) {
-            throw new ElementNotFoundException($driver, 'dragged element', 'css selector', $dragged);
-        }
-
-        $targetElement = $session->getPage()->find('css', $target);
-        if (empty($targetElement)) {
-            throw new ElementNotFoundException($driver, 'target element', 'css selector', $target);
-        }
-
-        $draggedElement->dragTo($targetElement);
+    $sourceElement = $page->find('css', $source);
+    if ($sourceElement === NULL) {
+      throw new ElementNotFoundException($driver, 'source element', 'css selector', $source);
     }
+
+    $targetElement = $page->find('css', $target);
+    if ($targetElement === NULL) {
+      throw new ElementNotFoundException($driver, 'target element', 'css selector', $target);
+    }
+
+    $sourceElement->dragTo($targetElement);
+  }
 
   /**
    * Assert a link is visible on the page.

--- a/tests/behat/features/drag_and_drop.feature
+++ b/tests/behat/features/drag_and_drop.feature
@@ -9,10 +9,10 @@ Feature: Drag and drop
     When I drag element "#source" onto element "#target"
     Then I should see "Element was dropped"
 
-  @test-blackbox @javascript
+  @test-blackbox
   Scenario: Assert "When I drag element :source onto element :target" fails for missing source
     Given some behat configuration
-    And scenario steps tagged with "@test-blackbox @javascript":
+    And scenario steps tagged with "@test-blackbox":
       """
       Given I am at "drag_and_drop.html"
       When I drag element "#nonexistent" onto element "#target"
@@ -23,10 +23,10 @@ Feature: Drag and drop
       Source element with css selector "#nonexistent" not found.
       """
 
-  @test-blackbox @javascript
+  @test-blackbox
   Scenario: Assert "When I drag element :source onto element :target" fails for missing target
     Given some behat configuration
-    And scenario steps tagged with "@test-blackbox @javascript":
+    And scenario steps tagged with "@test-blackbox":
       """
       Given I am at "drag_and_drop.html"
       When I drag element "#source" onto element "#nonexistent"

--- a/tests/behat/features/drag_and_drop.feature
+++ b/tests/behat/features/drag_and_drop.feature
@@ -1,0 +1,38 @@
+Feature: Drag and drop
+  As a developer
+  I want to drag one element onto another
+  So that I can test drag-and-drop interactions
+
+  @test-blackbox @javascript
+  Scenario: Assert "When I drag element :source onto element :target" passes
+    Given I am at "drag_and_drop.html"
+    When I drag element "#source" onto element "#target"
+    Then I should see "Element was dropped"
+
+  @test-blackbox @javascript
+  Scenario: Assert "When I drag element :source onto element :target" fails for missing source
+    Given some behat configuration
+    And scenario steps tagged with "@test-blackbox @javascript":
+      """
+      Given I am at "drag_and_drop.html"
+      When I drag element "#nonexistent" onto element "#target"
+      """
+    When I run behat
+    Then it should fail with an error:
+      """
+      Source element with css selector "#nonexistent" not found.
+      """
+
+  @test-blackbox @javascript
+  Scenario: Assert "When I drag element :source onto element :target" fails for missing target
+    Given some behat configuration
+    And scenario steps tagged with "@test-blackbox @javascript":
+      """
+      Given I am at "drag_and_drop.html"
+      When I drag element "#source" onto element "#nonexistent"
+      """
+    When I run behat
+    Then it should fail with an error:
+      """
+      Target element with css selector "#nonexistent" not found.
+      """

--- a/tests/behat/features/drag_and_drop.feature
+++ b/tests/behat/features/drag_and_drop.feature
@@ -4,10 +4,18 @@ Feature: Drag and drop
   So that I can test drag-and-drop interactions
 
   @test-blackbox @javascript
-  Scenario: Assert "When I drag element :source onto element :target" passes
+  Scenario: Assert "When I drag element :source onto element :target" passes for target A
     Given I am at "drag_and_drop.html"
-    When I drag element "#source" onto element "#target"
-    Then I should see "Element was dropped"
+    When I drag element "#source" onto element "#target-a"
+    Then I should see "Dropped on target-a"
+    And I should not see "Dropped on target-b"
+
+  @test-blackbox @javascript
+  Scenario: Assert "When I drag element :source onto element :target" passes for target B
+    Given I am at "drag_and_drop.html"
+    When I drag element "#source" onto element "#target-b"
+    Then I should see "Dropped on target-b"
+    And I should not see "Dropped on target-a"
 
   @test-blackbox
   Scenario: Assert "When I drag element :source onto element :target" fails for missing source
@@ -15,7 +23,7 @@ Feature: Drag and drop
     And scenario steps tagged with "@test-blackbox":
       """
       Given I am at "drag_and_drop.html"
-      When I drag element "#nonexistent" onto element "#target"
+      When I drag element "#nonexistent" onto element "#target-a"
       """
     When I run behat
     Then it should fail with an error:

--- a/tests/behat/fixtures/blackbox/drag_and_drop.html
+++ b/tests/behat/fixtures/blackbox/drag_and_drop.html
@@ -3,31 +3,31 @@
     <title>Drag and Drop Test</title>
     <style>
       #source { width: 100px; height: 100px; background: #3498db; cursor: move; }
-      #target { width: 200px; height: 200px; background: #ecf0f1; border: 2px dashed #bdc3c7; margin-top: 20px; }
-      #target.dropped { background: #2ecc71; }
+      .drop-zone { width: 200px; height: 200px; background: #ecf0f1; border: 2px dashed #bdc3c7; margin-top: 20px; display: inline-block; vertical-align: top; margin-right: 20px; }
     </style>
   </head>
   <body>
     <div id="source" draggable="true">Drag me</div>
-    <div id="target">Drop here</div>
+    <div id="target-a" class="drop-zone">Target A</div>
+    <div id="target-b" class="drop-zone">Target B</div>
     <div id="result"></div>
     <script>
       var source = document.getElementById('source');
-      var target = document.getElementById('target');
       var result = document.getElementById('result');
 
       source.addEventListener('dragstart', function(e) {
-        e.dataTransfer.setData('text/plain', 'dragged');
+        e.dataTransfer.setData('text/plain', source.id);
       });
 
-      target.addEventListener('dragover', function(e) {
-        e.preventDefault();
-      });
+      document.querySelectorAll('.drop-zone').forEach(function(zone) {
+        zone.addEventListener('dragover', function(e) {
+          e.preventDefault();
+        });
 
-      target.addEventListener('drop', function(e) {
-        e.preventDefault();
-        target.classList.add('dropped');
-        result.textContent = 'Element was dropped';
+        zone.addEventListener('drop', function(e) {
+          e.preventDefault();
+          result.textContent = 'Dropped on ' + zone.id;
+        });
       });
     </script>
   </body>

--- a/tests/behat/fixtures/blackbox/drag_and_drop.html
+++ b/tests/behat/fixtures/blackbox/drag_and_drop.html
@@ -1,0 +1,34 @@
+<html>
+  <head>
+    <title>Drag and Drop Test</title>
+    <style>
+      #source { width: 100px; height: 100px; background: #3498db; cursor: move; }
+      #target { width: 200px; height: 200px; background: #ecf0f1; border: 2px dashed #bdc3c7; margin-top: 20px; }
+      #target.dropped { background: #2ecc71; }
+    </style>
+  </head>
+  <body>
+    <div id="source" draggable="true">Drag me</div>
+    <div id="target">Drop here</div>
+    <div id="result"></div>
+    <script>
+      var source = document.getElementById('source');
+      var target = document.getElementById('target');
+      var result = document.getElementById('result');
+
+      source.addEventListener('dragstart', function(e) {
+        e.dataTransfer.setData('text/plain', 'dragged');
+      });
+
+      target.addEventListener('dragover', function(e) {
+        e.preventDefault();
+      });
+
+      target.addEventListener('drop', function(e) {
+        e.preventDefault();
+        target.classList.add('dropped');
+        result.textContent = 'Element was dropped';
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
> Iterates on #663 by @chrisolof. Thank you for the contribution!

Closes #662.

## Summary

This picks up the drag-and-drop work from #663 and brings it up to the current codebase standards. The core idea is the same — a `When I drag element :source onto element :target` step that wraps Mink's `dragTo()` — but a few things needed updating before it could land.

- Switched from Doctrine annotations to PHP 8 `#[When(...)]` attributes (the extension dropped annotation support in v5).
- Changed the annotation verb from `@Given` to `@When` — dragging is an action, not a precondition.
- Renamed the parameter from `$dragged` to `$source` for symmetry with `$target`.
- Added explicit type declarations (`string` arguments, `void` return).
- Replaced `empty()` checks with `=== NULL` to avoid false positives on `'0'`-style selectors.
- Added a `@code` example to the docblock so `ahoy docs` picks it up.
- Added an HTML fixture and three Behat scenarios: one positive `@javascript` test and two subprocess tests covering the "source not found" and "target not found" error paths.

## Changes

**`src/Drupal/DrupalExtension/Context/MinkContext.php`**

- Added `dragElementOntoAnother()` step definition using `#[When('I drag element :source onto element :target')]`.
- Throws `ElementNotFoundException` with a clear "source element" / "target element" label so error messages are readable in CI output.

**`tests/behat/fixtures/blackbox/drag_and_drop.html`**

- Static HTML page with a draggable `#source` div, a `#target` drop zone, and a JS `drop` listener that writes `"Element was dropped"` when the interaction completes. Used by the `@javascript` scenario.

**`tests/behat/features/drag_and_drop.feature`**

- Three scenarios covering positive (`@javascript`), missing source, and missing target cases.

## Before / After

```
Before (#663 — annotation style, no tests):
  /**
   * @Given I drag :dragged element onto :element element
   */
  public function dragElementOntoAnother($dragged, $element): void {
    ...
    if (empty($sourceElement)) {   // empty() surprises on '0' selectors
    ...
  }

After (this PR — attributes, typed, tested):
  #[When('I drag element :source onto element :target')]
  public function dragElementOntoAnother(string $source, string $target): void {
    ...
    if ($sourceElement === NULL) {  // explicit null check
    ...
    throw new ElementNotFoundException($driver, 'source element', 'css selector', $source);
  }
```

## Flow

```
Feature file                  MinkContext::dragElementOntoAnother()
-----------                   ------------------------------------
When I drag element           find($source) === NULL?
  "#source" onto               -> ElementNotFoundException("source element")
  element "#target"           find($target) === NULL?
                               -> ElementNotFoundException("target element")
                              $sourceElement->dragTo($targetElement)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added drag-and-drop testing capability to verify element dragging interactions.

* **Tests**
  * Added test scenarios for drag-and-drop functionality, including validation of successful drops and error handling when source or target elements are not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->