### PR TITLE
Switched 'drupal/drupal-driver' to 'dev-master' to verify upcoming release.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "behat/gherkin": "^4.13",
         "behat/mink": "^1.12",
         "behat/mink-browserkit-driver": "^2.1.0",
-        "drupal/drupal-driver": "^2.4.3",
+        "drupal/drupal-driver": "dev-master",
         "friends-of-behat/mink-extension": "^2.7.1",
         "lullabot/mink-selenium2-driver": "^1.7.4",
         "symfony/css-selector": "^6.4.3 || ^7",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "behat/gherkin": "^4.13",
         "behat/mink": "^1.12",
         "behat/mink-browserkit-driver": "^2.1.0",
-        "drupal/drupal-driver": "dev-master",
+        "drupal/drupal-driver": "dev-feature/fix-permissions",
         "friends-of-behat/mink-extension": "^2.7.1",
         "lullabot/mink-selenium2-driver": "^1.7.4",
         "symfony/css-selector": "^6.4.3 || ^7",


### PR DESCRIPTION
## Summary

This PR temporarily switches the `drupal/drupal-driver` constraint from `^2.4.3` to `dev-master` so that the full `drupalextension` test suite runs against the tip of the driver's master branch before a new release is cut. It is not intended to merge - the constraint should be reverted to a tagged version once the driver release is published and the CI run here confirms compatibility.

## Changes

- `composer.json`: `drupal/drupal-driver` constraint changed from `^2.4.3` to `dev-master`.

## Before / After

```
Before (tagged release)
┌─────────────────────────┐       ┌──────────────────────────────┐
│  drupalextension        │       │  Packagist                   │
│  composer.json          │──────▶│  drupal/drupal-driver        │
│  "^2.4.3"               │       │  resolves to: 2.4.3 (tagged) │
└─────────────────────────┘       └──────────────────────────────┘

After (dev-master branch tip)
┌─────────────────────────┐       ┌──────────────────────────────┐
│  drupalextension        │       │  GitHub                      │
│  composer.json          │──────▶│  drupal/drupal-driver        │
│  "dev-master"           │       │  resolves to: master HEAD    │
└─────────────────────────┘       └──────────────────────────────┘
                                           │
                                           ▼
                                  ┌─────────────────────┐
                                  │  CI: full test suite │
                                  │  against unreleased  │
                                  │  driver changes      │
                                  └─────────────────────┘
```
