### PR TITLE
Switched to Drupal coding standards.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -456,7 +456,7 @@ Then I should be able to edit an "article" content
   <summary><code>@Then (I )break</code></summary>
 
 <br/>
-Pauses the scenario until the user presses a key. Useful when debugging a scenario. 
+Pauses the scenario until the user presses a key. 
 <br/><br/>
 
 ```gherkin
@@ -862,7 +862,7 @@ Checks if the current page does not contain the given error message.
   <summary><code>@Given I should not see the success message( containing) :message</code></summary>
 
 <br/>
-Checks if the current page does not contain the given set of success message. 
+Checks the page does not contain the given success message. 
 <br/><br/>
 
 ```gherkin
@@ -877,7 +877,7 @@ Checks if the current page does not contain the given set of success message.
   <summary><code>@Given I should not see the warning message( containing) :message</code></summary>
 
 <br/>
-Checks if the current page does not contain the given set of warning message. 
+Checks the page does not contain the given warning message. 
 <br/><br/>
 
 ```gherkin
@@ -971,7 +971,7 @@ Checks if the current page contains the given set of success messages.
   <summary><code>@Then I should not see the following success messages:</code></summary>
 
 <br/>
-Checks if the current page does not contain the given set of success messages. 
+Checks the page does not contain the given set of success messages. 
 <br/><br/>
 
 ```gherkin
@@ -1018,7 +1018,7 @@ Checks if the current page contains the given set of warning messages.
   <summary><code>@Then I should not see the following warning messages:</code></summary>
 
 <br/>
-Checks if the current page does not contain the given set of warning messages. 
+Checks the page does not contain the given set of warning messages. 
 <br/><br/>
 
 ```gherkin
@@ -1131,7 +1131,7 @@ Press a key in a form field.
   <summary><code>@Given I press :button in the :region( region)</code></summary>
 
 <br/>
-Checks if a button with id|name|title|alt|value exists or not and presses the same. 
+Checks if a button exists and presses it. 
 <br/><br/>
 
 ```gherkin
@@ -1163,7 +1163,7 @@ Given I fill in "Search" with "test" in the "header" region
   <summary><code>@Given I check :locator in the :region( region)</code></summary>
 
 <br/>
-Checks if a checkbox with id|name|title|alt|value exists or not and checks the same. 
+Checks if a checkbox exists and checks it. 
 <br/><br/>
 
 ```gherkin
@@ -1178,7 +1178,7 @@ Given I check "Published" in the "content" region
   <summary><code>@Given I uncheck :checkbox in the :region( region)</code></summary>
 
 <br/>
-Checks if a checkbox with id|name|title|alt|value exists or not and unchecks the same. 
+Checks if a checkbox exists and unchecks it. 
 <br/><br/>
 
 ```gherkin
@@ -1339,7 +1339,7 @@ Then I should not see the link "Log out"
   <summary><code>@Then I should not visibly see the link :link</code></summary>
 
 <br/>
-Links are loaded but not visually visible (e.g they have display: hidden applied). 
+Links are loaded but not visually visible. 
 <br/><br/>
 
 ```gherkin

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "dantleech/gherkin-lint": "^0.2.3",
         "dflydev/dot-access-data": "^3.0.3",
         "drevops/behat-screenshot": "^2.2",
-        "drevops/phpcs-standard": "^0.6.2",
+        "drevops/phpcs-standard": "^0.7.0",
         "drupal/coder": "^8.3.27",
         "drupal/core": "^11",
         "drupal/core-composer-scaffold": "^11",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -14,10 +14,10 @@
     <file>tests/phpunit</file>
 
     <rule ref="Drupal">
-        <exclude name="Drupal.Files.LineLength.TooLong"/>
-        <exclude name="Drupal.Semantics.FunctionTriggerError"/>
         <exclude name="Drupal.Commenting.Deprecated"/>
     </rule>
+    <rule ref="DrevOps"/>
+    <rule ref="Generic.PHP.RequireStrictTypes" />
 
     <!-- PHPSpec uses snake_case methods without visibility keywords and does
          not follow Drupal commenting conventions. -->
@@ -40,22 +40,6 @@
 
     <rule ref="Generic.PHP.RequireStrictTypes">
         <exclude-pattern>*/spec/*</exclude-pattern>
-    </rule>
-
-    <rule ref="DrevOps.NamingConventions.LocalVariableNaming">
-        <properties>
-            <property name="format" value="camelCase"/>
-        </properties>
-        <exclude-pattern>*/spec/*</exclude-pattern>
-        <exclude-pattern>*/tests/behat/fixtures/*</exclude-pattern>
-    </rule>
-
-    <rule ref="DrevOps.NamingConventions.ParameterNaming">
-        <properties>
-            <property name="format" value="camelCase"/>
-        </properties>
-        <exclude-pattern>*/spec/*</exclude-pattern>
-        <exclude-pattern>*/tests/behat/fixtures/*</exclude-pattern>
     </rule>
 
 </ruleset>

--- a/scripts/check-coverage.php
+++ b/scripts/check-coverage.php
@@ -26,39 +26,39 @@ if (empty($argv[1])) {
   exit(1);
 }
 
-$traitName = $argv[1];
-$defaultCoverageFile = file_exists('/var/www/html/.logs/coverage/merged/cobertura.xml')
+$trait_name = $argv[1];
+$default_coverage_file = file_exists('/var/www/html/.logs/coverage/merged/cobertura.xml')
   ? '/var/www/html/.logs/coverage/merged/cobertura.xml'
   : __DIR__ . '/../.logs/coverage/merged/cobertura.xml';
-$coverageFile = $argv[2] ?? $defaultCoverageFile;
+$coverage_file = $argv[2] ?? $default_coverage_file;
 
-if (!file_exists($coverageFile)) {
-  echo sprintf("Error: Coverage file not found: %s\n", $coverageFile);
+if (!file_exists($coverage_file)) {
+  echo sprintf("Error: Coverage file not found: %s\n", $coverage_file);
   exit(1);
 }
 
-$xml = simplexml_load_file($coverageFile);
+$xml = simplexml_load_file($coverage_file);
 if ($xml === FALSE) {
-  echo sprintf("Error: Failed to parse coverage file: %s\n", $coverageFile);
+  echo sprintf("Error: Failed to parse coverage file: %s\n", $coverage_file);
   exit(1);
 }
 
 $xml->registerXPathNamespace('c', 'http://cobertura.sourceforge.net/xml/coverage-04.dtd');
 
-$classes = $xml->xpath(sprintf('//class[contains(@name, "%s")]', $traitName));
+$classes = $xml->xpath(sprintf('//class[contains(@name, "%s")]', $trait_name));
 
 if (empty($classes)) {
-  echo sprintf("Error: Class '%s' not found in coverage report.\n", $traitName);
+  echo sprintf("Error: Class '%s' not found in coverage report.\n", $trait_name);
   exit(1);
 }
 
 foreach ($classes as $class) {
-  $className = (string) $class['name'];
-  $lineRate = (float) $class['line-rate'];
-  $percentage = number_format($lineRate * 100, 2);
+  $class_name = (string) $class['name'];
+  $line_rate = (float) $class['line-rate'];
+  $percentage = number_format($line_rate * 100, 2);
 
-  echo sprintf("Class: %s\n", $className);
-  echo sprintf("Line rate: %s (%s%%)\n\n", $lineRate, $percentage);
+  echo sprintf("Class: %s\n", $class_name);
+  echo sprintf("Line rate: %s (%s%%)\n\n", $line_rate, $percentage);
 
   $uncovered = [];
   if (property_exists($class->lines, 'line') && $class->lines->line !== NULL) {

--- a/scripts/docs.php
+++ b/scripts/docs.php
@@ -40,7 +40,7 @@ use Behat\Step\Given;
 use Behat\Step\When;
 use Behat\Step\Then;
 
-// Execute the main function only when the script is run directly, not when included.
+// Execute main only when script is run directly, not when included.
 // @codeCoverageIgnoreStart
 if (basename((string) $_SERVER['SCRIPT_FILENAME']) === 'docs.php') {
   $options = getopt('', ['fail-on-change', 'path::', 'warning-on-invalid', 'log-dir::']);
@@ -57,61 +57,61 @@ if (basename((string) $_SERVER['SCRIPT_FILENAME']) === 'docs.php') {
  * @codeCoverageIgnoreStart
  */
 function main(array $options = []): void {
-  $basePath = is_string($options['path'] ?? NULL) ? $options['path'] : dirname(__DIR__);
+  $base_path = is_string($options['path'] ?? NULL) ? $options['path'] : dirname(__DIR__);
 
-  require_once $basePath . '/vendor/autoload.php';
+  require_once $base_path . '/vendor/autoload.php';
 
-  $contextDir = $basePath . '/src/Drupal/DrupalExtension/Context';
-  $info = extract_info($contextDir, [], $basePath);
+  $context_dir = $base_path . '/src/Drupal/DrupalExtension/Context';
+  $info = extract_info($context_dir, [], $base_path);
 
   $lenient = isset($options['warning-on-invalid']);
-  $results = validate($info, $basePath);
+  $results = validate($info, $base_path);
 
-  $treeOutput = '';
+  $tree_output = '';
   if (has_validation_errors($results)) {
-    $treeOutput = render_validation_tree($results);
-    echo $treeOutput;
+    $tree_output = render_validation_tree($results);
+    echo $tree_output;
     if (!$lenient) {
       exit(1);
     }
   }
 
-  $logDir = is_string($options['log-dir'] ?? NULL) ? $options['log-dir'] : NULL;
-  if ($logDir !== NULL) {
-    write_validation_logs($treeOutput, $logDir);
+  $log_dir = is_string($options['log-dir'] ?? NULL) ? $options['log-dir'] : NULL;
+  if ($log_dir !== NULL) {
+    write_validation_logs($tree_output, $log_dir);
   }
 
-  $stepsMarkdown = PHP_EOL . render_info($info, $basePath) . PHP_EOL;
-  $readmeMarkdown = PHP_EOL . render_info($info, $basePath, 'STEPS.md') . PHP_EOL;
+  $steps_markdown = PHP_EOL . render_info($info, $base_path) . PHP_EOL;
+  $readme_markdown = PHP_EOL . render_info($info, $base_path, 'STEPS.md') . PHP_EOL;
 
-  $stepsFile = 'STEPS.md';
-  $stepsContents = file_get_contents($basePath . DIRECTORY_SEPARATOR . $stepsFile);
-  if ($stepsContents === FALSE) {
-    printf('Failed to read %s.' . PHP_EOL, $stepsFile);
+  $steps_file = 'STEPS.md';
+  $steps_contents = file_get_contents($base_path . DIRECTORY_SEPARATOR . $steps_file);
+  if ($steps_contents === FALSE) {
+    printf('Failed to read %s.' . PHP_EOL, $steps_file);
     exit(1);
   }
-  $stepsReplaced = replace_content($stepsContents, '# Available steps', '[//]: # (END)', $stepsMarkdown);
+  $steps_replaced = replace_content($steps_contents, '# Available steps', '[//]: # (END)', $steps_markdown);
 
-  $readmeFile = 'README.md';
-  $readmeContents = file_get_contents($basePath . DIRECTORY_SEPARATOR . $readmeFile);
-  if ($readmeContents === FALSE) {
-    printf('Failed to read %s.' . PHP_EOL, $readmeFile);
+  $readme_file = 'README.md';
+  $readme_contents = file_get_contents($base_path . DIRECTORY_SEPARATOR . $readme_file);
+  if ($readme_contents === FALSE) {
+    printf('Failed to read %s.' . PHP_EOL, $readme_file);
     exit(1);
   }
-  $readmeReplaced = replace_content($readmeContents, '## Available steps', '[//]: # (END)', $readmeMarkdown);
+  $readme_replaced = replace_content($readme_contents, '## Available steps', '[//]: # (END)', $readme_markdown);
 
-  if ($stepsReplaced === $stepsContents && $readmeReplaced === $readmeContents) {
+  if ($steps_replaced === $steps_contents && $readme_replaced === $readme_contents) {
     echo PHP_EOL . "\033[32mDocumentation is up to date. No changes were made.\033[0m" . PHP_EOL;
     exit(0);
   }
 
-  $failOnChange = isset($options['fail-on-change']);
-  if ($failOnChange && ($stepsReplaced !== $stepsContents || $readmeReplaced !== $readmeContents)) {
+  $fail_on_change = isset($options['fail-on-change']);
+  if ($fail_on_change && ($steps_replaced !== $steps_contents || $readme_replaced !== $readme_contents)) {
     echo PHP_EOL . "\033[31mDocumentation is outdated. Please regenerate documentation.\033[0m" . PHP_EOL;
     exit(1);
   }
-  file_put_contents($basePath . DIRECTORY_SEPARATOR . $stepsFile, $stepsReplaced);
-  file_put_contents($basePath . DIRECTORY_SEPARATOR . $readmeFile, $readmeReplaced);
+  file_put_contents($base_path . DIRECTORY_SEPARATOR . $steps_file, $steps_replaced);
+  file_put_contents($base_path . DIRECTORY_SEPARATOR . $readme_file, $readme_replaced);
   echo 'Documentation updated.' . PHP_EOL;
 }
 
@@ -120,11 +120,11 @@ function main(array $options = []): void {
 /**
  * Parse info from the Context classes in a directory.
  *
- * @param string $contextDir
+ * @param string $context_dir
  *   The directory containing Context classes.
  * @param array<int, string> $exclude
  *   Array of class names to exclude.
- * @param string $basePath
+ * @param string $base_path
  *   Base path for the repository.
  *
  * @return array<string,array<string, array<int, array<string, array<int,string>|string>>|string>>
@@ -132,34 +132,34 @@ function main(array $options = []): void {
  *
  * @throws \ReflectionException
  */
-function extract_info(string $contextDir, array $exclude = [], string $basePath = '', string $namespace = 'Drupal\\DrupalExtension\\Context'): array {
-  if (empty($basePath)) {
+function extract_info(string $context_dir, array $exclude = [], string $base_path = '', string $namespace = 'Drupal\\DrupalExtension\\Context'): array {
+  if (empty($base_path)) {
     // @codeCoverageIgnore
-    $basePath = dirname(__DIR__);
+    $base_path = dirname(__DIR__);
   }
 
   $info = [];
 
-  if (!is_dir($contextDir)) {
-    throw new \Exception(sprintf('Context directory %s does not exist', $contextDir));
+  if (!is_dir($context_dir)) {
+    throw new \Exception(sprintf('Context directory %s does not exist', $context_dir));
   }
 
   // Collect all PHP files in the context directory.
-  $files = scandir($contextDir) ?: [];
-  $classFiles = [];
+  $files = scandir($context_dir) ?: [];
+  $class_files = [];
   foreach ($files as $file) {
-    if (is_file($contextDir . DIRECTORY_SEPARATOR . $file) && str_ends_with($file, '.php')) {
-      $classFiles[] = basename($file, '.php');
+    if (is_file($context_dir . DIRECTORY_SEPARATOR . $file) && str_ends_with($file, '.php')) {
+      $class_files[] = basename($file, '.php');
     }
   }
-  sort($classFiles);
+  sort($class_files);
 
-  foreach ($classFiles as $className) {
-    if (in_array($className, $exclude, TRUE)) {
+  foreach ($class_files as $class_name) {
+    if (in_array($class_name, $exclude, TRUE)) {
       continue;
     }
 
-    $fqcn = $namespace . '\\' . $className;
+    $fqcn = $namespace . '\\' . $class_name;
 
     if (!class_exists($fqcn)) {
       continue;
@@ -176,13 +176,13 @@ function extract_info(string $contextDir, array $exclude = [], string $basePath 
       continue;
     }
 
-    $classInfo = [
-      'name' => $className,
-      'name_contextual' => $className,
-      'context' => $className,
+    $class_info = [
+      'name' => $class_name,
+      'name_contextual' => $class_name,
+      'context' => $class_name,
       'methods' => [],
     ];
-    $classInfo += parse_class_comment($className, (string) $reflection->getDocComment());
+    $class_info += parse_class_comment($class_name, (string) $reflection->getDocComment());
 
     // Get all public methods declared in this class (not inherited).
     $methods = $reflection->getMethods(ReflectionMethod::IS_PUBLIC);
@@ -192,25 +192,25 @@ function extract_info(string $contextDir, array $exclude = [], string $basePath 
         continue;
       }
 
-      $attributeSteps = extract_step_attributes($method);
-      $parsedComment = parse_method_comment((string) $method->getDocComment(), !empty($attributeSteps));
+      $attribute_steps = extract_step_attributes($method);
+      $parsed_comment = parse_method_comment((string) $method->getDocComment(), !empty($attribute_steps));
 
-      if (!empty($attributeSteps)) {
-        $methodInfo = $parsedComment ?? ['steps' => [], 'description' => '', 'example' => ''];
-        $methodInfo['steps'] = $attributeSteps;
-        $classInfo['methods'][] = $methodInfo + ['name' => $method->getName()];
+      if (!empty($attribute_steps)) {
+        $method_info = $parsed_comment ?? ['steps' => [], 'description' => '', 'example' => ''];
+        $method_info['steps'] = $attribute_steps;
+        $class_info['methods'][] = $method_info + ['name' => $method->getName()];
       }
-      elseif ($parsedComment) {
-        $classInfo['methods'][] = $parsedComment + ['name' => $method->getName()];
+      elseif ($parsed_comment) {
+        $class_info['methods'][] = $parsed_comment + ['name' => $method->getName()];
       }
     }
 
-    if (!empty($classInfo['methods'])) {
+    if (!empty($class_info['methods'])) {
       // Sort info by Given, When, Then.
-      usort($classInfo['methods'], static function (array $a, array $b): int {
+      usort($class_info['methods'], static function (array $a, array $b): int {
           $order = ['@Given', '@When', '@Then'];
 
-          $getOrderIndex = function ($step) use ($order): int {
+          $get_order_index = function ($step) use ($order): int {
             foreach ($order as $index => $prefix) {
               if (str_starts_with($step, $prefix)) {
                 return $index;
@@ -222,19 +222,19 @@ function extract_info(string $contextDir, array $exclude = [], string $basePath 
               // @codeCoverageIgnoreEnd
           };
 
-          $aStep = $a['steps'][0] ?? '';
-          $bStep = $b['steps'][0] ?? '';
+          $a_step = $a['steps'][0] ?? '';
+          $b_step = $b['steps'][0] ?? '';
 
-          $aIndex = $getOrderIndex($aStep);
-          $bIndex = $getOrderIndex($bStep);
+          $a_index = $get_order_index($a_step);
+          $b_index = $get_order_index($b_step);
 
-          return $aIndex <=> $bIndex;
+          return $a_index <=> $b_index;
       });
     }
 
     // Only include classes that have step definitions.
-    if (!empty($classInfo['methods'])) {
-      $info[$className] = $classInfo;
+    if (!empty($class_info['methods'])) {
+      $info[$class_name] = $class_info;
     }
   }
 
@@ -244,7 +244,7 @@ function extract_info(string $contextDir, array $exclude = [], string $basePath 
 /**
  * Parse class comment.
  *
- * @param string $className
+ * @param string $class_name
  *   The class name.
  * @param string $comment
  *   The comment.
@@ -252,14 +252,14 @@ function extract_info(string $contextDir, array $exclude = [], string $basePath 
  * @return array<string, string>
  *   Array of 'description' and 'description_full' keys.
  */
-function parse_class_comment(string $className, string $comment): array {
+function parse_class_comment(string $class_name, string $comment): array {
   if (empty($comment)) {
-    throw new \Exception(sprintf('Class comment for %s is empty', $className));
+    throw new \Exception(sprintf('Class comment for %s is empty', $class_name));
   }
 
   $comment = preg_replace('#^/\*\*|^\s*\*\/$#m', '', $comment);
   $lines = explode(PHP_EOL, (string) $comment);
-  // Remove docblock asterisk and up to one space, but preserve remaining indentation.
+  // Remove docblock asterisk and up to one space, but keep indentation.
   $lines = array_map(static fn(string $l): string => preg_replace('/^\s*\* ?/', '', $l), $lines);
 
   // Remove first and last empty lines.
@@ -271,17 +271,17 @@ function parse_class_comment(string $className, string $comment): array {
   }
 
   // Trim lines, but preserve indentation within @code blocks.
-  $inCodeBlock = FALSE;
-  $lines = array_map(static function (string $l) use (&$inCodeBlock): string {
+  $in_code_block = FALSE;
+  $lines = array_map(static function (string $l) use (&$in_code_block): string {
     if (str_starts_with(trim($l), '@code')) {
-        $inCodeBlock = TRUE;
+        $in_code_block = TRUE;
         return trim($l);
     }
     if (str_starts_with(trim($l), '@endcode')) {
-        $inCodeBlock = FALSE;
+        $in_code_block = FALSE;
         return trim($l);
     }
-    if ($inCodeBlock) {
+    if ($in_code_block) {
         // Preserve indentation within code blocks.
         return rtrim($l);
     }
@@ -290,27 +290,27 @@ function parse_class_comment(string $className, string $comment): array {
 
   // @codeCoverageIgnoreStart
   if (empty($lines)) {
-    throw new \Exception(sprintf('Class comment for %s is empty', $className));
+    throw new \Exception(sprintf('Class comment for %s is empty', $class_name));
   }
   // @codeCoverageIgnoreEnd
   $description = $lines[0];
   if (empty($description)) {
-    throw new \Exception(sprintf('Class comment for %s is empty', $className));
+    throw new \Exception(sprintf('Class comment for %s is empty', $class_name));
   }
 
   if (str_starts_with($description, 'Class ')) {
-    throw new \Exception(sprintf('Class comment should have a descriptive content for %s', $className));
+    throw new \Exception(sprintf('Class comment should have a descriptive content for %s', $class_name));
   }
 
-  $fullDescription = implode(PHP_EOL, $lines);
+  $full_description = implode(PHP_EOL, $lines);
 
-  if (substr_count($fullDescription, '`') % 2 !== 0) {
-    throw new \Exception(sprintf('Class inline code block is not closed for %s', $className));
+  if (substr_count($full_description, '`') % 2 !== 0) {
+    throw new \Exception(sprintf('Class inline code block is not closed for %s', $class_name));
   }
 
   return [
     'description' => $description,
-    'description_full' => $fullDescription,
+    'description_full' => $full_description,
   ];
 }
 
@@ -319,7 +319,7 @@ function parse_class_comment(string $className, string $comment): array {
  *
  * @param string $comment
  *   The comment.
- * @param bool $allowEmptySteps
+ * @param bool $allow_empty_steps
  *   If TRUE, return the parsed data even when no step annotations are found.
  *   Used when step definitions come from PHP attributes instead of docblocks.
  *
@@ -327,7 +327,7 @@ function parse_class_comment(string $className, string $comment): array {
  *   Array of 'steps', 'description', and 'example' keys or NULL if steps were
  *   not found in the comment and $allow_empty_steps is FALSE.
  */
-function parse_method_comment(string $comment, bool $allowEmptySteps = FALSE): ?array {
+function parse_method_comment(string $comment, bool $allow_empty_steps = FALSE): ?array {
   if (empty($comment)) {
     return NULL;
   }
@@ -340,7 +340,7 @@ function parse_method_comment(string $comment, bool $allowEmptySteps = FALSE): ?
 
   $lines = explode(PHP_EOL, $comment);
 
-  $exampleStart = FALSE;
+  $example_start = FALSE;
   foreach ($lines as $line) {
     $line = str_replace('/*', '', $line);
     $line = str_replace('/**', '', $line);
@@ -351,21 +351,21 @@ function parse_method_comment(string $comment, bool $allowEmptySteps = FALSE): ?
     $line = substr($line, 1);
 
     if (str_starts_with($line, '@code')) {
-      $exampleStart = TRUE;
+      $example_start = TRUE;
     }
     elseif (str_starts_with($line, '@endcode')) {
-      $exampleStart = FALSE;
+      $example_start = FALSE;
     }
     elseif (str_starts_with($line, '@Given') || str_starts_with($line, '@When') || str_starts_with($line, '@Then')) {
       $line = trim($line, " \t\n\r\0\x0B");
       $return['steps'][] = $line;
     }
     else {
-      if (!$exampleStart && empty($line)) {
+      if (!$example_start && empty($line)) {
         continue;
       }
 
-      if ($exampleStart) {
+      if ($example_start) {
         $line = rtrim($line, "\t\n\r\0\x0B");
         $return['example'] .= $line . PHP_EOL;
       }
@@ -377,7 +377,7 @@ function parse_method_comment(string $comment, bool $allowEmptySteps = FALSE): ?
     }
   }
 
-  if ($exampleStart) {
+  if ($example_start) {
     throw new \Exception('Example not closed');
   }
 
@@ -385,9 +385,9 @@ function parse_method_comment(string $comment, bool $allowEmptySteps = FALSE): ?
     // Sort the steps by Given, When, Then.
     $sorted = [];
     foreach (['@Given', '@When', '@Then'] as $step) {
-      foreach ($return['steps'] as $stepItem) {
-        if (str_starts_with($stepItem, $step)) {
-          $sorted[] = $stepItem;
+      foreach ($return['steps'] as $step_item) {
+        if (str_starts_with($step_item, $step)) {
+          $sorted[] = $step_item;
         }
       }
     }
@@ -399,14 +399,14 @@ function parse_method_comment(string $comment, bool $allowEmptySteps = FALSE): ?
       // Remove indentation from the example, using the first line as a
       // reference.
       $lines = explode(PHP_EOL, $return['example']);
-      $firstLine = '';
+      $first_line = '';
       foreach ($lines as $l) {
         if ($l !== '') {
-          $firstLine = $l;
+          $first_line = $l;
           break;
         }
       }
-      $indentation = strspn($firstLine, ' ');
+      $indentation = strspn($first_line, ' ');
       foreach ($lines as $key => $line) {
         $line = rtrim($line);
         if (strlen($line) > $indentation) {
@@ -417,7 +417,7 @@ function parse_method_comment(string $comment, bool $allowEmptySteps = FALSE): ?
     }
   }
 
-  if (empty($return['steps']) && !$allowEmptySteps) {
+  if (empty($return['steps']) && !$allow_empty_steps) {
     return NULL;
   }
 
@@ -435,7 +435,7 @@ function parse_method_comment(string $comment, bool $allowEmptySteps = FALSE): ?
  *   step attributes found.
  */
 function extract_step_attributes(\ReflectionMethod $method): array {
-  $stepMap = [
+  $step_map = [
     Given::class => '@Given',
     When::class => '@When',
     Then::class => '@Then',
@@ -445,10 +445,10 @@ function extract_step_attributes(\ReflectionMethod $method): array {
 
   foreach ($method->getAttributes() as $attribute) {
     $name = $attribute->getName();
-    if (isset($stepMap[$name])) {
+    if (isset($step_map[$name])) {
       $args = $attribute->getArguments();
       $pattern = $args[0] ?? $args['pattern'] ?? '';
-      $steps[] = $stepMap[$name] . ' ' . $pattern;
+      $steps[] = $step_map[$name] . ' ' . $pattern;
     }
   }
 
@@ -460,110 +460,110 @@ function extract_step_attributes(\ReflectionMethod $method): array {
  *
  * @param array<string,array<string, array<int, array<string, array<int,string>|string>>|string>> $info
  *   Array of info items with 'name', 'from', and 'to' keys.
- * @param string $basePath
+ * @param string $base_path
  *   Base path for the repository.
- * @param string|null $pathForLinks
+ * @param string|null $path_for_links
  *   Path prefix for links in the index (e.g. 'STEPS.md').
  *
  * @return string
  *   Markdown table.
  */
-function render_info(array $info, string $basePath = '', ?string $pathForLinks = NULL): string {
-  if (empty($basePath)) {
+function render_info(array $info, string $base_path = '', ?string $path_for_links = NULL): string {
+  if (empty($base_path)) {
     // @codeCoverageIgnore
-    $basePath = dirname(__DIR__);
+    $base_path = dirname(__DIR__);
   }
 
-  $contentOutput = '';
-  $indexRows = [];
+  $content_output = '';
+  $index_rows = [];
 
-  foreach ($info as $class => $classInfo) {
+  foreach ($info as $class => $class_info) {
     // Find the source file.
-    $srcFile = find_source_file($class, $basePath);
-    if (!$srcFile) {
+    $src_file = find_source_file($class, $base_path);
+    if (!$src_file) {
       throw new \Exception(sprintf('Source file for %s does not exist', $class));
     }
 
     // Find the example feature file.
-    $exampleName = camel_to_snake(str_replace('Context', '', $class));
-    $exampleFile = sprintf('tests/behat/features/%s.feature', $exampleName);
-    $exampleFilePath = $basePath . DIRECTORY_SEPARATOR . $exampleFile;
+    $example_name = camel_to_snake(str_replace('Context', '', $class));
+    $example_file = sprintf('tests/behat/features/%s.feature', $example_name);
+    $example_file_path = $base_path . DIRECTORY_SEPARATOR . $example_file;
 
-    $exampleLink = '';
-    if (file_exists($exampleFilePath)) {
-      $exampleLink = sprintf(', [Example](%s)', $exampleFile);
+    $example_link = '';
+    if (file_exists($example_file_path)) {
+      $example_link = sprintf(', [Example](%s)', $example_file);
     }
 
-    $contentOutput .= sprintf('## %s', $classInfo['name_contextual']) . PHP_EOL . PHP_EOL;
-    $contentOutput .= sprintf('[Source](%s)%s', $srcFile, $exampleLink) . PHP_EOL . PHP_EOL;
+    $content_output .= sprintf('## %s', $class_info['name_contextual']) . PHP_EOL . PHP_EOL;
+    $content_output .= sprintf('[Source](%s)%s', $src_file, $example_link) . PHP_EOL . PHP_EOL;
 
     // Add description as markdown-safe accommodating for lists.
-    $descriptionFull = '';
-    $lines = explode(PHP_EOL, $classInfo['description_full']);
-    $wasList = FALSE;
-    $inCodeBlock = FALSE;
-    $codeBlock = '';
+    $description_full = '';
+    $lines = explode(PHP_EOL, $class_info['description_full']);
+    $was_list = FALSE;
+    $in_code_block = FALSE;
+    $code_block = '';
     foreach ($lines as $line) {
-      $trimmedLine = trim($line);
+      $trimmed_line = trim($line);
 
       // Handle @code tag - start collecting code block.
-      if (str_starts_with($trimmedLine, '@code')) {
-        $inCodeBlock = TRUE;
-        $codeBlock = '';
+      if (str_starts_with($trimmed_line, '@code')) {
+        $in_code_block = TRUE;
+        $code_block = '';
         continue;
       }
 
       // Handle @endcode tag - wrap collected code in markdown code block.
-      if (str_starts_with($trimmedLine, '@endcode')) {
-        $inCodeBlock = FALSE;
-        $descriptionFull .= '```' . PHP_EOL;
-        $descriptionFull .= rtrim($codeBlock) . PHP_EOL;
-        $descriptionFull .= '```' . PHP_EOL;
-        $codeBlock = '';
+      if (str_starts_with($trimmed_line, '@endcode')) {
+        $in_code_block = FALSE;
+        $description_full .= '```' . PHP_EOL;
+        $description_full .= rtrim($code_block) . PHP_EOL;
+        $description_full .= '```' . PHP_EOL;
+        $code_block = '';
         continue;
       }
 
       // If inside code block, collect lines without processing.
-      if ($inCodeBlock) {
-        $codeBlock .= $line . PHP_EOL;
+      if ($in_code_block) {
+        $code_block .= $line . PHP_EOL;
         continue;
       }
 
-      $isList = str_starts_with($trimmedLine, '-');
+      $is_list = str_starts_with($trimmed_line, '-');
 
-      if (!$isList) {
-        if (empty($line) && !$wasList) {
-          $descriptionFull .= $line . '<br/><br/>' . PHP_EOL;
+      if (!$is_list) {
+        if (empty($line) && !$was_list) {
+          $description_full .= $line . '<br/><br/>' . PHP_EOL;
         }
         else {
-          $descriptionFull .= $line . PHP_EOL;
+          $description_full .= $line . PHP_EOL;
         }
-        $wasList = FALSE;
+        $was_list = FALSE;
       }
       else {
-        if (str_ends_with($descriptionFull, '<br/><br/>' . PHP_EOL)) {
-          $descriptionFull = rtrim($descriptionFull, '<br/><br/>' . PHP_EOL) . PHP_EOL;
+        if (str_ends_with($description_full, '<br/><br/>' . PHP_EOL)) {
+          $description_full = rtrim($description_full, '<br/><br/>' . PHP_EOL) . PHP_EOL;
         }
 
-        $descriptionFull .= $line . PHP_EOL;
-        $wasList = TRUE;
+        $description_full .= $line . PHP_EOL;
+        $was_list = TRUE;
       }
     }
 
-    $descriptionFull = preg_replace('/^/m', '>  ', $descriptionFull);
-    $contentOutput .= $descriptionFull . PHP_EOL . PHP_EOL;
+    $description_full = preg_replace('/^/m', '>  ', $description_full);
+    $content_output .= $description_full . PHP_EOL . PHP_EOL;
 
     // Add to index.
-    $indexRowsPath = '#' . preg_replace('/[^A-Za-z0-9_\-]/', '', strtolower((string) $classInfo['name_contextual']));
-    if ($pathForLinks) {
-      $indexRowsPath = $pathForLinks . $indexRowsPath;
+    $index_rows_path = '#' . preg_replace('/[^A-Za-z0-9_\-]/', '', strtolower((string) $class_info['name_contextual']));
+    if ($path_for_links) {
+      $index_rows_path = $path_for_links . $index_rows_path;
     }
-    $indexRows[] = [
-      sprintf('[%s](%s)', $classInfo['name_contextual'], $indexRowsPath),
-      $classInfo['description'],
+    $index_rows[] = [
+      sprintf('[%s](%s)', $class_info['name_contextual'], $index_rows_path),
+      $class_info['description'],
     ];
 
-    foreach ($classInfo['methods'] as $method) {
+    foreach ($class_info['methods'] as $method) {
       $method['steps'] = is_array($method['steps']) ? $method['steps'] : [$method['steps']];
       $method['description'] = is_string($method['description']) ? $method['description'] : '';
       $method['example'] = is_string($method['example']) ? $method['example'] : '';
@@ -589,7 +589,7 @@ function render_info(array $info, string $basePath = '', ?string $pathForLinks =
 
 EOT;
 
-      $contentOutput .= strtr(
+      $content_output .= strtr(
             $template,
             [
               '[description]' => $method['description'],
@@ -598,22 +598,22 @@ EOT;
             ]
         );
 
-      $contentOutput .= PHP_EOL;
+      $content_output .= PHP_EOL;
     }
   }
 
-  $indexOutput = '';
-  if (!empty($indexRows)) {
-    $indexOutput .= array_to_markdown_table(['Class', 'Description'], $indexRows) . PHP_EOL . PHP_EOL;
+  $index_output = '';
+  if (!empty($index_rows)) {
+    $index_output .= array_to_markdown_table(['Class', 'Description'], $index_rows) . PHP_EOL . PHP_EOL;
   }
 
   $output = '';
-  $output .= $indexOutput . PHP_EOL;
+  $output .= $index_output . PHP_EOL;
 
   // Render content if this is not a path for links.
-  if (!$pathForLinks) {
+  if (!$path_for_links) {
     $output .= '---' . PHP_EOL . PHP_EOL;
-    $output .= $contentOutput . PHP_EOL;
+    $output .= $content_output . PHP_EOL;
   }
 
   return $output;
@@ -622,28 +622,28 @@ EOT;
 /**
  * Find the source file for a class relative to the base path.
  *
- * @param string $className
+ * @param string $class_name
  *   The class name.
- * @param string $basePath
+ * @param string $base_path
  *   Base path for the repository.
  *
  * @return string|null
  *   The relative path to the source file, or NULL if not found.
  */
-function find_source_file(string $className, string $basePath): ?string {
-  $srcFile = sprintf('src/Drupal/DrupalExtension/Context/%s.php', $className);
-  $srcFilePath = $basePath . DIRECTORY_SEPARATOR . $srcFile;
+function find_source_file(string $class_name, string $base_path): ?string {
+  $src_file = sprintf('src/Drupal/DrupalExtension/Context/%s.php', $class_name);
+  $src_file_path = $base_path . DIRECTORY_SEPARATOR . $src_file;
 
-  if (file_exists($srcFilePath)) {
-    return $srcFile;
+  if (file_exists($src_file_path)) {
+    return $src_file;
   }
 
   // Fallback: try root src directory (for tests).
-  $srcFile = sprintf('src/%s.php', $className);
-  $srcFilePath = $basePath . DIRECTORY_SEPARATOR . $srcFile;
+  $src_file = sprintf('src/%s.php', $class_name);
+  $src_file_path = $base_path . DIRECTORY_SEPARATOR . $src_file;
 
-  if (file_exists($srcFilePath)) {
-    return $srcFile;
+  if (file_exists($src_file_path)) {
+    return $src_file;
   }
 
   return NULL;
@@ -654,37 +654,37 @@ function find_source_file(string $className, string $basePath): ?string {
  *
  * @param array<string,array<string, array<int, array<string, array<int,string>|string>>|string>> $info
  *   Array of info items with 'name', 'from', and 'to' keys.
- * @param string $basePath
+ * @param string $base_path
  *   Base path for the repository.
  *
  * @return array<string, array<string, array<string, bool|string|array<string, array<string, bool|array<int, string>>>>>>
  *   Structured validation results per class and method.
  */
-function validate(array $info, string $basePath = ''): array {
-  if (empty($basePath)) {
+function validate(array $info, string $base_path = ''): array {
+  if (empty($base_path)) {
     // @codeCoverageIgnore
-    $basePath = dirname(__DIR__);
+    $base_path = dirname(__DIR__);
   }
 
   $results = [];
 
-  foreach ($info as $classInfo) {
-    $className = is_string($classInfo['name']) ? $classInfo['name'] : '';
+  foreach ($info as $class_info) {
+    $class_name = is_string($class_info['name']) ? $class_info['name'] : '';
 
     // Check example file.
-    $exampleName = camel_to_snake(str_replace('Context', '', $className));
-    $exampleFile = sprintf('tests/behat/features/%s.feature', $exampleName);
-    $exampleFilePath = $basePath . DIRECTORY_SEPARATOR . $exampleFile;
+    $example_name = camel_to_snake(str_replace('Context', '', $class_name));
+    $example_file = sprintf('tests/behat/features/%s.feature', $example_name);
+    $example_file_path = $base_path . DIRECTORY_SEPARATOR . $example_file;
 
-    $classResult = [
+    $class_result = [
       'file' => [
-        'pass' => file_exists($exampleFilePath),
-        'path' => $exampleFile,
+        'pass' => file_exists($example_file_path),
+        'path' => $example_file,
       ],
       'methods' => [],
     ];
 
-    foreach ($classInfo['methods'] as $method) {
+    foreach ($class_info['methods'] as $method) {
       $method['steps'] = is_array($method['steps']) ? $method['steps'] : [$method['steps']];
       $method['name'] = is_string($method['name']) ? $method['name'] : '';
       $method['description'] = is_string($method['description']) ? $method['description'] : '';
@@ -693,72 +693,72 @@ function validate(array $info, string $basePath = ''): array {
       $step = (string) $method['steps'][0];
 
       // Step wording check.
-      $stepWording = ['pass' => TRUE, 'messages' => []];
+      $step_wording = ['pass' => TRUE, 'messages' => []];
       if (str_starts_with($step, '@Given') && str_ends_with($step, ':') && !str_contains($step, 'following')) {
-        $stepWording['pass'] = FALSE;
-        $stepWording['messages'][] = 'Missing "following" in the step';
+        $step_wording['pass'] = FALSE;
+        $step_wording['messages'][] = 'Missing "following" in the step';
       }
       if (str_starts_with($step, '@When') && !str_contains($step, 'I ')) {
-        $stepWording['pass'] = FALSE;
-        $stepWording['messages'][] = 'Missing "I " in the step';
+        $step_wording['pass'] = FALSE;
+        $step_wording['messages'][] = 'Missing "I " in the step';
       }
       if (str_starts_with($step, '@Then')) {
         if (!str_contains($step, ' should ')) {
-          $stepWording['pass'] = FALSE;
-          $stepWording['messages'][] = 'Missing "should" in the step';
+          $step_wording['pass'] = FALSE;
+          $step_wording['messages'][] = 'Missing "should" in the step';
         }
         if (!(str_contains($step, ' the ') || str_contains($step, ' a ') || str_contains($step, ' no '))) {
-          $stepWording['pass'] = FALSE;
-          $stepWording['messages'][] = 'Missing "the", "a" or "no" in the step';
+          $step_wording['pass'] = FALSE;
+          $step_wording['messages'][] = 'Missing "the", "a" or "no" in the step';
         }
       }
 
       // Method naming check.
-      $methodNaming = ['pass' => TRUE, 'messages' => []];
+      $method_naming = ['pass' => TRUE, 'messages' => []];
       if (str_starts_with($step, '@Then')) {
         if (!str_contains((string) $method['name'], 'Assert')) {
-          $methodNaming['pass'] = FALSE;
-          $methodNaming['messages'][] = 'Missing "Assert" in the method name';
+          $method_naming['pass'] = FALSE;
+          $method_naming['messages'][] = 'Missing "Assert" in the method name';
         }
         if (str_contains((string) $method['name'], 'Should')) {
-          $methodNaming['pass'] = FALSE;
-          $methodNaming['messages'][] = 'Contains "Should" in the method name';
+          $method_naming['pass'] = FALSE;
+          $method_naming['messages'][] = 'Contains "Should" in the method name';
         }
       }
 
       // Single step check.
-      $singleStep = ['pass' => TRUE, 'messages' => []];
+      $single_step = ['pass' => TRUE, 'messages' => []];
       if (count($method['steps']) > 1) {
-        $singleStep['pass'] = FALSE;
-        $singleStep['messages'][] = 'Multiple steps found';
+        $single_step['pass'] = FALSE;
+        $single_step['messages'][] = 'Multiple steps found';
       }
 
       // Has example check.
-      $hasExample = ['pass' => TRUE, 'messages' => []];
+      $has_example = ['pass' => TRUE, 'messages' => []];
       if (empty($method['example'])) {
-        $hasExample['pass'] = FALSE;
-        $hasExample['messages'][] = 'Missing example';
+        $has_example['pass'] = FALSE;
+        $has_example['messages'][] = 'Missing example';
       }
 
       // Unnecessary regex check.
-      $regexConvertible = ['pass' => TRUE, 'messages' => []];
+      $regex_convertible = ['pass' => TRUE, 'messages' => []];
       $suggested = regex_to_turnip($step);
       if ($suggested !== NULL) {
-        $regexConvertible['pass'] = FALSE;
-        $regexConvertible['messages'][] = $step;
-        $regexConvertible['messages'][] = $suggested;
+        $regex_convertible['pass'] = FALSE;
+        $regex_convertible['messages'][] = $step;
+        $regex_convertible['messages'][] = $suggested;
       }
 
-      $classResult['methods'][$method['name']] = [
-        'step_wording' => $stepWording,
-        'method_naming' => $methodNaming,
-        'single_step' => $singleStep,
-        'has_example' => $hasExample,
-        'regex_convertible' => $regexConvertible,
+      $class_result['methods'][$method['name']] = [
+        'step_wording' => $step_wording,
+        'method_naming' => $method_naming,
+        'single_step' => $single_step,
+        'has_example' => $has_example,
+        'regex_convertible' => $regex_convertible,
       ];
     }
 
-    $results[$className] = $classResult;
+    $results[$class_name] = $class_result;
   }
 
   return $results;
@@ -774,9 +774,9 @@ function validate(array $info, string $basePath = ''): array {
  *   TRUE if there are validation errors.
  */
 function has_validation_errors(array $results): bool {
-  foreach ($results as $classResult) {
-    foreach ($classResult['methods'] as $methodChecks) {
-      foreach ($methodChecks as $check) {
+  foreach ($results as $class_result) {
+    foreach ($class_result['methods'] as $method_checks) {
+      foreach ($method_checks as $check) {
         if (!$check['pass']) {
           return TRUE;
         }
@@ -812,9 +812,9 @@ function render_validation_tree(array $results): string {
   ];
 
   // Count totals and violations per category.
-  $totalClasses = count($results);
-  $totalMethods = 0;
-  $totalViolations = 0;
+  $total_classes = count($results);
+  $total_methods = 0;
+  $total_violations = 0;
   $counts = [
     'step_wording' => 0,
     'method_naming' => 0,
@@ -823,17 +823,17 @@ function render_validation_tree(array $results): string {
     'regex_convertible' => 0,
     'file' => 0,
   ];
-  foreach ($results as $classResult) {
-    if (!$classResult['file']['pass']) {
+  foreach ($results as $class_result) {
+    if (!$class_result['file']['pass']) {
       $counts['file']++;
-      $totalViolations++;
+      $total_violations++;
     }
-    foreach ($classResult['methods'] as $methodChecks) {
-      $totalMethods++;
+    foreach ($class_result['methods'] as $method_checks) {
+      $total_methods++;
       foreach (array_keys($symbols) as $key) {
-        if (!$methodChecks[$key]['pass']) {
+        if (!$method_checks[$key]['pass']) {
           $counts[$key]++;
-          $totalViolations++;
+          $total_violations++;
         }
       }
     }
@@ -842,57 +842,57 @@ function render_validation_tree(array $results): string {
   $output = '';
   $output .= $yellow . 'Validation warnings:' . $reset . PHP_EOL . PHP_EOL;
 
-  $classNames = array_keys($results);
+  $class_names = array_keys($results);
 
-  foreach ($classNames as $className) {
-    $classResult = $results[$className];
-    $output .= $bold . $className . $reset . PHP_EOL;
+  foreach ($class_names as $class_name) {
+    $class_result = $results[$class_name];
+    $output .= $bold . $class_name . $reset . PHP_EOL;
 
-    $methodNames = array_keys($classResult['methods']);
-    $totalChildren = 1 + count($methodNames);
-    $childIndex = 0;
+    $method_names = array_keys($class_result['methods']);
+    $total_children = 1 + count($method_names);
+    $child_index = 0;
 
     // File check.
-    $childIndex++;
-    $isLast = ($childIndex === $totalChildren);
-    $branch = $isLast ? '└── ' : '├── ';
+    $child_index++;
+    $is_last = ($child_index === $total_children);
+    $branch = $is_last ? '└── ' : '├── ';
 
-    $fileCont = $isLast ? '    ' : '│   ';
-    if ($classResult['file']['pass']) {
+    $file_cont = $is_last ? '    ' : '│   ';
+    if ($class_result['file']['pass']) {
       $output .= '  ' . $branch . $green . '■' . $reset . ' Example file present' . PHP_EOL;
     }
     else {
       $output .= '  ' . $branch . $yellow . '□' . $reset . ' Example file absent' . PHP_EOL;
-      $output .= '  ' . $fileCont . '  ' . $dim . $classResult['file']['path'] . $reset . PHP_EOL;
+      $output .= '  ' . $file_cont . '  ' . $dim . $class_result['file']['path'] . $reset . PHP_EOL;
     }
 
     // Methods.
-    foreach ($methodNames as $methodName) {
-      $childIndex++;
-      $isLastMethod = ($childIndex === $totalChildren);
-      $methodBranch = $isLastMethod ? '└── ' : '├── ';
-      $methodCont = $isLastMethod ? '    ' : '│   ';
+    foreach ($method_names as $method_name) {
+      $child_index++;
+      $is_last_method = ($child_index === $total_children);
+      $method_branch = $is_last_method ? '└── ' : '├── ';
+      $method_cont = $is_last_method ? '    ' : '│   ';
 
-      $output .= '  ' . $methodBranch . $methodName . PHP_EOL;
+      $output .= '  ' . $method_branch . $method_name . PHP_EOL;
 
-      $checks = $classResult['methods'][$methodName];
-      $checkKeys = array_keys($symbols);
-      $totalChecks = count($checkKeys);
+      $checks = $class_result['methods'][$method_name];
+      $check_keys = array_keys($symbols);
+      $total_checks = count($check_keys);
 
-      foreach ($checkKeys as $ki => $checkKey) {
-        $check = $checks[$checkKey];
-        $sym = $symbols[$checkKey];
-        $isLastCheck = ($ki === $totalChecks - 1);
-        $checkBranch = $isLastCheck ? '└── ' : '├── ';
-        $checkCont = $isLastCheck ? '      ' : '│     ';
+      foreach ($check_keys as $ki => $check_key) {
+        $check = $checks[$check_key];
+        $sym = $symbols[$check_key];
+        $is_last_check = ($ki === $total_checks - 1);
+        $check_branch = $is_last_check ? '└── ' : '├── ';
+        $check_cont = $is_last_check ? '      ' : '│     ';
 
         if ($check['pass']) {
-          $output .= '  ' . $methodCont . $checkBranch . $green . $sym['pass'] . $reset . ' ' . $sym['label'] . PHP_EOL;
+          $output .= '  ' . $method_cont . $check_branch . $green . $sym['pass'] . $reset . ' ' . $sym['label'] . PHP_EOL;
         }
         else {
-          $output .= '  ' . $methodCont . $checkBranch . $yellow . $sym['warn'] . $reset . ' ' . $sym['label'] . PHP_EOL;
+          $output .= '  ' . $method_cont . $check_branch . $yellow . $sym['warn'] . $reset . ' ' . $sym['label'] . PHP_EOL;
           foreach ($check['messages'] as $message) {
-            $output .= '  ' . $methodCont . $checkCont . $dim . $message . $reset . PHP_EOL;
+            $output .= '  ' . $method_cont . $check_cont . $dim . $message . $reset . PHP_EOL;
           }
         }
       }
@@ -903,41 +903,41 @@ function render_validation_tree(array $results): string {
 
   // Summary.
   $output .= $yellow . 'Summary:' . $reset . PHP_EOL;
-  $output .= '  Scanned ' . $totalClasses . ' classes, ' . $totalMethods . ' steps.' . PHP_EOL . PHP_EOL;
+  $output .= '  Scanned ' . $total_classes . ' classes, ' . $total_methods . ' steps.' . PHP_EOL . PHP_EOL;
 
-  $summaryLines = [
+  $summary_lines = [
     [
       'Step wording', $symbols['step_wording'],
-      $totalMethods - $counts['step_wording'], $counts['step_wording'], $totalMethods,
+      $total_methods - $counts['step_wording'], $counts['step_wording'], $total_methods,
     ],
     [
       'Method naming', $symbols['method_naming'],
-      $totalMethods - $counts['method_naming'], $counts['method_naming'], $totalMethods,
+      $total_methods - $counts['method_naming'], $counts['method_naming'], $total_methods,
     ],
     [
       'Single step', $symbols['single_step'],
-      $totalMethods - $counts['single_step'], $counts['single_step'], $totalMethods,
+      $total_methods - $counts['single_step'], $counts['single_step'], $total_methods,
     ],
     [
       'Example', $symbols['has_example'],
-      $totalMethods - $counts['has_example'], $counts['has_example'], $totalMethods,
+      $total_methods - $counts['has_example'], $counts['has_example'], $total_methods,
     ],
     [
       'Regex usage', $symbols['regex_convertible'],
-      $totalMethods - $counts['regex_convertible'], $counts['regex_convertible'], $totalMethods,
+      $total_methods - $counts['regex_convertible'], $counts['regex_convertible'], $total_methods,
     ],
     [
       'Example file', ['pass' => '■', 'warn' => '□'],
-      $totalClasses - $counts['file'], $counts['file'], $totalClasses,
+      $total_classes - $counts['file'], $counts['file'], $total_classes,
     ],
   ];
 
-  foreach ($summaryLines as [$label, $sym, $passCount, $failCount, $total]) {
-    $lineColor = $failCount > 0 ? $yellow : $green;
-    $check = $failCount === 0 ? '✓' : '⚠';
-    $passStr = str_pad((string) $passCount, 3, ' ', STR_PAD_LEFT);
-    $failStr = str_pad((string) $failCount, 3, ' ', STR_PAD_LEFT);
-    $output .= $lineColor . '  ' . sprintf('%-15s', $label) . $sym['pass'] . $passStr . '  ' . $sym['warn'] . $failStr . '  ' . $check . $reset . PHP_EOL;
+  foreach ($summary_lines as [$label, $sym, $pass_count, $fail_count, $total]) {
+    $line_color = $fail_count > 0 ? $yellow : $green;
+    $check = $fail_count === 0 ? '✓' : '⚠';
+    $pass_str = str_pad((string) $pass_count, 3, ' ', STR_PAD_LEFT);
+    $fail_str = str_pad((string) $fail_count, 3, ' ', STR_PAD_LEFT);
+    $output .= $line_color . '  ' . sprintf('%-15s', $label) . $sym['pass'] . $pass_str . '  ' . $sym['warn'] . $fail_str . '  ' . $check . $reset . PHP_EOL;
   }
 
   return $output;
@@ -950,22 +950,22 @@ function render_validation_tree(array $results): string {
  * - validation-summary.txt: The summary block.
  * - validation-details.txt: The per-context tree.
  *
- * @param string $treeOutput
+ * @param string $tree_output
  *   The rendered validation tree (with ANSI codes).
- * @param string $logDir
+ * @param string $log_dir
  *   The directory to write the log files to.
  */
-function write_validation_logs(string $treeOutput, string $logDir): void {
-  if (!is_dir($logDir)) {
-    mkdir($logDir, 0777, TRUE);
+function write_validation_logs(string $tree_output, string $log_dir): void {
+  if (!is_dir($log_dir)) {
+    mkdir($log_dir, 0777, TRUE);
   }
 
   // Strip ANSI escape codes.
-  $plain = (string) preg_replace('/\033\[[0-9;]*m/', '', $treeOutput);
+  $plain = (string) preg_replace('/\033\[[0-9;]*m/', '', $tree_output);
 
   if (empty(trim($plain))) {
-    file_put_contents($logDir . '/validation-summary.txt', 'No validation warnings.' . PHP_EOL);
-    file_put_contents($logDir . '/validation-details.txt', '');
+    file_put_contents($log_dir . '/validation-summary.txt', 'No validation warnings.' . PHP_EOL);
+    file_put_contents($log_dir . '/validation-details.txt', '');
     return;
   }
 
@@ -974,8 +974,8 @@ function write_validation_logs(string $treeOutput, string $logDir): void {
   $details = trim($parts[0]);
   $summary = isset($parts[1]) ? 'Summary:' . $parts[1] : $details;
 
-  file_put_contents($logDir . '/validation-summary.txt', $summary);
-  file_put_contents($logDir . '/validation-details.txt', $details . PHP_EOL);
+  file_put_contents($log_dir . '/validation-summary.txt', $summary);
+  file_put_contents($log_dir . '/validation-details.txt', $details . PHP_EOL);
 }
 
 /**
@@ -1004,28 +1004,28 @@ function regex_to_turnip(string $step): ?string {
   // on non-capture-group content, character classes other than [^"]*.
   // We only convert if the pattern is literal text with simple capture groups.
   // Replace all capture groups with a placeholder to check the rest.
-  $argCount = 0;
-  $converted = preg_replace_callback('#\(([^)]*)\)#', function (array $m) use (&$argCount): string {
+  $arg_count = 0;
+  $converted = preg_replace_callback('#\(([^)]*)\)#', function (array $m) use (&$arg_count): string {
       $inner = $m[1];
       // Simple quoted string capture: [^"]*  or [^']*.
     if ($inner === '[^"]*' || $inner === "[^']*") {
-        $argCount++;
-        return ':arg' . $argCount;
+        $arg_count++;
+        return ':arg' . $arg_count;
     }
       // Simple unquoted capture: .*  or .+.
     if ($inner === '.*' || $inner === '.+') {
-        $argCount++;
-        return ':arg' . $argCount;
+        $arg_count++;
+        return ':arg' . $arg_count;
     }
       // Numeric capture: \d+ or [0-9]+.
     if ($inner === '\d+' || $inner === '[0-9]+') {
-        $argCount++;
-        return ':arg' . $argCount;
+        $arg_count++;
+        return ':arg' . $arg_count;
     }
       // Word capture: \w+.
     if ($inner === '\w+') {
-        $argCount++;
-        return ':arg' . $argCount;
+        $arg_count++;
+        return ':arg' . $arg_count;
     }
 
       // Return original match to signal unconvertible pattern.
@@ -1039,9 +1039,9 @@ function regex_to_turnip(string $step): ?string {
 
   // Check remaining literal text for regex metacharacters.
   // Remove known-safe escaped characters first.
-  $literalCheck = preg_replace('#\\\\[/"\'.]#', '', $converted);
+  $literal_check = preg_replace('#\\\\[/"\'.]#', '', $converted);
   // If there are remaining backslash sequences or regex metacharacters, bail.
-  if ($literalCheck !== NULL && preg_match('#[\\\\.*+?\[\]{}|^$]#', $literalCheck)) {
+  if ($literal_check !== NULL && preg_match('#[\\\\.*+?\[\]{}|^$]#', $literal_check)) {
     return NULL;
   }
 
@@ -1072,8 +1072,8 @@ function camel_to_snake(string $string, string $separator = '_'): string {
 
   $replacements = [];
   foreach (mb_str_split((string) $string) as $key => $char) {
-    $lowerCaseChar = mb_strtolower($char);
-    if ($lowerCaseChar !== $char && $key !== 0) {
+    $lower_case_char = mb_strtolower($char);
+    if ($lower_case_char !== $char && $key !== 0) {
       $replacements[$char] = $separator . $char;
     }
   }
@@ -1132,9 +1132,9 @@ function array_to_markdown_table(array $headers, array $rows): string {
     return '';
   }
 
-  $headerRow = '| ' . implode(' | ', $headers) . ' |';
-  $separatorRow = '| ' . implode(' | ', array_fill(0, count($headers), '---')) . ' |';
-  $dataRows = array_map(fn(array $row): string => '| ' . implode(' | ', $row) . ' |', $rows);
+  $header_row = '| ' . implode(' | ', $headers) . ' |';
+  $separator_row = '| ' . implode(' | ', array_fill(0, count($headers), '---')) . ' |';
+  $data_rows = array_map(fn(array $row): string => '| ' . implode(' | ', $row) . ' |', $rows);
 
-  return implode("\n", array_merge([$headerRow, $separatorRow], $dataRows));
+  return implode("\n", array_merge([$header_row, $separator_row], $data_rows));
 }

--- a/scripts/merge-coverage.php
+++ b/scripts/merge-coverage.php
@@ -55,7 +55,7 @@ echo "\033[32mCoverage merge started\033[0m" . PHP_EOL;
  * @var \SebastianBergmann\CodeCoverage\CodeCoverage|null $merged
  */
 $merged = NULL;
-$mergeCount = 0;
+$merge_count = 0;
 
 // Load main coverage sources (PHPUnit and Behat).
 foreach ($sources as $label => $file) {
@@ -83,30 +83,30 @@ foreach ($sources as $label => $file) {
   else {
     $merged->merge($coverage);
   }
-  $mergeCount++;
+  $merge_count++;
   echo sprintf("  \033[2m◆ Loaded %s coverage from: %s\033[0m%s", $label, $file, PHP_EOL);
 }
 
 // Find and merge subprocess coverage files.
-$subprocessFiles = [];
+$subprocess_files = [];
 if (is_dir(SOURCE_SUBPROCESS_COVERAGE_DIR)) {
-  $subprocessFiles = glob(SOURCE_SUBPROCESS_COVERAGE_DIR . '/*.php');
+  $subprocess_files = glob(SOURCE_SUBPROCESS_COVERAGE_DIR . '/*.php');
 }
 
-if (!empty($subprocessFiles)) {
-  echo sprintf("  \033[2m◆ Merging %d subprocess coverage files...\033[0m%s", count($subprocessFiles), PHP_EOL);
+if (!empty($subprocess_files)) {
+  echo sprintf("  \033[2m◆ Merging %d subprocess coverage files...\033[0m%s", count($subprocess_files), PHP_EOL);
 
-  foreach ($subprocessFiles as $file) {
+  foreach ($subprocess_files as $file) {
     try {
-      $subprocessCoverage = include $file;
-      if ($subprocessCoverage instanceof CodeCoverage) {
+      $subprocess_coverage = include $file;
+      if ($subprocess_coverage instanceof CodeCoverage) {
         if ($merged === NULL) {
-          $merged = $subprocessCoverage;
+          $merged = $subprocess_coverage;
         }
         else {
-          $merged->merge($subprocessCoverage);
+          $merged->merge($subprocess_coverage);
         }
-        $mergeCount++;
+        $merge_count++;
         echo "\033[2m    ├ Merged: " . basename($file) . "\033[0m" . PHP_EOL;
       }
     }
@@ -121,51 +121,51 @@ if ($merged === NULL) {
   exit(1);
 }
 
-echo sprintf('▶ Merged %d coverage sources.%s', $mergeCount, PHP_EOL);
+echo sprintf('▶ Merged %d coverage sources.%s', $merge_count, PHP_EOL);
 
 // Save merged coverage.
-$outputDir = dirname(OUTPUT_MERGED_COVERAGE_FILE);
-if (!is_dir($outputDir)) {
-  mkdir($outputDir, 0755, TRUE);
+$output_dir = dirname(OUTPUT_MERGED_COVERAGE_FILE);
+if (!is_dir($output_dir)) {
+  mkdir($output_dir, 0755, TRUE);
 }
 
 file_put_contents(OUTPUT_MERGED_COVERAGE_FILE, '<?php' . PHP_EOL . 'return \\unserialize(' . var_export(serialize($merged), TRUE) . ');' . PHP_EOL);
 echo sprintf("  \033[2m✦ Coverage merged and saved to: %s\033[0m%s", OUTPUT_MERGED_COVERAGE_FILE, PHP_EOL);
 
 // Generate Cobertura report.
-$coberturaReport = new Cobertura();
-file_put_contents(OUTPUT_COBERTURA_REPORT_FILE, $coberturaReport->process($merged));
+$cobertura_report = new Cobertura();
+file_put_contents(OUTPUT_COBERTURA_REPORT_FILE, $cobertura_report->process($merged));
 echo sprintf("  \033[2m✦ Cobertura report generated: %s\033[0m%s", OUTPUT_COBERTURA_REPORT_FILE, PHP_EOL);
 
 // Generate HTML report.
-$htmlReport = new Facade();
-$htmlReport->process($merged, OUTPUT_HTML_REPORT_DIR);
+$html_report = new Facade();
+$html_report->process($merged, OUTPUT_HTML_REPORT_DIR);
 echo sprintf("  \033[2m✦ HTML report generated: %s\033[0m%s", OUTPUT_HTML_REPORT_DIR, PHP_EOL);
 
 // Generate text report and split into summary and details.
-$textReport = new Text(Thresholds::default(), TRUE);
-$coverageText = $textReport->process($merged, FALSE);
-file_put_contents(COVERAGE_ROOT_PATH . '/merged/coverage.txt', $coverageText);
+$text_report = new Text(Thresholds::default(), TRUE);
+$coverage_text = $text_report->process($merged, FALSE);
+file_put_contents(COVERAGE_ROOT_PATH . '/merged/coverage.txt', $coverage_text);
 
-$lines = explode("\n", $coverageText);
-$summaryLines = [];
-$detailsLines = [];
-$inDetails = FALSE;
+$lines = explode("\n", $coverage_text);
+$summary_lines = [];
+$details_lines = [];
+$in_details = FALSE;
 foreach ($lines as $line) {
-  if (!$inDetails && preg_match('/^\S+\\\\\S+/', $line)) {
-    $inDetails = TRUE;
+  if (!$in_details && preg_match('/^\S+\\\\\S+/', $line)) {
+    $in_details = TRUE;
   }
-  if ($inDetails) {
-    $detailsLines[] = $line;
+  if ($in_details) {
+    $details_lines[] = $line;
   }
   elseif (preg_match('/^\s+(Classes|Methods|Lines):/', $line, $matches)) {
-    $summaryLines[$matches[1]] = $line;
+    $summary_lines[$matches[1]] = $line;
   }
 }
-$summaryOrder = ['Lines', 'Methods', 'Classes'];
-$orderedSummary = array_filter(array_map(fn(string $key): ?string => $summaryLines[$key] ?? NULL, $summaryOrder));
-file_put_contents(COVERAGE_ROOT_PATH . '/merged/coverage-summary.txt', implode("\n", $orderedSummary) . "\n");
-file_put_contents(COVERAGE_ROOT_PATH . '/merged/coverage-details.txt', implode("\n", $detailsLines));
+$summary_order = ['Lines', 'Methods', 'Classes'];
+$ordered_summary = array_filter(array_map(fn(string $key): ?string => $summary_lines[$key] ?? NULL, $summary_order));
+file_put_contents(COVERAGE_ROOT_PATH . '/merged/coverage-summary.txt', implode("\n", $ordered_summary) . "\n");
+file_put_contents(COVERAGE_ROOT_PATH . '/merged/coverage-details.txt', implode("\n", $details_lines));
 echo sprintf("  \033[2m✦ Text report generated: %s/merged/coverage.txt\033[0m%s", COVERAGE_ROOT_PATH, PHP_EOL);
 
 echo "\033[32mCoverage merge finished\033[0m" . PHP_EOL;

--- a/spec/Drupal/DrupalExtension/Context/Initializer/DrupalAwareInitializerSpec.php
+++ b/spec/Drupal/DrupalExtension/Context/Initializer/DrupalAwareInitializerSpec.php
@@ -30,11 +30,11 @@ class DrupalAwareInitializerSpec extends ObjectBehavior {
   private $dispatcher;
 
   public function let(DrupalDriverManager $drupal, DrupalAuthenticationManagerInterface $authenticationManager, DrupalUserManagerInterface $userManager) {
-    $callCenter = new CallCenter();
+    $call_center = new CallCenter();
     $manager = new EnvironmentManager();
     $repository = new HookRepository($manager);
     // Cannot mock this class as it is marked as final.
-    $this->dispatcher = new HookDispatcher($repository, $callCenter);
+    $this->dispatcher = new HookDispatcher($repository, $call_center);
     $this->beConstructedWith($drupal, [], $this->dispatcher, $authenticationManager, $userManager);
   }
 

--- a/spec/Drupal/DrupalExtension/Listener/DriverListenerSpec.php
+++ b/spec/Drupal/DrupalExtension/Listener/DriverListenerSpec.php
@@ -51,11 +51,11 @@ class DriverListenerSpec extends ObjectBehavior {
   }
 
   public function it_subscribes_to_scenarios_and_outlines() {
-    $subscribedEvents = [
+    $subscribed_events = [
       'tester.scenario_tested.before' => ['prepareDefaultDrupalDriver', 11],
       'tester.example_tested.before' => ['prepareDefaultDrupalDriver', 11],
     ];
-    $this->getSubscribedEvents()->shouldReturn($subscribedEvents);
+    $this->getSubscribedEvents()->shouldReturn($subscribed_events);
   }
 
 }

--- a/spec/Drupal/DrupalExtension/Selector/RegionSelectorSpec.php
+++ b/spec/Drupal/DrupalExtension/Selector/RegionSelectorSpec.php
@@ -12,12 +12,12 @@ use PhpSpec\ObjectBehavior;
 class RegionSelectorSpec extends ObjectBehavior {
 
   public function let(CssSelector $selector) {
-    $regionMap = [
+    $region_map = [
       'Left sidebar' => '#left-sidebar',
     ];
     $selector->translateToXPath('#left-sidebar')->willReturn('some xpath');
 
-    $this->beConstructedWith($selector, $regionMap);
+    $this->beConstructedWith($selector, $region_map);
   }
 
   public function it_is_initializable() {

--- a/src/Drupal/DrupalExtension/Compiler/DriverPass.php
+++ b/src/Drupal/DrupalExtension/Compiler/DriverPass.php
@@ -21,12 +21,12 @@ class DriverPass implements CompilerPassInterface {
       return;
     }
 
-    $drupalDefinition = $container->getDefinition('drupal.drupal');
+    $drupal_definition = $container->getDefinition('drupal.drupal');
 
     foreach ($container->findTaggedServiceIds('drupal.driver') as $id => $attributes) {
       foreach ($attributes as $attribute) {
         if (isset($attribute['alias']) && $name = $attribute['alias']) {
-          $drupalDefinition->addMethodCall('registerDriver', [$name, new Reference($id)]);
+          $drupal_definition->addMethodCall('registerDriver', [$name, new Reference($id)]);
         }
       }
 
@@ -36,16 +36,16 @@ class DriverPass implements CompilerPassInterface {
         continue;
       }
 
-      $coreIds = array_keys($container->findTaggedServiceIds('drupal.core'));
+      $core_ids = array_keys($container->findTaggedServiceIds('drupal.core'));
 
-      if ($coreIds === []) {
+      if ($core_ids === []) {
         continue;
       }
 
-      $container->getDefinition($id)->addMethodCall('setCore', [new Reference($coreIds[0])]);
+      $container->getDefinition($id)->addMethodCall('setCore', [new Reference($core_ids[0])]);
     }
 
-    $drupalDefinition->addMethodCall('setDefaultDriverName', [$container->getParameter('drupal.drupal.default_driver')]);
+    $drupal_definition->addMethodCall('setDefaultDriverName', [$container->getParameter('drupal.drupal.default_driver')]);
   }
 
 }

--- a/src/Drupal/DrupalExtension/Compiler/EventSubscriberPass.php
+++ b/src/Drupal/DrupalExtension/Compiler/EventSubscriberPass.php
@@ -20,12 +20,12 @@ class EventSubscriberPass implements CompilerPassInterface {
     if (!$container->hasDefinition('drupal.event_dispatcher')) {
       return;
     }
-    $dispatcherDefinition = $container->getDefinition('drupal.event_dispatcher');
+    $dispatcher_definition = $container->getDefinition('drupal.event_dispatcher');
 
     foreach ($container->findTaggedServiceIds('drupal.event_subscriber') as $id => $attributes) {
       foreach ($attributes as $attribute) {
         $priority = isset($attribute['priority']) ? intval($attribute['priority']) : 0;
-        $dispatcherDefinition->addMethodCall(
+        $dispatcher_definition->addMethodCall(
               'addSubscriber',
               [new Reference($id), $priority]
           );

--- a/src/Drupal/DrupalExtension/Context/Attribute/HookAttributeReader.php
+++ b/src/Drupal/DrupalExtension/Context/Attribute/HookAttributeReader.php
@@ -46,14 +46,14 @@ class HookAttributeReader implements AttributeReader {
 
     $callees = [];
     foreach ($attributes as $attribute) {
-      $hookCallClass = self::ATTRIBUTE_MAP[$attribute->getName()] ?? NULL;
-      if ($hookCallClass === NULL) {
+      $hook_call_class = self::ATTRIBUTE_MAP[$attribute->getName()] ?? NULL;
+      if ($hook_call_class === NULL) {
         continue;
       }
 
       $hook = $attribute->newInstance();
       $callable = [$contextClass, $method->getName()];
-      $callees[] = new $hookCallClass($hook->getFilterString(), $callable);
+      $callees[] = new $hook_call_class($hook->getFilterString(), $callable);
     }
 
     return $callees;

--- a/src/Drupal/DrupalExtension/Context/ConfigContext.php
+++ b/src/Drupal/DrupalExtension/Context/ConfigContext.php
@@ -50,7 +50,7 @@ class ConfigContext extends RawDrupalContext implements TranslatableContext {
     }
 
     // Revert config that was changed.
-    foreach ($this->config as $name => $keyValue) {
+    foreach ($this->config as $name => $key_value) {
       // Reset the config factory cache so the editable config object is
       // loaded fresh from storage. Without this, the cached object retains
       // stale originalData from when setConfig() ran, causing
@@ -59,7 +59,7 @@ class ConfigContext extends RawDrupalContext implements TranslatableContext {
         \Drupal::configFactory()->reset($name);
       }
 
-      foreach ($keyValue as $key => $value) {
+      foreach ($key_value as $key => $value) {
         $driver->configSet($name, $key, $value);
       }
     }

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -278,9 +278,9 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
   #[Given('I click :link in the :rowText row')]
   public function assertClickInTableRow(string $link, string $rowText): void {
     $page = $this->getSession()->getPage();
-    if ($linkElement = $this->getTableRow($page, $rowText)->findLink($link)) {
+    if ($link_element = $this->getTableRow($page, $rowText)->findLink($link)) {
       // Click the link and return.
-      $linkElement->click();
+      $link_element->click();
       return;
     }
     throw new \Exception(sprintf('Found a row containing "%s", but no "%s" link on the page %s', $rowText, $link, $this->getSession()->getCurrentUrl()));
@@ -300,9 +300,9 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
   #[Given('I press :button in the :rowText row')]
   public function assertPressInTableRow(string $button, string $rowText): void {
     $page = $this->getSession()->getPage();
-    if ($buttonElement = $this->getTableRow($page, $rowText)->findButton($button)) {
+    if ($button_element = $this->getTableRow($page, $rowText)->findButton($button)) {
       // Press the button and return.
-      $buttonElement->press();
+      $button_element->press();
       return;
     }
     throw new \Exception(sprintf('Found a row containing "%s", but no "%s" button on the page %s', $rowText, $button, $this->getSession()->getCurrentUrl()));
@@ -403,8 +403,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    */
   #[Given(':type content:')]
   public function createNodes(string $type, TableNode $nodesTable): void {
-    foreach ($nodesTable->getHash() as $nodeHash) {
-      $node = (object) $nodeHash;
+    foreach ($nodesTable->getHash() as $node_hash) {
+      $node = (object) $node_hash;
       $node->type = $type;
       $this->nodeCreate($node);
     }
@@ -500,17 +500,17 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
       throw new \RuntimeException(sprintf('The active Drupal driver "%s" does not support user role assignment.', $driver::class));
     }
 
-    foreach ($usersTable->getHash() as $userHash) {
+    foreach ($usersTable->getHash() as $user_hash) {
       // Split out roles to process after user is created.
       $roles = [];
 
-      if (isset($userHash['roles'])) {
-        $roles = explode(',', $userHash['roles']);
+      if (isset($user_hash['roles'])) {
+        $roles = explode(',', $user_hash['roles']);
         $roles = array_filter(array_map(trim(...), $roles));
-        unset($userHash['roles']);
+        unset($user_hash['roles']);
       }
 
-      $user = (object) $userHash;
+      $user = (object) $user_hash;
       // Set a password.
       if (!isset($user->pass)) {
         $user->pass = $this->getRandom()->name();
@@ -536,8 +536,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    */
   #[Given(':vocabulary terms:')]
   public function createTerms(string $vocabulary, TableNode $termsTable): void {
-    foreach ($termsTable->getHash() as $termsHash) {
-      $term = (object) $termsHash;
+    foreach ($termsTable->getHash() as $terms_hash) {
+      $term = (object) $terms_hash;
       $term->vocabulary_machine_name = $vocabulary;
       $this->termCreate($term);
     }
@@ -570,7 +570,9 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
   }
 
   /**
-   * Pauses the scenario until the user presses a key. Useful when debugging a scenario.
+   * Pauses the scenario until the user presses a key.
+   *
+   * Useful when debugging a scenario.
    *
    * @code
    * Then break
@@ -585,8 +587,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
       $line = trim(fgets(STDIN, 1024));
       // Note: this assumes ASCII encoding.  Should probably be revamped to
       // handle other character sets.
-      $charCode = ord($line);
-      switch ($charCode) {
+      $char_code = ord($line);
+      switch ($char_code) {
         // CR.
         case 0:
           // Y.

--- a/src/Drupal/DrupalExtension/Context/DrupalSubContextBase.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalSubContextBase.php
@@ -28,7 +28,7 @@ abstract class DrupalSubContextBase extends RawDrupalContext implements DrupalSu
    * @see \Drupal\DrupalExtension\Context\RawDrupalContext::getUserManager()
    */
   protected function getUser() {
-    @trigger_error('DrupalSubContextBase::getUser() is deprecated. Use RawDrupalContext::getUserManager()->getCurrentUser() instead.', E_USER_DEPRECATED);
+    @trigger_error('DrupalSubContextBase::getUser() is deprecated in drupalextension:4.0.0 and is removed from drupalextension:5.0.0. Use RawDrupalContext::getUserManager()->getCurrentUser() instead. See https://www.drupal.org/project/drupalextension/issues/676', E_USER_DEPRECATED);
 
     $user = $this->getUserManager()->getCurrentUser();
 

--- a/src/Drupal/DrupalExtension/Context/Environment/Reader/Reader.php
+++ b/src/Drupal/DrupalExtension/Context/Environment/Reader/Reader.php
@@ -81,9 +81,9 @@ final class Reader implements EnvironmentReader {
       return $callees;
     }
 
-    $contextClasses = $this->findSubContextClasses();
+    $context_classes = $this->findSubContextClasses();
 
-    foreach ($contextClasses as $contextClass) {
+    foreach ($context_classes as $context_class) {
       // When executing test scenarios with an examples table the registering of
       // contexts is handled differently in newer version of Behat. Starting
       // with Behat 3.2.0 the contexts are already registered, and the callees
@@ -92,14 +92,14 @@ final class Reader implements EnvironmentReader {
       // 3.2.0 and higher by checking if the class already exists before
       // registering it and returning the callees.
       // @see https://github.com/Behat/Behat/issues/758
-      if (!$environment->hasContextClass($contextClass)) {
+      if (!$environment->hasContextClass($context_class)) {
         $callees = array_merge(
           $callees,
-          $this->readContextCallees($environment, $contextClass)
+          $this->readContextCallees($environment, $context_class)
         );
 
         // Register context.
-        $environment->registerContextClass($contextClass, [$this->drupalDriverManager]);
+        $environment->registerContextClass($context_class, [$this->drupalDriverManager]);
       }
     }
 
@@ -114,10 +114,10 @@ final class Reader implements EnvironmentReader {
    */
   protected function readContextCallees(ContextEnvironment $environment, string $contextClass): array {
     $callees = [];
-    foreach ($this->contextReaders as $contextReader) {
+    foreach ($this->contextReaders as $context_reader) {
       $callees = array_merge(
         $callees,
-        $contextReader->readContextCallees($environment, $contextClass)
+        $context_reader->readContextCallees($environment, $contextClass)
       );
     }
 
@@ -131,7 +131,7 @@ final class Reader implements EnvironmentReader {
    *   An array of fully-qualified class names.
    */
   protected function findSubContextClasses(): array {
-    $classNames = [];
+    $class_names = [];
 
     // Initialize any available sub-contexts.
     if (isset($this->parameters['subcontexts'])) {
@@ -149,7 +149,7 @@ final class Reader implements EnvironmentReader {
       if (isset($this->parameters['subcontexts']['paths'])) {
         if (!empty($this->parameters['subcontexts']['paths'])) {
           @trigger_error(
-            'The `subcontexts.paths` parameter is deprecated in Drupal Behat Extension 4.0.0 and will be removed in 4.1.0. Normal Behat contexts should be used instead and loaded via behat.yml.',
+            'The "subcontexts.paths" parameter is deprecated in drupalextension:4.0.0 and is removed from drupalextension:4.1.0. Normal Behat contexts should be used instead and loaded via behat.yml. See https://www.drupal.org/project/drupalextension/issues/676',
             E_USER_DEPRECATED
           );
         }
@@ -168,13 +168,13 @@ final class Reader implements EnvironmentReader {
       foreach ($classes as $class) {
         $reflect = new \ReflectionClass($class);
         if (!$reflect->isAbstract() && $reflect->implementsInterface(DrupalSubContextInterface::class)) {
-          @trigger_error('Sub-contexts are deprecated in Drupal Behat Extension 4.0.0 and will be removed in 4.1.0. Class ' . $class . ' is a subcontext. This logic should be moved to a normal Behat context and loaded via behat.yml.', E_USER_DEPRECATED);
-          $classNames[] = $class;
+          @trigger_error('Sub-context support is deprecated in drupalextension:4.0.0 and is removed from drupalextension:4.1.0. Class ' . $class . ' is a sub-context. This logic should be moved to a normal Behat context and loaded via behat.yml. See https://www.drupal.org/project/drupalextension/issues/676', E_USER_DEPRECATED);
+          $class_names[] = $class;
         }
       }
     }
 
-    return $classNames;
+    return $class_names;
   }
 
   /**
@@ -196,14 +196,14 @@ final class Reader implements EnvironmentReader {
 
     self::$subContexts[$pattern][$path] = [];
 
-    $fileIterator = new \RegexIterator(
+    $file_iterator = new \RegexIterator(
       new \RecursiveIteratorIterator(
         new \RecursiveDirectoryIterator($path)
       ),
       $pattern,
       \RegexIterator::MATCH
     );
-    foreach ($fileIterator as $found) {
+    foreach ($file_iterator as $found) {
       self::$subContexts[$pattern][$path][$found->getRealPath()] = $found->getFileName();
     }
 

--- a/src/Drupal/DrupalExtension/Context/MailContext.php
+++ b/src/Drupal/DrupalExtension/Context/MailContext.php
@@ -170,12 +170,12 @@ class MailContext extends RawMailContext {
   #[Then(':count (e)mail(s) has/have been sent to :to with the subject :subject')]
   public function noMailHasBeenSent(string $count, string $to = '', string $subject = ''): void {
     $actual = $this->getMail(['to' => $to, 'subject' => $subject]);
-    $expectedCount = match ($count) {
+    $expected_count = match ($count) {
       'no' => 0,
             'a', 'an' => NULL,
             default => (int) $count,
     };
-    $this->assertMessageCount($actual, $expectedCount);
+    $this->assertMessageCount($actual, $expected_count);
   }
 
   /**
@@ -192,12 +192,12 @@ class MailContext extends RawMailContext {
   #[Then(':count new (e)mail(s) is/are sent to :to with the subject :subject')]
   public function noNewMailIsSent(string $count, string $to = '', string $subject = ''): void {
     $actual = $this->getMail(['to' => $to, 'subject' => $subject], TRUE);
-    $expectedCount = match ($count) {
+    $expected_count = match ($count) {
       'no' => 0,
             'a', 'an' => 1,
             default => (int) $count,
     };
-    $this->assertMessageCount($actual, $expectedCount);
+    $this->assertMessageCount($actual, $expected_count);
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Context/MarkupContext.php
+++ b/src/Drupal/DrupalExtension/Context/MarkupContext.php
@@ -106,9 +106,9 @@ class MarkupContext extends RawMinkContext {
    */
   #[Then('I( should) see :text in the :tag element in the :region( region)')]
   public function assertRegionElementText(string $text, string $tag, string $region): void {
-    $regionObj = $this->getRegion($region);
+    $region_obj = $this->getRegion($region);
 
-    foreach ($regionObj->findAll('css', $tag) as $result) {
+    foreach ($region_obj->findAll('css', $tag) as $result) {
       if ($result->getText() == $text) {
         return;
       }
@@ -127,9 +127,9 @@ class MarkupContext extends RawMinkContext {
    */
   #[Then('I( should) not see :text in the :tag element in the :region( region)')]
   public function assertNotRegionElementText(string $text, string $tag, string $region): void {
-    $regionObj = $this->getRegion($region);
+    $region_obj = $this->getRegion($region);
 
-    foreach ($regionObj->findAll('css', $tag) as $result) {
+    foreach ($region_obj->findAll('css', $tag) as $result) {
       if ($result->getText() == $text) {
         throw new \Exception(sprintf('The text "%s" was found in the "%s" element in the "%s" region on the page %s', $text, $tag, $region, $this->getSession()->getCurrentUrl()));
       }
@@ -155,19 +155,19 @@ class MarkupContext extends RawMinkContext {
       return;
     }
 
-    $attrFound = FALSE;
+    $attr_found = FALSE;
 
     foreach ($elements as $element) {
       $attr = $element->getAttribute($attribute);
       if (!empty($attr)) {
-        $attrFound = TRUE;
+        $attr_found = TRUE;
         if (str_contains($attr, $value)) {
           return;
         }
       }
     }
 
-    if (!$attrFound) {
+    if (!$attr_found) {
       throw new \Exception(sprintf('The "%s" attribute is not present on the element "%s" in the "%s" region on the page %s', $attribute, $tag, $region, $this->getSession()->getCurrentUrl()));
     }
 

--- a/src/Drupal/DrupalExtension/Context/MessageContext.php
+++ b/src/Drupal/DrupalExtension/Context/MessageContext.php
@@ -155,7 +155,7 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
   }
 
   /**
-   * Checks if the current page does not contain the given set of success message.
+   * Checks the page does not contain the given success message.
    *
    * @param string $message
    *   The text to be checked.
@@ -175,7 +175,7 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
   }
 
   /**
-   * Checks if the current page does not contain the given set of success messages.
+   * Checks the page does not contain the given set of success messages.
    *
    * @param \Behat\Gherkin\Node\TableNode $messages
    *   An array of texts to be checked. The first row should consist of the
@@ -242,7 +242,7 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
   }
 
   /**
-   * Checks if the current page does not contain the given set of warning message.
+   * Checks the page does not contain the given warning message.
    *
    * @param string $message
    *   The text to be checked.
@@ -262,7 +262,7 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
   }
 
   /**
-   * Checks if the current page does not contain the given set of warning messages.
+   * Checks the page does not contain the given set of warning messages.
    *
    * @param \Behat\Gherkin\Node\TableNode $messages
    *   An array of texts to be checked. The first row should consist of the
@@ -338,18 +338,18 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    */
   protected function assertValidMessageTable(TableNode $messages, string $expected_header) {
     // Check that the table only contains a single column.
-    $headerRow = $messages->getRow(0);
+    $header_row = $messages->getRow(0);
 
-    $columnCount = count($headerRow);
-    if ($columnCount !== 1) {
-      throw new \RuntimeException(sprintf('The list of %s should only contain 1 column. It has %s columns.', $expected_header, $columnCount));
+    $column_count = count($header_row);
+    if ($column_count !== 1) {
+      throw new \RuntimeException(sprintf('The list of %s should only contain 1 column. It has %s columns.', $expected_header, $column_count));
     }
 
     // Check that the correct header is used.
-    $actualHeader = reset($headerRow);
-    if (strtolower(trim($actualHeader)) !== $expected_header) {
-      $capitalizedHeader = ucfirst($expected_header);
-      throw new \RuntimeException(sprintf("The list of %s should have the header '%s', but found '%s'.", $expected_header, $capitalizedHeader, $actualHeader));
+    $actual_header = reset($header_row);
+    if (strtolower(trim($actual_header)) !== $expected_header) {
+      $capitalized_header = ucfirst($expected_header);
+      throw new \RuntimeException(sprintf("The list of %s should have the header '%s', but found '%s'.", $expected_header, $capitalized_header, $actual_header));
     }
   }
 
@@ -372,12 +372,12 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    */
   protected function assert(string $message, string $selectorId, string $exceptionMsgNone, string $exceptionMsgMissing): void {
     $selector = $this->getDrupalSelector($selectorId);
-    $selectorObjects = $this->getSession()->getPage()->findAll("css", $selector);
-    if (empty($selectorObjects)) {
+    $selector_objects = $this->getSession()->getPage()->findAll("css", $selector);
+    if (empty($selector_objects)) {
       throw new ExpectationException(sprintf($exceptionMsgNone, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
     }
-    foreach ($selectorObjects as $selectorObject) {
-      if (str_contains(trim($selectorObject->getText()), $message)) {
+    foreach ($selector_objects as $selector_object) {
+      if (str_contains(trim($selector_object->getText()), $message)) {
         return;
       }
     }
@@ -385,7 +385,7 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
   }
 
   /**
-   * Internal callback to check if the current page does not contain the given message.
+   * Internal callback to check the page does not contain the given message.
    *
    * @param string $message
    *   The message to be checked.
@@ -400,10 +400,10 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    */
   protected function assertNot(string $message, string $selectorId, string $exceptionMsg): void {
     $selector = $this->getDrupalSelector($selectorId);
-    $selectorObjects = $this->getSession()->getPage()->findAll("css", $selector);
-    if (!empty($selectorObjects)) {
-      foreach ($selectorObjects as $selectorObject) {
-        if (str_contains(trim($selectorObject->getText()), $message)) {
+    $selector_objects = $this->getSession()->getPage()->findAll("css", $selector);
+    if (!empty($selector_objects)) {
+      foreach ($selector_objects as $selector_object) {
+        if (str_contains(trim($selector_object->getText()), $message)) {
           throw new ExpectationException(sprintf($exceptionMsg, $this->getSession()->getCurrentUrl(), $message), $this->getSession()->getDriver());
         }
       }

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -156,15 +156,15 @@ class MinkContext extends MinkExtension implements TranslatableContext {
       );
     }());
 JS;
-    $ajaxTimeout = $this->getMinkParameter('ajax_timeout');
-    $result = $this->getSession()->wait(1000 * $ajaxTimeout, $condition);
+    $ajax_timeout = $this->getMinkParameter('ajax_timeout');
+    $result = $this->getSession()->wait(1000 * $ajax_timeout, $condition);
     if (!$result) {
-      if ($ajaxTimeout === NULL) {
+      if ($ajax_timeout === NULL) {
         throw new \Exception('No AJAX timeout has been defined. Please verify that "Drupal\MinkExtension" is configured in behat.yml (and not "Behat\MinkExtension").');
       }
       if ($event) {
         /** @var \Behat\Behat\Hook\Scope\BeforeStepScope $event */
-        $eventData = ' ' . json_encode([
+        $event_data = ' ' . json_encode([
           'name' => $event->getName(),
           'feature' => $event->getFeature()->getTitle(),
           'step' => $event->getStep()->getText(),
@@ -172,9 +172,9 @@ JS;
         ]);
       }
       else {
-        $eventData = '';
+        $event_data = '';
       }
-      throw new \RuntimeException('Unable to complete AJAX request.' . $eventData);
+      throw new \RuntimeException('Unable to complete AJAX request.' . $event_data);
     }
   }
 
@@ -281,17 +281,17 @@ JS;
     $page = $this->getSession()->getPage();
     $driver = $this->getSession()->getDriver();
 
-    $sourceElement = $page->find('css', $source);
-    if ($sourceElement === NULL) {
+    $source_element = $page->find('css', $source);
+    if ($source_element === NULL) {
       throw new ElementNotFoundException($driver, 'source element', 'css selector', $source);
     }
 
-    $targetElement = $page->find('css', $target);
-    if ($targetElement === NULL) {
+    $target_element = $page->find('css', $target);
+    if ($target_element === NULL) {
       throw new ElementNotFoundException($driver, 'target element', 'css selector', $target);
     }
 
-    $sourceElement->dragTo($targetElement);
+    $source_element->dragTo($target_element);
   }
 
   /**
@@ -351,7 +351,9 @@ JS;
   }
 
   /**
-   * Links are loaded but not visually visible (e.g they have display: hidden applied).
+   * Links are loaded but not visually visible.
+   *
+   * For example, they have 'display: hidden' applied.
    *
    * @code
    * Then I should not visibly see the link "Skip to main content"
@@ -428,8 +430,8 @@ JS;
   #[Then('I (should ) see the :button button')]
   public function assertButton(string $button): void {
     $element = $this->getSession()->getPage();
-    $buttonObj = $element->findButton($button);
-    if (empty($buttonObj)) {
+    $button_obj = $element->findButton($button);
+    if (empty($button_obj)) {
       throw new \Exception(sprintf("The button '%s' was not found on the page %s", $button, $this->getSession()->getCurrentUrl()));
     }
   }
@@ -446,8 +448,8 @@ JS;
   #[Then('I should not see the :button button')]
   public function assertNotButton(string $button): void {
     $element = $this->getSession()->getPage();
-    $buttonObj = $element->findButton($button);
-    if (!empty($buttonObj)) {
+    $button_obj = $element->findButton($button);
+    if (!empty($button_obj)) {
       throw new \Exception(sprintf("The button '%s' was found on the page %s", $button, $this->getSession()->getCurrentUrl()));
     }
   }
@@ -466,18 +468,25 @@ JS;
    */
   #[When('I follow/click :link in the :region( region)')]
   public function assertRegionLinkFollow(string $link, string $region): void {
-    $regionObj = $this->getRegion($region);
+    $region_obj = $this->getRegion($region);
 
     // Find the link within the region.
-    $linkObj = $regionObj->findLink($link);
-    if (empty($linkObj)) {
-      throw new \Exception(sprintf('The link "%s" was not found in the region "%s" on the page %s', $link, $region, $this->getSession()->getCurrentUrl()));
+    $link_obj = $region_obj->findLink($link);
+    if (empty($link_obj)) {
+      throw new \Exception(sprintf(
+        'The link "%s" was not found in the region "%s" on the page %s',
+        $link,
+        $region,
+        $this->getSession()->getCurrentUrl()
+      ));
     }
-    $linkObj->click();
+    $link_obj->click();
   }
 
   /**
-   * Checks if a button with id|name|title|alt|value exists or not and presses the same.
+   * Checks if a button exists and presses it.
+   *
+   * Matches by id|name|title|alt|value.
    *
    * @param string $button
    *   The id|name|title|alt|value of the button to be pressed.
@@ -494,13 +503,13 @@ JS;
    */
   #[Given('I press :button in the :region( region)')]
   public function assertRegionPressButton(string $button, string $region): void {
-    $regionObj = $this->getRegion($region);
+    $region_obj = $this->getRegion($region);
 
-    $buttonObj = $regionObj->findButton($button);
-    if (empty($buttonObj)) {
+    $button_obj = $region_obj->findButton($button);
+    if (empty($button_obj)) {
       throw new \Exception(sprintf("The button '%s' was not found in the region '%s' on the page %s", $button, $region, $this->getSession()->getCurrentUrl()));
     }
-    $buttonObj->press();
+    $button_obj->press();
   }
 
   /**
@@ -520,12 +529,14 @@ JS;
   public function regionFillField(string $field, string $value, string $region): void {
     $field = $this->fixStepArgument($field);
     $value = $this->fixStepArgument($value);
-    $regionObj = $this->getRegion($region);
-    $regionObj->fillField($field, $value);
+    $region_obj = $this->getRegion($region);
+    $region_obj->fillField($field, $value);
   }
 
   /**
-   * Checks if a checkbox with id|name|title|alt|value exists or not and checks the same.
+   * Checks if a checkbox exists and checks it.
+   *
+   * Matches by id|name|title|alt|value.
    *
    * @param string $locator
    *   The id|name|title|alt|value of the checkbox to be checked.
@@ -542,12 +553,14 @@ JS;
    */
   #[Given('I check :locator in the :region( region)')]
   public function assertRegionCheckBox(string $locator, string $region): void {
-    $regionObj = $this->getRegion($region);
-    $regionObj->checkField($locator);
+    $region_obj = $this->getRegion($region);
+    $region_obj->checkField($locator);
   }
 
   /**
-   * Checks if a checkbox with id|name|title|alt|value exists or not and unchecks the same.
+   * Checks if a checkbox exists and unchecks it.
+   *
+   * Matches by id|name|title|alt|value.
    *
    * @param string $locator
    *   The id|name|title|alt|value of the checkbox to be unchecked.
@@ -564,8 +577,8 @@ JS;
    */
   #[Given('I uncheck :checkbox in the :region( region)')]
   public function assertRegionUncheckBox(string $locator, string $region): void {
-    $regionObj = $this->getRegion($region);
-    $regionObj->uncheckField($locator);
+    $region_obj = $this->getRegion($region);
+    $region_obj->uncheckField($locator);
   }
 
   /**
@@ -583,9 +596,9 @@ JS;
   #[Then('I should see the heading :heading in the :region( region)')]
   #[Then('I should see the :heading heading in the :region( region)')]
   public function assertRegionHeading(string $heading, string $region): void {
-    $regionObj = $this->getRegion($region);
+    $region_obj = $this->getRegion($region);
 
-    foreach ($regionObj->findAll('css', 'h1, h2, h3, h4, h5, h6') as $element) {
+    foreach ($region_obj->findAll('css', 'h1, h2, h3, h4, h5, h6') as $element) {
       if (trim($element->getText()) === $heading) {
         return;
       }
@@ -607,9 +620,9 @@ JS;
    */
   #[Then('I should see the link :link in the :region( region)')]
   public function assertLinkRegion(string $link, string $region): void {
-    $regionObj = $this->getRegion($region);
+    $region_obj = $this->getRegion($region);
 
-    $result = $regionObj->findLink($link);
+    $result = $region_obj->findLink($link);
     if (empty($result)) {
       throw new \Exception(sprintf('No link to "%s" in the "%s" region on the page %s', $link, $region, $this->getSession()->getCurrentUrl()));
     }
@@ -628,9 +641,9 @@ JS;
    */
   #[Then('I should not see the link :link in the :region( region)')]
   public function assertNotLinkRegion(string $link, string $region): void {
-    $regionObj = $this->getRegion($region);
+    $region_obj = $this->getRegion($region);
 
-    $result = $regionObj->findLink($link);
+    $result = $region_obj->findLink($link);
     if (!empty($result)) {
       throw new \Exception(sprintf('Link to "%s" in the "%s" region on the page %s', $link, $region, $this->getSession()->getCurrentUrl()));
     }
@@ -650,11 +663,11 @@ JS;
    */
   #[Then('I should see( the text) :text in the :region( region)')]
   public function assertRegionText(string $text, string $region): void {
-    $regionObj = $this->getRegion($region);
+    $region_obj = $this->getRegion($region);
 
     // Find the text within the region.
-    $regionText = $regionObj->getText();
-    if (!str_contains($regionText, $text)) {
+    $region_text = $region_obj->getText();
+    if (!str_contains($region_text, $text)) {
       throw new \Exception(sprintf("The text '%s' was not found in the region '%s' on the page %s", $text, $region, $this->getSession()->getCurrentUrl()));
     }
   }
@@ -673,11 +686,11 @@ JS;
    */
   #[Then('I should not see( the text) :text in the :region( region)')]
   public function assertNotRegionText(string $text, string $region): void {
-    $regionObj = $this->getRegion($region);
+    $region_obj = $this->getRegion($region);
 
     // Find the text within the region.
-    $regionText = $regionObj->getText();
-    if (str_contains($regionText, $text)) {
+    $region_text = $region_obj->getText();
+    if (str_contains($region_text, $text)) {
       throw new \Exception(sprintf('The text "%s" was found in the region "%s" on the page %s', $text, $region, $this->getSession()->getCurrentUrl()));
     }
   }
@@ -788,8 +801,8 @@ JS;
       throw new \Exception(sprintf('The radio button with "%s" was not found on the page %s', $id ?: $label, $this->getSession()->getCurrentUrl()));
     }
     $value = $radiobutton->getAttribute('value');
-    $radioId = $radiobutton->getAttribute('id');
-    $labelonpage = $element->find('css', sprintf("label[for='%s']", $radioId))->getText();
+    $radio_id = $radiobutton->getAttribute('id');
+    $labelonpage = $element->find('css', sprintf("label[for='%s']", $radio_id))->getText();
     if ($label != $labelonpage) {
       throw new \Exception(sprintf("Button with id '%s' has label '%s' instead of '%s' on the page %s", $id, $labelonpage, $label, $this->getSession()->getCurrentUrl()));
     }
@@ -813,31 +826,31 @@ JS;
     $literal = $this->getSession()->getSelectorsHandler()->xpathLiteral($summary);
 
     if ($action === 'expand') {
-      $expandedState = "[not(@open)]";
+      $expanded_state = "[not(@open)]";
     }
     elseif ($action === 'collapse') {
-      $expandedState = "[@open]";
+      $expanded_state = "[@open]";
     }
     elseif ($action === 'click') {
-      $expandedState = '';
+      $expanded_state = '';
     }
     else {
       throw new \InvalidArgumentException(sprintf("Unknown action '%s'. Expected expand, collapse, or click.", $action));
     }
 
-    $xpath = sprintf('//details%s/summary[normalize-space()][contains(normalize-space(.), %s)]', $expandedState, $literal);
+    $xpath = sprintf('//details%s/summary[normalize-space()][contains(normalize-space(.), %s)]', $expanded_state, $literal);
 
     $element = $page->find('xpath', $xpath);
     if (!$element) {
-      throw new \Exception(sprintf('Unable to find details%s containing text %s for action %s', $expandedState, $summary, $action));
+      throw new \Exception(sprintf('Unable to find details%s containing text %s for action %s', $expanded_state, $summary, $action));
     }
 
-    $ajaxTimeout = $this->getMinkParameter('ajax_timeout') ?? 5;
+    $ajax_timeout = $this->getMinkParameter('ajax_timeout') ?? 5;
     // 1/10th of ajax_timeout, in microseconds.
-    $animateDelay = $ajaxTimeout * 100000;
+    $animate_delay = $ajax_timeout * 100000;
     try {
       $element->click();
-      usleep($animateDelay);
+      usleep($animate_delay);
     }
     catch (UnsupportedDriverActionException) {
       // Goutte etc only supports clicking link, submit, button;

--- a/src/Drupal/DrupalExtension/Context/RandomContext.php
+++ b/src/Drupal/DrupalExtension/Context/RandomContext.php
@@ -69,18 +69,18 @@ class RandomContext extends RawDrupalContext {
     $steps = array_merge($steps, $scope->getScenario()->getSteps());
     foreach ($steps as $step) {
       preg_match_all(static::VARIABLE_REGEX, $step->getText(), $matches);
-      $variablesFound = $matches[0];
+      $variables_found = $matches[0];
       // Find variables in are TableNodes or PyStringNodes.
-      $stepArgument = $step->getArguments();
-      if (!empty($stepArgument) && $stepArgument[0] instanceof TableNode) {
-        preg_match_all(static::VARIABLE_REGEX, $stepArgument[0]->getTableAsString(), $matches);
-        $variablesFound = array_filter(array_merge($variablesFound, $matches[0]));
+      $step_argument = $step->getArguments();
+      if (!empty($step_argument) && $step_argument[0] instanceof TableNode) {
+        preg_match_all(static::VARIABLE_REGEX, $step_argument[0]->getTableAsString(), $matches);
+        $variables_found = array_filter(array_merge($variables_found, $matches[0]));
       }
-      foreach ($variablesFound as $variableFound) {
-        if (!isset($this->values[$variableFound])) {
+      foreach ($variables_found as $variable_found) {
+        if (!isset($this->values[$variable_found])) {
           $value = $this->getDriver()->getRandom()->name(10);
           // Value forced to lowercase to ensure it is machine-readable.
-          $this->values[$variableFound] = strtolower((string) $value);
+          $this->values[$variable_found] = strtolower((string) $value);
         }
       }
     }

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -338,12 +338,12 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    */
   protected function dispatchHooks(string $scopeClass, \stdClass $entity) {
     $scope = new $scopeClass($this->getDrupal()->getEnvironment(), $this, $entity);
-    $callResults = $this->dispatcher->dispatchScopeHooks($scope);
+    $call_results = $this->dispatcher->dispatchScopeHooks($scope);
 
     // The dispatcher suppresses exceptions, throw them here if there are any.
-    foreach ($callResults as $callResult) {
-      if ($callResult->hasException()) {
-        $exception = $callResult->getException();
+    foreach ($call_results as $call_result) {
+      if ($call_result->hasException()) {
+        $exception = $call_result->getException();
         throw $exception;
       }
     }
@@ -470,22 +470,22 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
 
     $classifier = $driver->getCore()->classifier();
 
-    $multicolumnField = '';
-    $multicolumnColumn = '';
-    $multicolumnFields = [];
+    $multicolumn_field = '';
+    $multicolumn_column = '';
+    $multicolumn_fields = [];
 
-    foreach ((array) (clone $entity) as $field => $fieldValue) {
-      // Reset the multicolumn field if the field name does not contain a column.
+    foreach ((array) (clone $entity) as $field => $field_value) {
+      // Reset the multicolumn field if the field name does not have a column.
       if (!str_contains((string) $field, ':')) {
-        $multicolumnField = '';
-        $multicolumnColumn = '';
+        $multicolumn_field = '';
+        $multicolumn_column = '';
       }
       elseif (str_contains(substr((string) $field, 1), ':')) {
-        // Start tracking a new multicolumn field if the field name contains a ':'
-        // which is preceded by at least 1 character.
-        [$multicolumnField, $multicolumnColumn] = explode(':', (string) $field);
+        // Start tracking a new multicolumn field if the field name contains a
+        // ':' which is preceded by at least 1 character.
+        [$multicolumn_field, $multicolumn_column] = explode(':', (string) $field);
       }
-      elseif (empty($multicolumnField)) {
+      elseif (empty($multicolumn_field)) {
         // If a field name starts with a ':' but we are not yet tracking a
         // multicolumn field we don't know to which field this belongs.
         throw new \RuntimeException('Field name missing for ' . $field);
@@ -493,15 +493,15 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
       else {
         // Update the column name if the field name starts with a ':' and we are
         // already tracking a multicolumn field.
-        $multicolumnColumn = substr((string) $field, 1);
+        $multicolumn_column = substr((string) $field, 1);
       }
 
-      $isMulticolumn = $multicolumnField && $multicolumnColumn;
-      $fieldName = $multicolumnField ?: $field;
-      if ($classifier->fieldIsConfigurable($entity_type, $fieldName)) {
+      $is_multicolumn = $multicolumn_field && $multicolumn_column;
+      $field_name = $multicolumn_field ?: $field;
+      if ($classifier->fieldIsConfigurable($entity_type, $field_name)) {
         // Split up multiple values in multi-value fields.
         $values = [];
-        foreach (str_getcsv((string) $fieldValue, escape: "\\") as $key => $value) {
+        foreach (str_getcsv((string) $field_value, escape: "\\") as $key => $value) {
           $value = trim((string) $value);
           $columns = $value;
           // Split up field columns if the ' - ' separator is present.
@@ -509,12 +509,12 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
           // field value, allowing values like "Alpha - Bravo" to pass
           // through as-is (e.g., entity reference titles with dashes).
           // @see https://github.com/jhedstrom/drupalextension/issues/642
-          $wasQuoted = str_contains((string) $fieldValue, '"' . $value . '"');
-          if (!$wasQuoted && str_contains($value, ' - ')) {
+          $was_quoted = str_contains((string) $field_value, '"' . $value . '"');
+          if (!$was_quoted && str_contains($value, ' - ')) {
             $columns = [];
             foreach (explode(' - ', $value) as $column) {
               // Check if it is an inline named column.
-              if (!$isMulticolumn && str_contains(substr($column, 1), ': ')) {
+              if (!$is_multicolumn && str_contains(substr($column, 1), ': ')) {
                 [$key, $column] = explode(': ', $column);
                 $columns[$key] = $column;
               }
@@ -525,8 +525,8 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
           }
 
           // Use the column name if we are tracking a multicolumn field.
-          if ($isMulticolumn) {
-            $multicolumnFields[$multicolumnField][$key][$multicolumnColumn] = $columns;
+          if ($is_multicolumn) {
+            $multicolumn_fields[$multicolumn_field][$key][$multicolumn_column] = $columns;
             unset($entity->$field);
           }
           else {
@@ -535,11 +535,11 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
         }
 
         // Replace regular fields inline in the entity after parsing.
-        if (!$isMulticolumn) {
-          $entity->$fieldName = $values;
+        if (!$is_multicolumn) {
+          $entity->$field_name = $values;
           // Don't specify any value if the step author has left it blank.
-          if ($fieldValue === '') {
-            unset($entity->$fieldName);
+          if ($field_value === '') {
+            unset($entity->$field_name);
           }
         }
       }
@@ -550,22 +550,22 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
         // custom storage), so the OR replaces the single v2 check and keeps
         // computed/custom-storage base fields like 'moderation_state' from
         // tripping the unknown-field guard.
-        $isBaseField = $classifier->fieldIsBaseStandard($entity_type, $fieldName)
-          || $classifier->fieldIsBaseComputedReadOnly($entity_type, $fieldName)
-          || $classifier->fieldIsBaseComputedWritable($entity_type, $fieldName)
-          || $classifier->fieldIsBaseCustomStorage($entity_type, $fieldName);
+        $is_base_field = $classifier->fieldIsBaseStandard($entity_type, $field_name)
+          || $classifier->fieldIsBaseComputedReadOnly($entity_type, $field_name)
+          || $classifier->fieldIsBaseComputedWritable($entity_type, $field_name)
+          || $classifier->fieldIsBaseCustomStorage($entity_type, $field_name);
 
-        if (!$isBaseField && !in_array($fieldName, $ignored_properties, TRUE)) {
-          throw new \RuntimeException(sprintf('Field "%s" does not exist on entity type "%s".', $fieldName, $entity_type));
+        if (!$is_base_field && !in_array($field_name, $ignored_properties, TRUE)) {
+          throw new \RuntimeException(sprintf('Field "%s" does not exist on entity type "%s".', $field_name, $entity_type));
         }
       }
     }
 
     // Add the multicolumn fields to the entity.
-    foreach ($multicolumnFields as $fieldName => $columns) {
+    foreach ($multicolumn_fields as $field_name => $columns) {
       // Don't specify any value if the step author has left it blank.
       if (count(array_filter($columns, fn($var): bool => $var !== '')) > 0) {
-        $entity->$fieldName = $columns;
+        $entity->$field_name = $columns;
       }
     }
   }
@@ -796,7 +796,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    *   current user's role before creating a new user.
    */
   public function loggedInWithRole($role): bool {
-    @trigger_error("loggedInWithRole() is deprecated in drupalextension:5.3.0 and is removed from drupalextension:6.0.0. Role-based login steps no longer check the current user's role before creating a new user.", E_USER_DEPRECATED);
+    @trigger_error("loggedInWithRole() is deprecated in drupalextension:5.3.0 and is removed from drupalextension:6.0.0. Role-based login steps no longer check the current user's role before creating a new user. See https://www.drupal.org/project/drupalextension/issues/676", E_USER_DEPRECATED);
     return $this->loggedIn() && $this->getUserManager()->currentUserHasRole($role);
   }
 

--- a/src/Drupal/DrupalExtension/Context/RawMailContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawMailContext.php
@@ -68,12 +68,12 @@ class RawMailContext extends RawDrupalContext {
    */
   protected function getMail(array $criteria = [], bool $new = FALSE, ?int $index = NULL, string $store = 'default') {
     $messages = $this->getMailManager()->getMail($store);
-    $previousCount = $this->getMailMessageCount($store);
+    $previous_count = $this->getMailMessageCount($store);
     $this->mailMessageCount[$store] = count($messages);
 
     // Ignore previously seen messages.
     if ($new) {
-      $messages = array_slice($messages, $previousCount);
+      $messages = array_slice($messages, $previous_count);
     }
 
     // Filter messages based on $matches; keep only mail where each field
@@ -138,20 +138,20 @@ class RawMailContext extends RawDrupalContext {
    */
   protected function compareMessages(array $actualMessages, array $expectedMessages) {
     // Make sure there is the same number of actual and expected.
-    $expectedCount = count($expectedMessages);
-    $this->assertMessageCount($actualMessages, $expectedCount);
+    $expected_count = count($expectedMessages);
+    $this->assertMessageCount($actualMessages, $expected_count);
 
     // For each row of expected mail, check the corresponding actual mail.
     // Make the comparison insensitive to the order mails were sent.
     $actualMessages = $this->sortMessages($actualMessages);
     $expectedMessages = $this->sortMessages($expectedMessages);
-    foreach ($expectedMessages as $index => $expectedMailItem) {
+    foreach ($expectedMessages as $index => $expected_mail_item) {
       // For each column of the expected, check the field of the actual mail.
-      foreach ($expectedMailItem as $fieldName => $fieldValue) {
-        $expectedField = [$fieldName => $fieldValue];
-        $isMatch = $this->matchMessage($actualMessages[$index], $expectedField);
-        if (!$isMatch) {
-          throw new \Exception(sprintf("The #%s mail did not have '%s' in its %s field. It had:\n'%s'", $index, $fieldValue, $fieldName, mb_strimwidth((string) $actualMessages[$index][$fieldName], 0, 30, "...")));
+      foreach ($expected_mail_item as $field_name => $field_value) {
+        $expected_field = [$field_name => $field_value];
+        $is_match = $this->matchMessage($actualMessages[$index], $expected_field);
+        if (!$is_match) {
+          throw new \Exception(sprintf("The #%s mail did not have '%s' in its %s field. It had:\n'%s'", $index, $field_value, $field_name, mb_strimwidth((string) $actualMessages[$index][$field_name], 0, 30, "...")));
         }
       }
     }
@@ -166,23 +166,23 @@ class RawMailContext extends RawDrupalContext {
    *   Optional. The number of mails expected.
    */
   protected function assertMessageCount(array $actualMessages, ?int $expectedCount = NULL) {
-    $actualCount = count($actualMessages);
+    $actual_count = count($actualMessages);
     if (is_null($expectedCount)) {
       // If number to expect is not specified, expect more than zero.
-      if ($actualCount === 0) {
+      if ($actual_count === 0) {
         throw new \Exception("Expected some mail, but none found.");
       }
     }
-    elseif ($expectedCount !== $actualCount) {
+    elseif ($expectedCount !== $actual_count) {
       // Prepare a simple list of actual mail.
-      $formattedActualMessages = [];
-      foreach ($actualMessages as $actualMessage) {
-        $formattedActualMessages[] = [
-          'to' => $actualMessage['to'],
-          'subject' => $actualMessage['subject'],
+      $formatted_actual_messages = [];
+      foreach ($actualMessages as $actual_message) {
+        $formatted_actual_messages[] = [
+          'to' => $actual_message['to'],
+          'subject' => $actual_message['subject'],
         ];
       }
-      throw new \Exception(sprintf("Expected %s mail, but %s found:\n\n%s", $expectedCount, $actualCount, print_r($formattedActualMessages, TRUE)));
+      throw new \Exception(sprintf("Expected %s mail, but %s found:\n\n%s", $expectedCount, $actual_count, print_r($formatted_actual_messages, TRUE)));
     }
   }
 
@@ -212,13 +212,13 @@ class RawMailContext extends RawDrupalContext {
    * Get the mink context, so we can visit pages using the mink session.
    */
   protected function getMinkContext(): object {
-    $minkContext = $this->getContext(RawMinkContext::class);
+    $mink_context = $this->getContext(RawMinkContext::class);
 
-    if ($minkContext === FALSE) {
+    if ($mink_context === FALSE) {
       throw new \Exception('No mink context found.');
     }
 
-    return $minkContext;
+    return $mink_context;
   }
 
 }

--- a/src/Drupal/DrupalExtension/Element/DocumentElement.php
+++ b/src/Drupal/DrupalExtension/Element/DocumentElement.php
@@ -65,17 +65,17 @@ class DocumentElement extends TraversableElement {
       // To simulate what the user sees, it removes:
       // - all text inside the head tags
       // - Drupal settings json.
-      $rawContent = preg_replace([
+      $raw_content = preg_replace([
         '@<head>(.+?)</head>@si',
         '@<script type="application/json" data-drupal-selector="drupal-settings-json">([^<]*)</script>@',
       ], '', $this->getContent());
       // Filter out all HTML tags, as they are not visible in a normal browser.
-      $text = strip_tags((string) $rawContent);
+      $text = strip_tags((string) $raw_content);
       // To preserve BC and match \Behat\Mink\Element\Element::getText() include
       // the page title.
-      $titleElement = $this->find('css', 'title');
-      if ($titleElement) {
-        $text = $titleElement->getText() . ' ' . $text;
+      $title_element = $this->find('css', 'title');
+      if ($title_element) {
+        $text = $title_element->getText() . ' ' . $text;
       }
       // To match what the user sees and \Behat\Mink\Element\Element::getText()
       // decode HTML entities.

--- a/src/Drupal/DrupalExtension/FeatureTrait.php
+++ b/src/Drupal/DrupalExtension/FeatureTrait.php
@@ -12,7 +12,7 @@ use Behat\Behat\Hook\Scope\BeforeStepScope;
  *
  * @see https://github.com/Behat/Behat/issues/653
  * @see https://github.com/Behat/Behat/issues/650
- * The solution is documented in this issue: https://github.com/Behat/Behat/issues/703#issuecomment-86687563
+ * @see https://github.com/Behat/Behat/issues/703#issuecomment-86687563
  */
 trait FeatureTrait {
 

--- a/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
@@ -45,8 +45,8 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
     $session = $this->getSession();
 
     // Navigate to the login page.
-    $loginUrl = $this->locatePath($this->getDrupalText('login_url'));
-    $session->visit($loginUrl);
+    $login_url = $this->locatePath($this->getDrupalText('login_url'));
+    $session->visit($login_url);
 
     // Fill in the login form credentials.
     $page = $session->getPage();
@@ -54,29 +54,29 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
     $page->fillField($this->getDrupalText('password_field'), $user->pass);
 
     // Submit the login form.
-    $loginElement = $this->getLoginElement($page);
-    if (empty($loginElement)) {
+    $login_element = $this->getLoginElement($page);
+    if (empty($login_element)) {
       throw new \Exception(sprintf('No submit button at %s', $session->getCurrentUrl()));
     }
-    $loginElement->click();
+    $login_element->click();
 
     // Wait for the browser to load after login, if configured.
-    $loginWait = $this->getDrupalParameter('login_wait');
-    if ($loginWait > 0) {
+    $login_wait = $this->getDrupalParameter('login_wait');
+    if ($login_wait > 0) {
       // Wait for URL change after login (redirect away from login form).
-      $timeout = microtime(TRUE) + $loginWait;
-      while (microtime(TRUE) < $timeout && $session->getCurrentUrl() === $loginUrl) {
+      $timeout = microtime(TRUE) + $login_wait;
+      while (microtime(TRUE) < $timeout && $session->getCurrentUrl() === $login_url) {
         usleep(100000);
       }
 
       // Wait for page body to render.
-      $timeout = microtime(TRUE) + $loginWait;
+      $timeout = microtime(TRUE) + $login_wait;
       while (microtime(TRUE) < $timeout && !$session->getPage()->find('css', 'body')) {
         usleep(100000);
       }
 
       // Wait for the logged-in selector to appear (may be added by JS/AJAX).
-      $timeout = microtime(TRUE) + $loginWait;
+      $timeout = microtime(TRUE) + $login_wait;
       while (microtime(TRUE) < $timeout && !$session->getPage()->has('css', $this->getDrupalSelector('logged_in_selector'))) {
         usleep(100000);
       }
@@ -102,20 +102,20 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
   public function logout(): void {
     $session = $this->getSession();
 
-    $logoutUrl = $this->locatePath($this->getDrupalText('logout_url'));
-    $logoutConfirmUrl = $this->locatePath($this->getDrupalText('logout_confirm_url'));
+    $logout_url = $this->locatePath($this->getDrupalText('logout_url'));
+    $logout_confirm_url = $this->locatePath($this->getDrupalText('logout_confirm_url'));
 
-    $session->visit($logoutUrl);
+    $session->visit($logout_url);
 
     // Check to see if the user is on the logout confirm page (10.3+).
-    if ($session->getCurrentUrl() === $logoutConfirmUrl) {
-      $logoutElement = $this->getLogoutConfirmElement($session->getPage());
+    if ($session->getCurrentUrl() === $logout_confirm_url) {
+      $logout_element = $this->getLogoutConfirmElement($session->getPage());
 
-      if (empty($logoutElement)) {
+      if (empty($logout_element)) {
         throw new \Exception(sprintf("Unable to determine if logged out because '%s' button cannot be found on the logout confirmation page at %s", $this->getDrupalText('log_out'), $session->getCurrentUrl()));
       }
 
-      $logoutElement->click();
+      $logout_element->click();
     }
 
     // Reset the currently tracked user.
@@ -156,8 +156,8 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
 
     // Some themes do not add that class to the body, so check if the login
     // form is displayed (defaults to /user/login).
-    $loginUrl = $this->locatePath($this->getDrupalText('login_url'));
-    $session->visit($loginUrl);
+    $login_url = $this->locatePath($this->getDrupalText('login_url'));
+    $session->visit($login_url);
     if ($page->has('css', $this->getDrupalSelector('login_form_selector'))) {
       $this->fastLogout();
       return FALSE;

--- a/src/Drupal/DrupalExtension/MinkAwareTrait.php
+++ b/src/Drupal/DrupalExtension/MinkAwareTrait.php
@@ -120,8 +120,8 @@ trait MinkAwareTrait {
   /**
    * Visits provided relative path using provided or default session.
    */
-  public function visitPath(string $path, ?string $sessionName = NULL): void {
-    $this->getSession($sessionName)->visit($this->locatePath($path));
+  public function visitPath(string $path, ?string $session_name = NULL): void {
+    $this->getSession($session_name)->visit($this->locatePath($path));
   }
 
   /**
@@ -130,9 +130,9 @@ trait MinkAwareTrait {
    * Override to provide custom routing mechanism.
    */
   public function locatePath(string $path): string {
-    $startUrl = rtrim($this->getMinkParameter('base_url'), '/') . '/';
+    $start_url = rtrim($this->getMinkParameter('base_url'), '/') . '/';
 
-    return str_starts_with($path, 'http') ? $path : $startUrl . ltrim($path, '/');
+    return str_starts_with($path, 'http') ? $path : $start_url . ltrim($path, '/');
   }
 
   /**

--- a/src/Drupal/DrupalExtension/RegionTrait.php
+++ b/src/Drupal/DrupalExtension/RegionTrait.php
@@ -23,12 +23,12 @@ trait RegionTrait {
    */
   public function getRegion(string $region) {
     $session = $this->getSession();
-    $regionObj = $session->getPage()->find('region', $region);
-    if (!$regionObj) {
+    $region_obj = $session->getPage()->find('region', $region);
+    if (!$region_obj) {
       throw new \Exception(sprintf('No region "%s" found on the page %s.', $region, $session->getCurrentUrl()));
     }
 
-    return $regionObj;
+    return $region_obj;
   }
 
 }

--- a/src/Drupal/DrupalExtension/ScenarioTrait.php
+++ b/src/Drupal/DrupalExtension/ScenarioTrait.php
@@ -12,7 +12,7 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
  *
  * @see https://github.com/Behat/Behat/issues/653
  * @see https://github.com/Behat/Behat/issues/650
- * The solution is documented in this issue: https://github.com/Behat/Behat/issues/703#issuecomment-86687563
+ * @see https://github.com/Behat/Behat/issues/703#issuecomment-86687563
  */
 trait ScenarioTrait {
 

--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -324,16 +324,16 @@ class DrupalExtension implements ExtensionInterface {
    * Process the Driver Pass.
    */
   protected function processDriverPass(ContainerBuilder $container): void {
-    $driverPass = new DriverPass();
-    $driverPass->process($container);
+    $driver_pass = new DriverPass();
+    $driver_pass->process($container);
   }
 
   /**
    * Process the Event Subscriber Pass.
    */
   protected function processEventSubscriberPass(ContainerBuilder $container): void {
-    $eventSubscriberPass = new EventSubscriberPass();
-    $eventSubscriberPass->process($container);
+    $event_subscriber_pass = new EventSubscriberPass();
+    $event_subscriber_pass->process($container);
   }
 
   /**

--- a/src/Drupal/DrupalExtension/TagTrait.php
+++ b/src/Drupal/DrupalExtension/TagTrait.php
@@ -17,9 +17,9 @@ trait TagTrait {
    *   An array of tag strings.
    */
   protected function getTags(): array {
-    $featureTags = $this->getFeature()->getTags();
-    $scenarioTags = $this->getScenario()->getTags();
-    return array_unique(array_merge($featureTags, $scenarioTags));
+    $feature_tags = $this->getFeature()->getTags();
+    $scenario_tags = $this->getScenario()->getTags();
+    return array_unique(array_merge($feature_tags, $scenario_tags));
   }
 
   /**

--- a/src/Drupal/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
+++ b/src/Drupal/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
@@ -28,10 +28,10 @@ class BrowserKitFactory extends BrowserKitFactoryOriginal {
       // @codeCoverageIgnoreEnd
     }
 
-    $drupalFinder = new DrupalFinder();
-    $drupalFinder->locateRoot($this->getCwd());
-    $drupalRoot = $drupalFinder->getDrupalRoot();
-    require_once $drupalRoot . '/core/tests/Drupal/Tests/DrupalTestBrowser.php';
+    $drupal_finder = new DrupalFinder();
+    $drupal_finder->locateRoot($this->getCwd());
+    $drupal_root = $drupal_finder->getDrupalRoot();
+    require_once $drupal_root . '/core/tests/Drupal/Tests/DrupalTestBrowser.php';
 
     if (!class_exists('Drupal\Tests\DrupalTestBrowser')) {
       // @codeCoverageIgnoreStart
@@ -41,17 +41,17 @@ class BrowserKitFactory extends BrowserKitFactoryOriginal {
       // @codeCoverageIgnoreEnd
     }
 
-    $guzzleRequestOptions = $config['guzzle_request_options'] ?? [
+    $guzzle_request_options = $config['guzzle_request_options'] ?? [
       'allow_redirects' => FALSE,
       'cookies' => TRUE,
     ];
 
-    $guzzleClientService = new Definition(Client::class, [$guzzleRequestOptions]);
-    $testBrowserService = (new Definition('Drupal\Tests\DrupalTestBrowser'))
-      ->addMethodCall('setClient', [$guzzleClientService]);
+    $guzzle_client_service = new Definition(Client::class, [$guzzle_request_options]);
+    $test_browser_service = (new Definition('Drupal\Tests\DrupalTestBrowser'))
+      ->addMethodCall('setClient', [$guzzle_client_service]);
 
     return new Definition(BrowserKitDriver::class, [
-      $testBrowserService,
+      $test_browser_service,
       '%mink.base_url%',
     ]);
   }

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -89,11 +89,11 @@ trait BehatCliTrait {
     $content = strtr((string) $content, ["'''" => '"""']);
 
     // Make sure that indentation in provided content is accurate.
-    $contentLines = explode(PHP_EOL, $content);
-    foreach ($contentLines as $k => $contentLine) {
-      $contentLines[$k] = str_repeat(' ', 4) . trim($contentLine);
+    $content_lines = explode(PHP_EOL, $content);
+    foreach ($content_lines as $k => $content_line) {
+      $content_lines[$k] = str_repeat(' ', 4) . trim($content_line);
     }
-    $content = implode(PHP_EOL, $contentLines);
+    $content = implode(PHP_EOL, $content_lines);
 
     $tokens = [
       '{{SCENARIO_CONTENT}}' => $content,
@@ -157,7 +157,7 @@ EOL;
       // Update the code coverage configuration to use an alternative
       // coverage report target. This report is merged into a single report
       // with scripts/merge-coverage.php.
-      $coverageId = md5($this->workingDir);
+      $coverage_id = md5($this->workingDir);
       $yaml['default']['extensions'][Extension::class] = [
         'filter' => [
           'include' => [
@@ -172,7 +172,7 @@ EOL;
             'showOnlySummary' => TRUE,
           ],
           'php' => [
-            'target' => '/var/www/html/.logs/coverage/behat_cli/phpcov/' . $coverageId . '.php',
+            'target' => '/var/www/html/.logs/coverage/behat_cli/phpcov/' . $coverage_id . '.php',
           ],
         ],
       ];
@@ -186,12 +186,12 @@ EOL;
     // Resolve the drush binary to an absolute path so subprocess tests
     // can find it regardless of their working directory.
     // The source behat.yml is at /var/www/html, so resolve relative to that.
-    $projectRoot = dirname($source);
-    $drushBinary = $projectRoot . '/vendor/bin/drush';
-    if (file_exists($drushBinary)) {
+    $project_root = dirname($source);
+    $drush_binary = $project_root . '/vendor/bin/drush';
+    if (file_exists($drush_binary)) {
       foreach (['default', 'drupal', 'drupal_https'] as $profile) {
         if (isset($yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush'])) {
-          $yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush']['binary'] = $drushBinary;
+          $yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush']['binary'] = $drush_binary;
         }
       }
     }
@@ -207,7 +207,7 @@ EOL;
   }
 
   /**
-   * Asserts that behat failed with an assertion error matching the given message.
+   * Asserts that behat failed with the given assertion error.
    */
   #[Then('it should fail with an error:')]
   public function behatCliAssertFailWithError(PyStringNode $message): void {
@@ -215,9 +215,9 @@ EOL;
 
     $output = $this->getOutput();
 
-    $hasValidException = str_contains((string) $output, ' (Exception)') || str_contains((string) $output, ' (Behat\Mink\Exception');
+    $has_valid_exception = str_contains((string) $output, ' (Exception)') || str_contains((string) $output, ' (Behat\Mink\Exception');
 
-    if (!$hasValidException) {
+    if (!$has_valid_exception) {
       throw new \RuntimeException('The output does not contain an assertion exception string as expected.');
     }
 
@@ -248,15 +248,15 @@ EOL;
    */
   #[When('I run behat with drupal profile and :key set to :value')]
   public function behatCliRunWithDrupalProfileAndConfig(string $key, string $value):void {
-    $configFile = $this->workingDir . DIRECTORY_SEPARATOR . 'behat.yml';
-    $yaml = Yaml::parse(file_get_contents($configFile));
+    $config_file = $this->workingDir . DIRECTORY_SEPARATOR . 'behat.yml';
+    $yaml = Yaml::parse(file_get_contents($config_file));
     $yaml['drupal']['extensions']['Drupal\DrupalExtension'][$key] = is_numeric($value) ? (int) $value : $value;
-    file_put_contents($configFile, Yaml::dump($yaml, 4, 2));
+    file_put_contents($config_file, Yaml::dump($yaml, 4, 2));
     $this->iRunBehat('--profile=drupal --no-colors');
   }
 
   /**
-   * Asserts that behat failed with a RuntimeException matching the given message.
+   * Asserts that behat failed with the given RuntimeException.
    */
   #[Then('it should fail with an exception:')]
   public function behatCliAssertFailWithException(PyStringNode $message): void {
@@ -268,7 +268,7 @@ EOL;
   }
 
   /**
-   * Asserts that behat failed with a specific exception class matching the given message.
+   * Asserts that behat failed with the given exception class.
    */
   #[Then('it should fail with a :exception exception:')]
   public function behatCliAssertFailWithCustomException(string $exception, PyStringNode $message): void {
@@ -342,16 +342,16 @@ EOL;
    * Copy fixtures to the working directory.
    */
   protected function behatCliCopyFixtures() {
-    $fixturePathRel = 'tests/behat/fixtures';
+    $fixture_path_rel = 'tests/behat/fixtures';
 
     // @note Hardcoded path to the fixture directory.
-    $fixturePathAbs = '/var/www/html/' . DIRECTORY_SEPARATOR . $fixturePathRel;
+    $fixture_path_abs = '/var/www/html/' . DIRECTORY_SEPARATOR . $fixture_path_rel;
 
-    if (is_dir($fixturePathAbs)) {
-      $dst = $this->workingDir . DIRECTORY_SEPARATOR . $fixturePathRel;
+    if (is_dir($fixture_path_abs)) {
+      $dst = $this->workingDir . DIRECTORY_SEPARATOR . $fixture_path_rel;
       mkdir($dst, 0777, TRUE);
 
-      foreach (glob($fixturePathAbs . '/*') as $file) {
+      foreach (glob($fixture_path_abs . '/*') as $file) {
         // @note Only copy files for speed.
         if (is_file($file)) {
           $filename = basename($file);

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -58,12 +58,12 @@ class FeatureContext extends RawDrupalContext {
    */
   #[BeforeScenario]
   public function testStopSessionsBeforeSubProcess(BeforeScenarioScope $scope): void {
-    $hasTraitTag = (bool) array_filter($scope->getScenario()->getTags(), fn(string $tag): bool => str_starts_with($tag, 'javascript'));
+    $has_trait_tag = (bool) array_filter($scope->getScenario()->getTags(), fn(string $tag): bool => str_starts_with($tag, 'javascript'));
 
     // Stop all Mink sessions before sub-process scenarios to prevent
     // connection interference between parent and child processes.
     // @see \Behat\MinkExtension\Listener\SessionsListener::prepareDefaultMinkSession().
-    if ($hasTraitTag) {
+    if ($has_trait_tag) {
       $this->getMink()->stopSessions();
     }
   }
@@ -218,12 +218,12 @@ class FeatureContext extends RawDrupalContext {
 
     // The first row of the table contains the field names.
     $table = $user_table->getTable();
-    $firstRow = array_key_first($table);
+    $first_row = array_key_first($table);
 
     // Replace the aliased field names with the actual ones.
-    foreach ($table[$firstRow] as $key => $alias) {
+    foreach ($table[$first_row] as $key => $alias) {
       if (array_key_exists($alias, $aliases)) {
-        $table[$firstRow][$key] = $aliases[$alias];
+        $table[$first_row][$key] = $aliases[$alias];
       }
     }
 
@@ -343,9 +343,9 @@ class FeatureContext extends RawDrupalContext {
    */
   #[Given('the request time is :seconds seconds in the past')]
   public function testSetStaleRequestTime(int $seconds): void {
-    $staleTime = time() - $seconds;
-    $_SERVER['REQUEST_TIME'] = $staleTime;
-    \Drupal::request()->server->set('REQUEST_TIME', $staleTime);
+    $stale_time = time() - $seconds;
+    $_SERVER['REQUEST_TIME'] = $stale_time;
+    \Drupal::request()->server->set('REQUEST_TIME', $stale_time);
   }
 
   /**
@@ -363,10 +363,10 @@ class FeatureContext extends RawDrupalContext {
       throw new \RuntimeException('Cron time drift was not recorded. Ensure the behat_test module is enabled.');
     }
     if (abs($drift) >= $seconds) {
-      $requestTime = \Drupal::state()->get('behat_test.cron_request_time');
-      $actualTime = \Drupal::state()->get('behat_test.cron_actual_time');
+      $request_time = \Drupal::state()->get('behat_test.cron_request_time');
+      $actual_time = \Drupal::state()->get('behat_test.cron_actual_time');
       throw new ExpectationException(
-        sprintf('Cron request time drift is %d seconds (request_time=%d, actual_time=%d), expected less than %d.', $drift, $requestTime, $actualTime, $seconds),
+        sprintf('Cron request time drift is %d seconds (request_time=%d, actual_time=%d), expected less than %d.', $drift, $request_time, $actual_time, $seconds),
         $this->getSession()->getDriver()
       );
     }
@@ -464,22 +464,22 @@ class FeatureContext extends RawDrupalContext {
 
     /** @var \Drupal\Core\Entity\FieldableEntityInterface $term */
     $term = reset($terms);
-    $parentValues = $term->get('parent')->getValue();
-    $parentTid = (int) ($parentValues[0]['target_id'] ?? 0);
+    $parent_values = $term->get('parent')->getValue();
+    $parent_tid = (int) ($parent_values[0]['target_id'] ?? 0);
 
-    if ($parentTid === 0) {
+    if ($parent_tid === 0) {
       throw new ExpectationException(sprintf('Term "%s" has no parent, expected "%s".', $name, $parentName), $this->getSession()->getDriver());
     }
 
-    $parentTerm = $storage->load($parentTid);
+    $parent_term = $storage->load($parent_tid);
 
-    if (!$parentTerm) {
-      throw new ExpectationException(sprintf('Parent term with tid %d not found for term "%s".', $parentTid, $name), $this->getSession()->getDriver());
+    if (!$parent_term) {
+      throw new ExpectationException(sprintf('Parent term with tid %d not found for term "%s".', $parent_tid, $name), $this->getSession()->getDriver());
     }
 
-    $actualParentName = $parentTerm->label();
-    if ($actualParentName !== $parentName) {
-      throw new ExpectationException(sprintf('Term "%s" has parent "%s", expected "%s".', $name, $actualParentName, $parentName), $this->getSession()->getDriver());
+    $actual_parent_name = $parent_term->label();
+    if ($actual_parent_name !== $parentName) {
+      throw new ExpectationException(sprintf('Term "%s" has parent "%s", expected "%s".', $name, $actual_parent_name, $parentName), $this->getSession()->getDriver());
     }
   }
 
@@ -646,9 +646,9 @@ class BehatTestAddressFieldHandler extends AbstractHandler {
     $row = [];
     $position = 0;
 
-    foreach ($value as $key => $fieldValue) {
+    foreach ($value as $key => $field_value) {
       if (is_string($key)) {
-        $row[$key] = $fieldValue;
+        $row[$key] = $field_value;
         continue;
       }
 
@@ -656,7 +656,7 @@ class BehatTestAddressFieldHandler extends AbstractHandler {
         throw new \RuntimeException(sprintf('Too many positional values supplied for "behat_test_address_field"; only %d columns available.', count($columns)));
       }
 
-      $row[$columns[$position]] = $fieldValue;
+      $row[$columns[$position]] = $field_value;
       $position++;
     }
 

--- a/tests/phpunit/src/BehatDistYmlTest.php
+++ b/tests/phpunit/src/BehatDistYmlTest.php
@@ -32,9 +32,9 @@ class BehatDistYmlTest extends TestCase {
    */
   public static function setUpBeforeClass(): void {
     parent::setUpBeforeClass();
-    $distFile = dirname(__DIR__, 3) . '/behat.dist.yml';
-    self::assertFileExists($distFile);
-    self::$distConfig = Yaml::parseFile($distFile);
+    $dist_file = dirname(__DIR__, 3) . '/behat.dist.yml';
+    self::assertFileExists($dist_file);
+    self::$distConfig = Yaml::parseFile($dist_file);
   }
 
   /**
@@ -51,17 +51,17 @@ class BehatDistYmlTest extends TestCase {
    * Processes the dist file values through the actual config tree builder
    * to ensure all keys are recognized by the schema.
    */
-  #[DataProvider('dataProviderProfiles')]
+  #[DataProvider('dataProviderDrupalExtensionConfigIsValid')]
   public function testDrupalExtensionConfigIsValid(string $profile): void {
-    $distValues = self::$distConfig[$profile]['extensions']['Drupal\DrupalExtension'] ?? [];
-    if ($distValues === NULL) {
-      $distValues = [];
+    $dist_values = self::$distConfig[$profile]['extensions']['Drupal\DrupalExtension'] ?? [];
+    if ($dist_values === NULL) {
+      $dist_values = [];
     }
 
     $tree = $this->buildDrupalExtensionTree();
 
     // Process through the real config tree — throws on unknown keys.
-    $processed = $tree->finalize($tree->normalize($distValues));
+    $processed = $tree->finalize($tree->normalize($dist_values));
     $this->assertIsArray($processed);
   }
 
@@ -72,20 +72,20 @@ class BehatDistYmlTest extends TestCase {
    * in at least one profile's dist file section.
    */
   public function testDistCoversAllDrupalExtensionKeys(): void {
-    $allDistKeys = [];
+    $all_dist_keys = [];
     foreach (self::$distConfig as $profile) {
       $values = $profile['extensions']['Drupal\DrupalExtension'] ?? [];
       if (is_array($values)) {
-        $allDistKeys = array_merge($allDistKeys, array_keys($values));
+        $all_dist_keys = array_merge($all_dist_keys, array_keys($values));
       }
     }
-    $allDistKeys = array_unique($allDistKeys);
+    $all_dist_keys = array_unique($all_dist_keys);
 
     $tree = $this->buildDrupalExtensionTree();
 
-    $schemaKeys = array_keys($tree->getChildren());
-    foreach ($schemaKeys as $key) {
-      $this->assertContains($key, $allDistKeys, sprintf('behat.dist.yml missing DrupalExtension key "%s" in all profiles.', $key));
+    $schema_keys = array_keys($tree->getChildren());
+    foreach ($schema_keys as $key) {
+      $this->assertContains($key, $all_dist_keys, sprintf('behat.dist.yml missing DrupalExtension key "%s" in all profiles.', $key));
     }
   }
 
@@ -96,11 +96,11 @@ class BehatDistYmlTest extends TestCase {
    * The MinkExtension requires at least one session to be defined.
    */
   public function testMinkExtensionConfigIsValid(): void {
-    $distValues = self::$distConfig['default']['extensions']['Drupal\MinkExtension'] ?? [];
+    $dist_values = self::$distConfig['default']['extensions']['Drupal\MinkExtension'] ?? [];
 
     $tree = $this->buildMinkExtensionTree();
 
-    $processed = $tree->finalize($tree->normalize($distValues));
+    $processed = $tree->finalize($tree->normalize($dist_values));
     $this->assertIsArray($processed);
     $this->assertArrayHasKey('ajax_timeout', $processed);
   }
@@ -113,18 +113,18 @@ class BehatDistYmlTest extends TestCase {
    * (e.g., "browserkit_http: ~") and is excluded from this check.
    */
   public function testDistCoversAllMinkExtensionKeys(): void {
-    $distValues = self::$distConfig['default']['extensions']['Drupal\MinkExtension'] ?? [];
+    $dist_values = self::$distConfig['default']['extensions']['Drupal\MinkExtension'] ?? [];
 
     $tree = $this->buildMinkExtensionTree();
 
     // Sessions are populated via shortcut syntax normalization, so exclude
     // them from the direct key check. Also exclude internal keys that are
     // not meant for end-user configuration.
-    $skipKeys = ['sessions', 'mink_loader', 'default_session'];
-    $schemaKeys = array_diff(array_keys($tree->getChildren()), $skipKeys);
+    $skip_keys = ['sessions', 'mink_loader', 'default_session'];
+    $schema_keys = array_diff(array_keys($tree->getChildren()), $skip_keys);
 
-    foreach ($schemaKeys as $key) {
-      $this->assertArrayHasKey($key, $distValues, sprintf('behat.dist.yml default profile missing MinkExtension key "%s".', $key));
+    foreach ($schema_keys as $key) {
+      $this->assertArrayHasKey($key, $dist_values, sprintf('behat.dist.yml default profile missing MinkExtension key "%s".', $key));
     }
   }
 
@@ -153,7 +153,7 @@ class BehatDistYmlTest extends TestCase {
   /**
    * Data provider for profile-level tests.
    */
-  public static function dataProviderProfiles(): \Iterator {
+  public static function dataProviderDrupalExtensionConfigIsValid(): \Iterator {
     yield 'default profile' => ['default'];
     yield 'drupal profile' => ['drupal'];
   }

--- a/tests/phpunit/src/BrowserKitFactoryTest.php
+++ b/tests/phpunit/src/BrowserKitFactoryTest.php
@@ -73,19 +73,19 @@ class BrowserKitFactoryTest extends TestCase {
     $this->assertSame('%mink.base_url%', $args[1]);
 
     // Verify the test browser service definition.
-    $testBrowser = $args[0];
-    $this->assertInstanceOf(Definition::class, $testBrowser);
-    $this->assertSame('Drupal\Tests\DrupalTestBrowser', $testBrowser->getClass());
+    $test_browser = $args[0];
+    $this->assertInstanceOf(Definition::class, $test_browser);
+    $this->assertSame('Drupal\Tests\DrupalTestBrowser', $test_browser->getClass());
 
     // Verify the Guzzle client service definition.
-    $methodCalls = $testBrowser->getMethodCalls();
-    $this->assertCount(1, $methodCalls);
-    $this->assertSame('setClient', $methodCalls[0][0]);
+    $method_calls = $test_browser->getMethodCalls();
+    $this->assertCount(1, $method_calls);
+    $this->assertSame('setClient', $method_calls[0][0]);
 
-    $guzzleDefinition = $methodCalls[0][1][0];
-    $this->assertInstanceOf(Definition::class, $guzzleDefinition);
-    $this->assertSame(Client::class, $guzzleDefinition->getClass());
-    $this->assertSame($expected_guzzle_options, $guzzleDefinition->getArguments()[0]);
+    $guzzle_definition = $method_calls[0][1][0];
+    $this->assertInstanceOf(Definition::class, $guzzle_definition);
+    $this->assertSame(Client::class, $guzzle_definition->getClass());
+    $this->assertSame($expected_guzzle_options, $guzzle_definition->getArguments()[0]);
   }
 
   /**

--- a/tests/phpunit/src/ConfigContextTest.php
+++ b/tests/phpunit/src/ConfigContextTest.php
@@ -45,8 +45,8 @@ class ConfigContextTest extends TestCase {
    */
   #[DataProvider('dataProviderSetBasicConfigBackup')]
   public function testSetBasicConfigBackup(array $operations, array $expected_backup): void {
-    $getReturns = array_column($operations, 'original');
-    $this->driver->method('configGetOriginal')->willReturnOnConsecutiveCalls(...$getReturns);
+    $get_returns = array_column($operations, 'original');
+    $this->driver->method('configGetOriginal')->willReturnOnConsecutiveCalls(...$get_returns);
     $this->driver->method('configSet');
 
     foreach ($operations as $operation) {
@@ -100,17 +100,17 @@ class ConfigContextTest extends TestCase {
   public function testCleanConfigRestoresAllValues(): void {
     $this->driver->method('configGetOriginal')->willReturn('Original');
 
-    $setArgs = [];
+    $set_args = [];
     $this->driver->method('configSet')
-      ->willReturnCallback(function (string $name, string $key, mixed $value) use (&$setArgs): void {
-                $setArgs[] = [$name, $key, $value];
+      ->willReturnCallback(function (string $name, string $key, mixed $value) use (&$set_args): void {
+                $set_args[] = [$name, $key, $value];
       });
 
     $this->context->setBasicConfig('system.site', 'name', 'New Name');
     $this->context->cleanConfig();
 
-    $restoreCall = end($setArgs);
-    $this->assertSame(['system.site', 'name', 'Original'], $restoreCall);
+    $restore_call = end($set_args);
+    $this->assertSame(['system.site', 'name', 'Original'], $restore_call);
 
     $config = new \ReflectionProperty(ConfigContext::class, 'config');
     $this->assertSame([], $config->getValue($this->context));

--- a/tests/phpunit/src/DocsTest.php
+++ b/tests/phpunit/src/DocsTest.php
@@ -43,11 +43,11 @@ class DocsTest extends TestCase {
     require_once __DIR__ . '/../../../scripts/docs.php';
 
     // Pre-load all fixture context classes.
-    $fixturesDir = __DIR__ . '/../fixtures/docs';
-    $fixtureFiles = glob($fixturesDir . '/*.php');
-    if ($fixtureFiles !== FALSE) {
-      foreach ($fixtureFiles as $fixtureFile) {
-        require_once $fixtureFile;
+    $fixtures_dir = __DIR__ . '/../fixtures/docs';
+    $fixture_files = glob($fixtures_dir . '/*.php');
+    if ($fixture_files !== FALSE) {
+      foreach ($fixture_files as $fixture_file) {
+        require_once $fixture_file;
       }
     }
 
@@ -430,18 +430,18 @@ EOD,
       $this->expectExceptionMessage($exception);
     }
 
-    $basePath = static::$tmp;
+    $base_path = static::$tmp;
 
     // Create temporary files for testing.
-    $srcDir = $basePath . DIRECTORY_SEPARATOR . 'src';
-    $featuresDir = $basePath . DIRECTORY_SEPARATOR . 'tests/behat/features';
+    $src_dir = $base_path . DIRECTORY_SEPARATOR . 'src';
+    $features_dir = $base_path . DIRECTORY_SEPARATOR . 'tests/behat/features';
 
     // Ensure directories exist.
-    if (!is_dir($srcDir)) {
-      mkdir($srcDir, 0777, TRUE);
+    if (!is_dir($src_dir)) {
+      mkdir($src_dir, 0777, TRUE);
     }
-    if (!is_dir($featuresDir)) {
-      mkdir($featuresDir, 0777, TRUE);
+    if (!is_dir($features_dir)) {
+      mkdir($features_dir, 0777, TRUE);
     }
 
     // Create sample files that the function will check for existence.
@@ -453,39 +453,39 @@ EOD,
 
       if ($class !== 'MissingContext') {
         // Create the source file.
-        $srcFile = sprintf('src/%s.php', $class);
-        $srcFilePath = $basePath . DIRECTORY_SEPARATOR . $srcFile;
-        file_put_contents($srcFilePath, '<?php');
+        $src_file = sprintf('src/%s.php', $class);
+        $src_file_path = $base_path . DIRECTORY_SEPARATOR . $src_file;
+        file_put_contents($src_file_path, '<?php');
       }
 
-      $exampleName = camel_to_snake(str_replace('Context', '', $class));
-      $exampleFile = sprintf('tests/behat/features/%s.feature', $exampleName);
-      $exampleFilePath = $basePath . DIRECTORY_SEPARATOR . $exampleFile;
-      file_put_contents($exampleFilePath, 'Feature: Test');
+      $example_name = camel_to_snake(str_replace('Context', '', $class));
+      $example_file = sprintf('tests/behat/features/%s.feature', $example_name);
+      $example_file_path = $base_path . DIRECTORY_SEPARATOR . $example_file;
+      file_put_contents($example_file_path, 'Feature: Test');
     }
 
     // For the missing file test.
     if (isset($info['MissingContext'])) {
-      $srcFilePath = $basePath . DIRECTORY_SEPARATOR . 'src/MissingContext.php';
-      @unlink($srcFilePath);
+      $src_file_path = $base_path . DIRECTORY_SEPARATOR . 'src/MissingContext.php';
+      @unlink($src_file_path);
     }
 
-    $actual = render_info($info, $basePath);
+    $actual = render_info($info, $base_path);
 
     // Only test for certain elements instead of exact formatting.
     if ($exception === NULL && !empty($info)) {
       // Verify index table exists.
       foreach ($info as $class => $data) {
-        $nameContextual = $data['name_contextual'] ?? $class;
-        $linkId = strtolower(preg_replace('/[^A-Za-z0-9_\-]/', '', $nameContextual));
-        $this->assertStringContainsString(sprintf("[%s](#%s)", $nameContextual, $linkId), $actual);
+        $name_contextual = $data['name_contextual'] ?? $class;
+        $link_id = strtolower(preg_replace('/[^A-Za-z0-9_\-]/', '', $name_contextual));
+        $this->assertStringContainsString(sprintf("[%s](#%s)", $name_contextual, $link_id), $actual);
         $this->assertStringContainsString($data['description'], $actual);
       }
 
       // Verify class sections exist.
       foreach ($info as $class => $data) {
-        $nameContextual = $data['name_contextual'] ?? $class;
-        $this->assertStringContainsString(sprintf("## %s", $nameContextual), $actual);
+        $name_contextual = $data['name_contextual'] ?? $class;
+        $this->assertStringContainsString(sprintf("## %s", $name_contextual), $actual);
         $this->assertStringContainsString("[Source](src", $actual);
 
         // Verify step details for each method.
@@ -509,8 +509,8 @@ EOD,
               else {
                 $example = is_string($method['example']) ? $method['example'] : (string) $method['example'];
                 if (!empty($example)) {
-                  $exampleLines = explode("\n", $example);
-                  foreach ($exampleLines as $line) {
+                  $example_lines = explode("\n", $example);
+                  foreach ($example_lines as $line) {
                     if (!empty(trim($line))) {
                       $this->assertStringContainsString($line, $actual);
                     }
@@ -628,18 +628,18 @@ EOD,
 
   #[DataProvider('dataProviderRenderInfoWithPathForLinks')]
   public function testRenderInfoWithPathForLinks(array $info, string $path_for_links): void {
-    $basePath = static::$tmp;
+    $base_path = static::$tmp;
 
     // Create temporary files for testing.
-    $srcDir = $basePath . DIRECTORY_SEPARATOR . 'src';
-    $featuresDir = $basePath . DIRECTORY_SEPARATOR . 'tests/behat/features';
+    $src_dir = $base_path . DIRECTORY_SEPARATOR . 'src';
+    $features_dir = $base_path . DIRECTORY_SEPARATOR . 'tests/behat/features';
 
     // Ensure directories exist.
-    if (!is_dir($srcDir)) {
-      mkdir($srcDir, 0777, TRUE);
+    if (!is_dir($src_dir)) {
+      mkdir($src_dir, 0777, TRUE);
     }
-    if (!is_dir($featuresDir)) {
-      mkdir($featuresDir, 0777, TRUE);
+    if (!is_dir($features_dir)) {
+      mkdir($features_dir, 0777, TRUE);
     }
 
     // Create sample files.
@@ -648,22 +648,22 @@ EOD,
         $info[$class]['name_contextual'] = $class;
       }
 
-      $srcFile = sprintf('src/%s.php', $class);
-      file_put_contents($basePath . DIRECTORY_SEPARATOR . $srcFile, '<?php');
+      $src_file = sprintf('src/%s.php', $class);
+      file_put_contents($base_path . DIRECTORY_SEPARATOR . $src_file, '<?php');
 
-      $exampleName = camel_to_snake(str_replace('Context', '', $class));
-      $exampleFile = sprintf('tests/behat/features/%s.feature', $exampleName);
-      file_put_contents($basePath . DIRECTORY_SEPARATOR . $exampleFile, 'Feature: Test');
+      $example_name = camel_to_snake(str_replace('Context', '', $class));
+      $example_file = sprintf('tests/behat/features/%s.feature', $example_name);
+      file_put_contents($base_path . DIRECTORY_SEPARATOR . $example_file, 'Feature: Test');
     }
 
-    $actual = render_info($info, $basePath, $path_for_links);
+    $actual = render_info($info, $base_path, $path_for_links);
 
     // Verify that the path_for_links is used in the index.
     foreach ($info as $class => $data) {
-      $nameContextual = $data['name_contextual'] ?? $class;
-      $linkId = strtolower(preg_replace('/[^A-Za-z0-9_\-]/', '', $nameContextual));
-      $expectedLink = sprintf("%s#%s", $path_for_links, $linkId);
-      $this->assertStringContainsString($expectedLink, $actual);
+      $name_contextual = $data['name_contextual'] ?? $class;
+      $link_id = strtolower(preg_replace('/[^A-Za-z0-9_\-]/', '', $name_contextual));
+      $expected_link = sprintf("%s#%s", $path_for_links, $link_id);
+      $this->assertStringContainsString($expected_link, $actual);
     }
 
     // When path_for_links is set, the actual content should not be rendered.
@@ -721,15 +721,15 @@ EOD,
       return;
     }
 
-    $className = array_key_first($info);
-    $this->assertArrayHasKey($className, $results);
+    $class_name = array_key_first($info);
+    $this->assertArrayHasKey($class_name, $results);
 
     if (empty($method_name)) {
       return;
     }
 
-    $this->assertArrayHasKey($method_name, $results[$className]['methods']);
-    $check = $results[$className]['methods'][$method_name][$check_key];
+    $this->assertArrayHasKey($method_name, $results[$class_name]['methods']);
+    $check = $results[$class_name]['methods'][$method_name][$check_key];
     $this->assertSame($expected_pass, $check['pass']);
     $this->assertSame($expected_messages, $check['messages']);
   }
@@ -1600,30 +1600,30 @@ EOD,
     array $exclude,
     array $expected_class_names,
   ): void {
-    $basePath = static::$tmp;
-    $contextDir = $basePath . DIRECTORY_SEPARATOR . 'src';
-    if (!is_dir($contextDir)) {
-      mkdir($contextDir, 0777, TRUE);
+    $base_path = static::$tmp;
+    $context_dir = $base_path . DIRECTORY_SEPARATOR . 'src';
+    if (!is_dir($context_dir)) {
+      mkdir($context_dir, 0777, TRUE);
     }
 
     // Copy fixture files to the context directory.
-    $fixturesDir = __DIR__ . '/../fixtures/docs';
-    foreach ($class_names as $className) {
-      $fixtureFile = $fixturesDir . DIRECTORY_SEPARATOR . $className . '.php';
-      if (file_exists($fixtureFile)) {
-        copy($fixtureFile, $contextDir . DIRECTORY_SEPARATOR . $className . '.php');
+    $fixtures_dir = __DIR__ . '/../fixtures/docs';
+    foreach ($class_names as $class_name) {
+      $fixture_file = $fixtures_dir . DIRECTORY_SEPARATOR . $class_name . '.php';
+      if (file_exists($fixture_file)) {
+        copy($fixture_file, $context_dir . DIRECTORY_SEPARATOR . $class_name . '.php');
       }
     }
 
-    $result = extract_info($contextDir, $exclude, $basePath, 'Drupal\\DrupalExtension\\Tests\\Fixtures');
+    $result = extract_info($context_dir, $exclude, $base_path, 'Drupal\\DrupalExtension\\Tests\\Fixtures');
 
-    foreach ($expected_class_names as $expectedClass) {
-      if (!in_array($expectedClass, $exclude, TRUE)) {
-        $this->assertArrayHasKey($expectedClass, $result);
-        $this->assertEquals($expectedClass, $result[$expectedClass]['name']);
+    foreach ($expected_class_names as $expected_class) {
+      if (!in_array($expected_class, $exclude, TRUE)) {
+        $this->assertArrayHasKey($expected_class, $result);
+        $this->assertEquals($expected_class, $result[$expected_class]['name']);
       }
       else {
-        $this->assertArrayNotHasKey($expectedClass, $result);
+        $this->assertArrayNotHasKey($expected_class, $result);
       }
     }
   }
@@ -1650,29 +1650,29 @@ EOD,
    * Test extract_info with context having multiple methods (tests sorting).
    */
   public function testExtractInfoMultipleMethods(): void {
-    $basePath = static::$tmp;
-    $contextDir = $basePath . DIRECTORY_SEPARATOR . 'src';
-    if (!is_dir($contextDir)) {
-      mkdir($contextDir, 0777, TRUE);
+    $base_path = static::$tmp;
+    $context_dir = $base_path . DIRECTORY_SEPARATOR . 'src';
+    if (!is_dir($context_dir)) {
+      mkdir($context_dir, 0777, TRUE);
     }
 
-    $className = 'MultiMethodContext';
-    $fixturesDir = __DIR__ . '/../fixtures/docs';
-    copy($fixturesDir . DIRECTORY_SEPARATOR . $className . '.php', $contextDir . DIRECTORY_SEPARATOR . $className . '.php');
+    $class_name = 'MultiMethodContext';
+    $fixtures_dir = __DIR__ . '/../fixtures/docs';
+    copy($fixtures_dir . DIRECTORY_SEPARATOR . $class_name . '.php', $context_dir . DIRECTORY_SEPARATOR . $class_name . '.php');
 
-    $result = extract_info($contextDir, [], $basePath, 'Drupal\\DrupalExtension\\Tests\\Fixtures');
+    $result = extract_info($context_dir, [], $base_path, 'Drupal\\DrupalExtension\\Tests\\Fixtures');
 
-    $this->assertArrayHasKey($className, $result);
-    $this->assertIsArray($result[$className]['methods']);
-    $this->assertCount(3, $result[$className]['methods']);
+    $this->assertArrayHasKey($class_name, $result);
+    $this->assertIsArray($result[$class_name]['methods']);
+    $this->assertCount(3, $result[$class_name]['methods']);
 
     // Check order: Given, When, Then.
-    $this->assertArrayHasKey('steps', $result[$className]['methods'][0]);
-    $this->assertStringContainsString('@Given', $result[$className]['methods'][0]['steps'][0]);
-    $this->assertArrayHasKey('steps', $result[$className]['methods'][1]);
-    $this->assertStringContainsString('@When', $result[$className]['methods'][1]['steps'][0]);
-    $this->assertArrayHasKey('steps', $result[$className]['methods'][2]);
-    $this->assertStringContainsString('@Then', $result[$className]['methods'][2]['steps'][0]);
+    $this->assertArrayHasKey('steps', $result[$class_name]['methods'][0]);
+    $this->assertStringContainsString('@Given', $result[$class_name]['methods'][0]['steps'][0]);
+    $this->assertArrayHasKey('steps', $result[$class_name]['methods'][1]);
+    $this->assertStringContainsString('@When', $result[$class_name]['methods'][1]['steps'][0]);
+    $this->assertArrayHasKey('steps', $result[$class_name]['methods'][2]);
+    $this->assertStringContainsString('@Then', $result[$class_name]['methods'][2]['steps'][0]);
   }
 
   /**
@@ -1682,17 +1682,17 @@ EOD,
     $this->expectException(\Exception::class);
     $this->expectExceptionMessage('Class comment for EmptyCommentContext is empty');
 
-    $basePath = static::$tmp;
-    $contextDir = $basePath . DIRECTORY_SEPARATOR . 'src';
-    if (!is_dir($contextDir)) {
-      mkdir($contextDir, 0777, TRUE);
+    $base_path = static::$tmp;
+    $context_dir = $base_path . DIRECTORY_SEPARATOR . 'src';
+    if (!is_dir($context_dir)) {
+      mkdir($context_dir, 0777, TRUE);
     }
 
-    $className = 'EmptyCommentContext';
-    $fixturesDir = __DIR__ . '/../fixtures/docs';
-    copy($fixturesDir . DIRECTORY_SEPARATOR . $className . '.php', $contextDir . DIRECTORY_SEPARATOR . $className . '.php');
+    $class_name = 'EmptyCommentContext';
+    $fixtures_dir = __DIR__ . '/../fixtures/docs';
+    copy($fixtures_dir . DIRECTORY_SEPARATOR . $class_name . '.php', $context_dir . DIRECTORY_SEPARATOR . $class_name . '.php');
 
-    extract_info($contextDir, [], $basePath, 'Drupal\\DrupalExtension\\Tests\\Fixtures');
+    extract_info($context_dir, [], $base_path, 'Drupal\\DrupalExtension\\Tests\\Fixtures');
   }
 
   /**
@@ -1709,34 +1709,34 @@ EOD,
    * Test extract_info excludes classes without step definitions.
    */
   public function testExtractInfoNoStepAnnotations(): void {
-    $basePath = static::$tmp;
-    $contextDir = $basePath . DIRECTORY_SEPARATOR . 'src';
-    if (!is_dir($contextDir)) {
-      mkdir($contextDir, 0777, TRUE);
+    $base_path = static::$tmp;
+    $context_dir = $base_path . DIRECTORY_SEPARATOR . 'src';
+    if (!is_dir($context_dir)) {
+      mkdir($context_dir, 0777, TRUE);
     }
 
-    $className = 'NoStepAnnotationContext';
-    $fixturesDir = __DIR__ . '/../fixtures/docs';
-    copy($fixturesDir . DIRECTORY_SEPARATOR . $className . '.php', $contextDir . DIRECTORY_SEPARATOR . $className . '.php');
+    $class_name = 'NoStepAnnotationContext';
+    $fixtures_dir = __DIR__ . '/../fixtures/docs';
+    copy($fixtures_dir . DIRECTORY_SEPARATOR . $class_name . '.php', $context_dir . DIRECTORY_SEPARATOR . $class_name . '.php');
 
-    $result = extract_info($contextDir, [], $basePath, 'Drupal\\DrupalExtension\\Tests\\Fixtures');
+    $result = extract_info($context_dir, [], $base_path, 'Drupal\\DrupalExtension\\Tests\\Fixtures');
 
     // Context should not appear since it has no step methods.
-    $this->assertArrayNotHasKey($className, $result);
+    $this->assertArrayNotHasKey($class_name, $result);
   }
 
   /**
    * Test find_source_file function.
    */
   public function testFindSourceFile(): void {
-    $basePath = static::$tmp;
+    $base_path = static::$tmp;
 
     // Test with file in Context directory.
-    $contextDir = $basePath . '/src/Drupal/DrupalExtension/Context';
-    mkdir($contextDir, 0777, TRUE);
-    file_put_contents($contextDir . '/TestContext.php', '<?php');
+    $context_dir = $base_path . '/src/Drupal/DrupalExtension/Context';
+    mkdir($context_dir, 0777, TRUE);
+    file_put_contents($context_dir . '/TestContext.php', '<?php');
 
-    $result = find_source_file('TestContext', $basePath);
+    $result = find_source_file('TestContext', $base_path);
     $this->assertEquals('src/Drupal/DrupalExtension/Context/TestContext.php', $result);
   }
 
@@ -1744,15 +1744,15 @@ EOD,
    * Test find_source_file with fallback to src root.
    */
   public function testFindSourceFileFallback(): void {
-    $basePath = static::$tmp;
+    $base_path = static::$tmp;
 
-    $srcDir = $basePath . '/src';
-    if (!is_dir($srcDir)) {
-      mkdir($srcDir, 0777, TRUE);
+    $src_dir = $base_path . '/src';
+    if (!is_dir($src_dir)) {
+      mkdir($src_dir, 0777, TRUE);
     }
-    file_put_contents($srcDir . '/TestContext.php', '<?php');
+    file_put_contents($src_dir . '/TestContext.php', '<?php');
 
-    $result = find_source_file('TestContext', $basePath);
+    $result = find_source_file('TestContext', $base_path);
     $this->assertEquals('src/TestContext.php', $result);
   }
 
@@ -1765,18 +1765,18 @@ EOD,
   }
 
   public function testExtractInfoSkipsInterfacesAndAbstract(): void {
-    $basePath = static::$tmp;
-    $contextDir = $basePath . DIRECTORY_SEPARATOR . 'src';
-    if (!is_dir($contextDir)) {
-      mkdir($contextDir, 0777, TRUE);
+    $base_path = static::$tmp;
+    $context_dir = $base_path . DIRECTORY_SEPARATOR . 'src';
+    if (!is_dir($context_dir)) {
+      mkdir($context_dir, 0777, TRUE);
     }
 
-    $fixturesDir = __DIR__ . '/../fixtures/docs';
-    foreach (['InterfaceContext', 'AbstractContext', 'SampleContext'] as $className) {
-      copy($fixturesDir . DIRECTORY_SEPARATOR . $className . '.php', $contextDir . DIRECTORY_SEPARATOR . $className . '.php');
+    $fixtures_dir = __DIR__ . '/../fixtures/docs';
+    foreach (['InterfaceContext', 'AbstractContext', 'SampleContext'] as $class_name) {
+      copy($fixtures_dir . DIRECTORY_SEPARATOR . $class_name . '.php', $context_dir . DIRECTORY_SEPARATOR . $class_name . '.php');
     }
 
-    $result = extract_info($contextDir, [], $basePath, 'Drupal\\DrupalExtension\\Tests\\Fixtures');
+    $result = extract_info($context_dir, [], $base_path, 'Drupal\\DrupalExtension\\Tests\\Fixtures');
 
     $this->assertArrayNotHasKey('InterfaceContext', $result);
     $this->assertArrayNotHasKey('AbstractContext', $result);
@@ -1784,16 +1784,16 @@ EOD,
   }
 
   public function testExtractInfoSkipsInheritedMethods(): void {
-    $basePath = static::$tmp;
-    $contextDir = $basePath . DIRECTORY_SEPARATOR . 'src';
-    if (!is_dir($contextDir)) {
-      mkdir($contextDir, 0777, TRUE);
+    $base_path = static::$tmp;
+    $context_dir = $base_path . DIRECTORY_SEPARATOR . 'src';
+    if (!is_dir($context_dir)) {
+      mkdir($context_dir, 0777, TRUE);
     }
 
-    $fixturesDir = __DIR__ . '/../fixtures/docs';
-    copy($fixturesDir . DIRECTORY_SEPARATOR . 'InheritedContext.php', $contextDir . DIRECTORY_SEPARATOR . 'InheritedContext.php');
+    $fixtures_dir = __DIR__ . '/../fixtures/docs';
+    copy($fixtures_dir . DIRECTORY_SEPARATOR . 'InheritedContext.php', $context_dir . DIRECTORY_SEPARATOR . 'InheritedContext.php');
 
-    $result = extract_info($contextDir, [], $basePath, 'Drupal\\DrupalExtension\\Tests\\Fixtures');
+    $result = extract_info($context_dir, [], $base_path, 'Drupal\\DrupalExtension\\Tests\\Fixtures');
 
     $this->assertArrayHasKey('InheritedContext', $result);
     // Should only have its own method, not the inherited one.
@@ -1802,33 +1802,33 @@ EOD,
   }
 
   public function testExtractInfoSkipsNonExistentClasses(): void {
-    $basePath = static::$tmp;
-    $contextDir = $basePath . DIRECTORY_SEPARATOR . 'src';
-    if (!is_dir($contextDir)) {
-      mkdir($contextDir, 0777, TRUE);
+    $base_path = static::$tmp;
+    $context_dir = $base_path . DIRECTORY_SEPARATOR . 'src';
+    if (!is_dir($context_dir)) {
+      mkdir($context_dir, 0777, TRUE);
     }
 
     // Create a PHP file whose class doesn't match the namespace.
-    file_put_contents($contextDir . DIRECTORY_SEPARATOR . 'NonExistent.php', '<?php');
+    file_put_contents($context_dir . DIRECTORY_SEPARATOR . 'NonExistent.php', '<?php');
 
-    $result = extract_info($contextDir, [], $basePath, 'Drupal\\DrupalExtension\\Tests\\Fixtures');
+    $result = extract_info($context_dir, [], $base_path, 'Drupal\\DrupalExtension\\Tests\\Fixtures');
 
     $this->assertArrayNotHasKey('NonExistent', $result);
   }
 
   public function testRenderInfoWithListDescription(): void {
-    $basePath = static::$tmp;
-    $srcDir = $basePath . '/src';
-    if (!is_dir($srcDir)) {
-      mkdir($srcDir, 0777, TRUE);
+    $base_path = static::$tmp;
+    $src_dir = $base_path . '/src';
+    if (!is_dir($src_dir)) {
+      mkdir($src_dir, 0777, TRUE);
     }
-    file_put_contents($srcDir . '/ListDescContext.php', '<?php');
+    file_put_contents($src_dir . '/ListDescContext.php', '<?php');
 
-    $featureDir = $basePath . '/tests/behat/features';
-    if (!is_dir($featureDir)) {
-      mkdir($featureDir, 0777, TRUE);
+    $feature_dir = $base_path . '/tests/behat/features';
+    if (!is_dir($feature_dir)) {
+      mkdir($feature_dir, 0777, TRUE);
     }
-    file_put_contents($featureDir . '/list_desc.feature', 'Feature: Test');
+    file_put_contents($feature_dir . '/list_desc.feature', 'Feature: Test');
 
     $info = [
       'ListDescContext' => [
@@ -1846,14 +1846,14 @@ EOD,
       ],
     ];
 
-    $output = render_info($info, $basePath);
+    $output = render_info($info, $base_path);
 
     $this->assertStringContainsString('- First item', $output);
     $this->assertStringContainsString('- Second item', $output);
   }
 
   public function testWriteValidationLogsWithWarnings(): void {
-    $logDir = static::$tmp . '/logs';
+    $log_dir = static::$tmp . '/logs';
 
     $results = [
       'TestContext' => [
@@ -1870,14 +1870,14 @@ EOD,
       ],
     ];
 
-    $treeOutput = render_validation_tree($results);
-    write_validation_logs($treeOutput, $logDir);
+    $tree_output = render_validation_tree($results);
+    write_validation_logs($tree_output, $log_dir);
 
-    $this->assertFileExists($logDir . '/validation-summary.txt');
-    $this->assertFileExists($logDir . '/validation-details.txt');
+    $this->assertFileExists($log_dir . '/validation-summary.txt');
+    $this->assertFileExists($log_dir . '/validation-details.txt');
 
-    $summary = file_get_contents($logDir . '/validation-summary.txt');
-    $details = file_get_contents($logDir . '/validation-details.txt');
+    $summary = file_get_contents($log_dir . '/validation-summary.txt');
+    $details = file_get_contents($log_dir . '/validation-details.txt');
 
     // Summary should contain the summary block without ANSI.
     $this->assertStringContainsString('Summary:', $summary);
@@ -1889,27 +1889,27 @@ EOD,
   }
 
   public function testWriteValidationLogsEmpty(): void {
-    $logDir = static::$tmp . '/logs-empty';
+    $log_dir = static::$tmp . '/logs-empty';
 
-    write_validation_logs('', $logDir);
+    write_validation_logs('', $log_dir);
 
-    $this->assertFileExists($logDir . '/validation-summary.txt');
-    $this->assertFileExists($logDir . '/validation-details.txt');
+    $this->assertFileExists($log_dir . '/validation-summary.txt');
+    $this->assertFileExists($log_dir . '/validation-details.txt');
 
-    $summary = file_get_contents($logDir . '/validation-summary.txt');
+    $summary = file_get_contents($log_dir . '/validation-summary.txt');
     $this->assertSame('No validation warnings.' . PHP_EOL, $summary);
 
-    $details = file_get_contents($logDir . '/validation-details.txt');
+    $details = file_get_contents($log_dir . '/validation-details.txt');
     $this->assertSame('', $details);
   }
 
   public function testWriteValidationLogsCreatesDirectory(): void {
-    $logDir = static::$tmp . '/nested/logs/dir';
+    $log_dir = static::$tmp . '/nested/logs/dir';
 
-    write_validation_logs('', $logDir);
+    write_validation_logs('', $log_dir);
 
-    $this->assertDirectoryExists($logDir);
-    $this->assertFileExists($logDir . '/validation-summary.txt');
+    $this->assertDirectoryExists($log_dir);
+    $this->assertFileExists($log_dir . '/validation-summary.txt');
   }
 
   public function testRegexToTurnipWithRemainingMetachars(): void {

--- a/tests/phpunit/src/DrupalAuthenticationManagerTest.php
+++ b/tests/phpunit/src/DrupalAuthenticationManagerTest.php
@@ -72,13 +72,13 @@ class DrupalAuthenticationManagerTest extends TestCase {
     // @phpstan-ignore method.notFound
     $session->method('isStarted')->willReturn(TRUE);
 
-    $userManager = new DrupalUserManager();
-    $driverManager = $this->createDriverManagerMock();
-    $manager = $this->createManager($session, $userManager, $driverManager);
+    $user_manager = new DrupalUserManager();
+    $driver_manager = $this->createDriverManagerMock();
+    $manager = $this->createManager($session, $user_manager, $driver_manager);
 
     $user = (object) ['name' => 'admin', 'pass' => 'password'];
     $manager->logIn($user);
-    $this->assertSame($user, $userManager->getCurrentUser());
+    $this->assertSame($user, $user_manager->getCurrentUser());
   }
 
   /**
@@ -152,13 +152,13 @@ class DrupalAuthenticationManagerTest extends TestCase {
     // @phpstan-ignore method.notFound
     $session->method('isStarted')->willReturn(TRUE);
 
-    $authDriver = $this->createAuthDriverMock();
-    $authDriver->expects($this->once())->method('login');
+    $auth_driver = $this->createAuthDriverMock();
+    $auth_driver->expects($this->once())->method('login');
 
-    $driverManager = $this->createMock(DrupalDriverManagerInterface::class);
-    $driverManager->method('getDriver')->willReturn($authDriver);
+    $driver_manager = $this->createMock(DrupalDriverManagerInterface::class);
+    $driver_manager->method('getDriver')->willReturn($auth_driver);
 
-    $manager = $this->createManager($session, NULL, $driverManager);
+    $manager = $this->createManager($session, NULL, $driver_manager);
     $manager->logIn((object) ['name' => 'admin', 'pass' => 'pass']);
   }
 
@@ -174,13 +174,13 @@ class DrupalAuthenticationManagerTest extends TestCase {
     // @phpstan-ignore method.notFound
     $session->method('getCurrentUrl')->willReturn('http://localhost/user/logout');
 
-    $userManager = new DrupalUserManager();
-    $userManager->setCurrentUser((object) ['name' => 'admin']);
+    $user_manager = new DrupalUserManager();
+    $user_manager->setCurrentUser((object) ['name' => 'admin']);
 
-    $driverManager = $this->createDriverManagerMock();
-    $manager = $this->createManager($session, $userManager, $driverManager);
+    $driver_manager = $this->createDriverManagerMock();
+    $manager = $this->createManager($session, $user_manager, $driver_manager);
     $manager->logout();
-    $this->assertFalse($userManager->getCurrentUser());
+    $this->assertFalse($user_manager->getCurrentUser());
   }
 
   /**
@@ -197,11 +197,11 @@ class DrupalAuthenticationManagerTest extends TestCase {
     // @phpstan-ignore method.notFound
     $session->method('getCurrentUrl')->willReturn('http://localhost/user/logout/confirm');
 
-    $userManager = new DrupalUserManager();
-    $driverManager = $this->createDriverManagerMock();
-    $manager = $this->createManager($session, $userManager, $driverManager);
+    $user_manager = new DrupalUserManager();
+    $driver_manager = $this->createDriverManagerMock();
+    $manager = $this->createManager($session, $user_manager, $driver_manager);
     $manager->logout();
-    $this->assertFalse($userManager->getCurrentUser());
+    $this->assertFalse($user_manager->getCurrentUser());
   }
 
   /**
@@ -231,13 +231,13 @@ class DrupalAuthenticationManagerTest extends TestCase {
     // @phpstan-ignore method.notFound
     $session->method('getCurrentUrl')->willReturn('http://localhost/user/logout');
 
-    $authDriver = $this->createAuthDriverMock();
-    $authDriver->expects($this->once())->method('logout');
+    $auth_driver = $this->createAuthDriverMock();
+    $auth_driver->expects($this->once())->method('logout');
 
-    $driverManager = $this->createMock(DrupalDriverManagerInterface::class);
-    $driverManager->method('getDriver')->willReturn($authDriver);
+    $driver_manager = $this->createMock(DrupalDriverManagerInterface::class);
+    $driver_manager->method('getDriver')->willReturn($auth_driver);
 
-    $manager = $this->createManager($session, NULL, $driverManager);
+    $manager = $this->createManager($session, NULL, $driver_manager);
     $manager->logout();
   }
 
@@ -248,14 +248,14 @@ class DrupalAuthenticationManagerTest extends TestCase {
   public function testLoggedIn(bool $session_started, bool $has_logged_in_selector, bool $has_login_form, bool $has_logout_link, bool $expected): void {
     $page = $this->createMock(DocumentElement::class);
 
-    $hasMap = [];
+    $has_map = [];
     if ($session_started) {
-      $hasMap[] = ['css', 'body.logged-in', $has_logged_in_selector];
+      $has_map[] = ['css', 'body.logged-in', $has_logged_in_selector];
       if (!$has_logged_in_selector) {
-        $hasMap[] = ['css', 'form#user-login', $has_login_form];
+        $has_map[] = ['css', 'form#user-login', $has_login_form];
       }
     }
-    $page->method('has')->willReturnMap($hasMap);
+    $page->method('has')->willReturnMap($has_map);
     $page->method('findLink')->willReturn($has_logout_link ? $this->createMock(NodeElement::class) : NULL);
 
     $session = $this->createSessionMock($page);
@@ -324,18 +324,18 @@ class DrupalAuthenticationManagerTest extends TestCase {
     $mink = new Mink(['default' => $session]);
     $mink->setDefaultSessionName('default');
 
-    $userManager = new DrupalUserManager();
-    $userManager->setCurrentUser((object) ['name' => 'admin']);
+    $user_manager = new DrupalUserManager();
+    $user_manager->setCurrentUser((object) ['name' => 'admin']);
 
-    $driverManager = $this->createDriverManagerMock();
-    $manager = new DrupalAuthenticationManager($mink, $userManager, $driverManager, self::MINK_PARAMS, self::DRUPAL_PARAMS);
+    $driver_manager = $this->createDriverManagerMock();
+    $manager = new DrupalAuthenticationManager($mink, $user_manager, $driver_manager, self::MINK_PARAMS, self::DRUPAL_PARAMS);
     $manager->fastLogout();
 
-    $this->assertFalse($userManager->getCurrentUser());
+    $this->assertFalse($user_manager->getCurrentUser());
   }
 
   /**
-   * Tests that fastLogout() skips session reset when the session is not started.
+   * Tests fastLogout() skips session reset when the session is not started.
    */
   public function testFastLogoutSkipsResetWhenNotStarted(): void {
     $session = $this->createMock(Session::class);
@@ -345,8 +345,8 @@ class DrupalAuthenticationManagerTest extends TestCase {
     $mink = new Mink(['default' => $session]);
     $mink->setDefaultSessionName('default');
 
-    $driverManager = $this->createDriverManagerMock();
-    $manager = new DrupalAuthenticationManager($mink, new DrupalUserManager(), $driverManager, self::MINK_PARAMS, self::DRUPAL_PARAMS);
+    $driver_manager = $this->createDriverManagerMock();
+    $manager = new DrupalAuthenticationManager($mink, new DrupalUserManager(), $driver_manager, self::MINK_PARAMS, self::DRUPAL_PARAMS);
     $manager->fastLogout();
   }
 
@@ -360,13 +360,13 @@ class DrupalAuthenticationManagerTest extends TestCase {
     $mink = new Mink(['default' => $session]);
     $mink->setDefaultSessionName('default');
 
-    $authDriver = $this->createAuthDriverMock();
-    $authDriver->expects($this->once())->method('logout');
+    $auth_driver = $this->createAuthDriverMock();
+    $auth_driver->expects($this->once())->method('logout');
 
-    $driverManager = $this->createMock(DrupalDriverManagerInterface::class);
-    $driverManager->method('getDriver')->willReturn($authDriver);
+    $driver_manager = $this->createMock(DrupalDriverManagerInterface::class);
+    $driver_manager->method('getDriver')->willReturn($auth_driver);
 
-    $manager = new DrupalAuthenticationManager($mink, new DrupalUserManager(), $driverManager, self::MINK_PARAMS, self::DRUPAL_PARAMS);
+    $manager = new DrupalAuthenticationManager($mink, new DrupalUserManager(), $driver_manager, self::MINK_PARAMS, self::DRUPAL_PARAMS);
     $manager->fastLogout();
   }
 
@@ -393,7 +393,7 @@ class DrupalAuthenticationManagerTest extends TestCase {
   }
 
   /**
-   * Creates a mock implementing both AuthenticationCapabilityInterface and DriverInterface.
+   * Creates a mock for the AuthenticationCapability and DriverInterface.
    */
   private function createAuthDriverMock(): AuthenticationCapabilityInterface|DriverInterface|MockObject {
     $driver = $this->createMockForIntersectionOfInterfaces([
@@ -410,9 +410,9 @@ class DrupalAuthenticationManagerTest extends TestCase {
   private function createDriverManagerMock(): DrupalDriverManagerInterface {
     $driver = $this->createMock(DriverInterface::class);
     $driver->method('isBootstrapped')->willReturn(TRUE);
-    $driverManager = $this->createMock(DrupalDriverManagerInterface::class);
-    $driverManager->method('getDriver')->willReturn($driver);
-    return $driverManager;
+    $driver_manager = $this->createMock(DrupalDriverManagerInterface::class);
+    $driver_manager->method('getDriver')->willReturn($driver);
+    return $driver_manager;
   }
 
   /**
@@ -448,16 +448,16 @@ class DrupalAuthenticationManagerTest extends TestCase {
   public function testLogInWaitsForLoggedInSelector(): void {
     $submit = $this->createMock(NodeElement::class);
 
-    $callCount = 0;
+    $call_count = 0;
     $page = $this->createMock(DocumentElement::class);
     $page->method('findButton')->with('Log in')->willReturn($submit);
     // Simulate: logged_in_selector not found on first call, found on second.
-    $page->method('has')->willReturnCallback(function (string $selector, string $locator) use (&$callCount): bool {
+    $page->method('has')->willReturnCallback(function (string $selector, string $locator) use (&$call_count): bool {
       if ($locator === 'body.logged-in') {
-        $callCount++;
+        $call_count++;
         // First two calls return FALSE (during wait loop and loggedIn check),
         // then return TRUE.
-        return $callCount > 2;
+        return $call_count > 2;
       }
       return FALSE;
     });
@@ -468,25 +468,25 @@ class DrupalAuthenticationManagerTest extends TestCase {
       return NULL;
     });
 
-    $urlCallCount = 0;
+    $url_call_count = 0;
     $session = $this->createSessionMock($page);
     // @phpstan-ignore method.notFound
     $session->method('isStarted')->willReturn(TRUE);
     // Simulate URL change after login (redirect).
     // @phpstan-ignore method.notFound
-    $session->method('getCurrentUrl')->willReturnCallback(function () use (&$urlCallCount): string {
-      $urlCallCount++;
-      return $urlCallCount <= 1 ? 'http://localhost/user/login' : 'http://localhost/user/1';
+    $session->method('getCurrentUrl')->willReturnCallback(function () use (&$url_call_count): string {
+      $url_call_count++;
+      return $url_call_count <= 1 ? 'http://localhost/user/login' : 'http://localhost/user/1';
     });
 
     $params = self::DRUPAL_PARAMS;
     $params['login_wait'] = 1;
 
-    $userManager = new DrupalUserManager();
-    $manager = $this->createManager($session, $userManager, NULL, $params);
+    $user_manager = new DrupalUserManager();
+    $manager = $this->createManager($session, $user_manager, NULL, $params);
     $manager->logIn((object) ['name' => 'admin', 'pass' => 'password']);
 
-    $this->assertNotFalse($userManager->getCurrentUser());
+    $this->assertNotFalse($user_manager->getCurrentUser());
   }
 
   /**

--- a/tests/phpunit/src/DrupalDriverManagerTest.php
+++ b/tests/phpunit/src/DrupalDriverManagerTest.php
@@ -119,15 +119,15 @@ class DrupalDriverManagerTest extends TestCase {
    * Tests that getDrivers returns all registered drivers.
    */
   public function testGetDriversReturnsAllRegistered(): void {
-    $driverA = $this->createDriverMock(TRUE);
-    $driverB = $this->createDriverMock(TRUE);
+    $driver_a = $this->createDriverMock(TRUE);
+    $driver_b = $this->createDriverMock(TRUE);
     $manager = new DrupalDriverManager();
-    $manager->registerDriver('a', $driverA);
-    $manager->registerDriver('b', $driverB);
+    $manager->registerDriver('a', $driver_a);
+    $manager->registerDriver('b', $driver_b);
     $drivers = $manager->getDrivers();
     $this->assertCount(2, $drivers);
-    $this->assertSame($driverA, $drivers['a']);
-    $this->assertSame($driverB, $drivers['b']);
+    $this->assertSame($driver_a, $drivers['a']);
+    $this->assertSame($driver_b, $drivers['b']);
   }
 
   /**

--- a/tests/phpunit/src/DrupalMailManagerTest.php
+++ b/tests/phpunit/src/DrupalMailManagerTest.php
@@ -24,8 +24,8 @@ class DrupalMailManagerTest extends TestCase {
     $driver = $this->createMock(MailCapabilityInterface::class);
     $driver->expects($this->once())->method($driver_method);
 
-    foreach ($extra_driver_methods as $extraDriverMethod) {
-      $driver->expects($this->once())->method($extraDriverMethod);
+    foreach ($extra_driver_methods as $extra_driver_method) {
+      $driver->expects($this->once())->method($extra_driver_method);
     }
 
     $manager = new DrupalMailManager($driver);

--- a/tests/phpunit/src/DrupalUserManagerTest.php
+++ b/tests/phpunit/src/DrupalUserManagerTest.php
@@ -88,14 +88,14 @@ class DrupalUserManagerTest extends TestCase {
    */
   public function testGetUsersReturnsAll(): void {
     $manager = new DrupalUserManager();
-    $userA = (object) ['name' => 'alice'];
-    $userB = (object) ['name' => 'bob'];
-    $manager->addUser($userA);
-    $manager->addUser($userB);
+    $user_a = (object) ['name' => 'alice'];
+    $user_b = (object) ['name' => 'bob'];
+    $manager->addUser($user_a);
+    $manager->addUser($user_b);
     $users = $manager->getUsers();
     $this->assertCount(2, $users);
-    $this->assertSame($userA, $users['alice']);
-    $this->assertSame($userB, $users['bob']);
+    $this->assertSame($user_a, $users['alice']);
+    $this->assertSame($user_b, $users['bob']);
   }
 
   /**

--- a/tests/phpunit/src/MessageContextTest.php
+++ b/tests/phpunit/src/MessageContextTest.php
@@ -87,7 +87,7 @@ class MessageContextTest extends TestCase {
   /**
    * Tests that all message types are accepted.
    */
-  #[DataProvider('dataProviderMessageTypes')]
+  #[DataProvider('dataProviderValidMessageTableAcceptsAllTypes')]
   public function testValidMessageTableAcceptsAllTypes(string $header, string $type): void {
     $table = new TableNode([
           [$header],
@@ -100,7 +100,7 @@ class MessageContextTest extends TestCase {
   /**
    * Provides data for testValidMessageTableAcceptsAllTypes().
    */
-  public static function dataProviderMessageTypes(): \Iterator {
+  public static function dataProviderValidMessageTableAcceptsAllTypes(): \Iterator {
     yield 'error messages' => ['Error messages', 'error messages'];
     yield 'success messages' => ['Success messages', 'success messages'];
     yield 'warning messages' => ['Warning messages', 'warning messages'];

--- a/tests/phpunit/src/RawDrupalContextTest.php
+++ b/tests/phpunit/src/RawDrupalContextTest.php
@@ -51,16 +51,16 @@ class RawDrupalContextTest extends TestCase {
   #[DataProvider('dataProviderParseEntityFields')]
   public function testParseEntityFields(array $input, array $expected, ?array $fields = NULL, ?array $baseFields = NULL, ?string $exception = NULL, array $ignored_properties = []): void {
     if ($fields !== NULL) {
-      $isBaseField = fn(string $entityType, string $fieldName): bool => in_array($fieldName, $baseFields ?? [], TRUE);
+      $is_base_field = fn(string $entity_type, string $field_name): bool => in_array($field_name, $baseFields ?? [], TRUE);
 
       $classifier = $this->createMock(FieldClassifierInterface::class);
       $classifier->method('fieldIsConfigurable')->willReturnCallback(
-        fn(string $entityType, string $fieldName): bool => in_array($fieldName, $fields, TRUE)
+        fn(string $entity_type, string $field_name): bool => in_array($field_name, $fields, TRUE)
       );
-      $classifier->method('fieldIsBaseStandard')->willReturnCallback($isBaseField);
-      $classifier->method('fieldIsBaseComputedReadOnly')->willReturnCallback($isBaseField);
-      $classifier->method('fieldIsBaseComputedWritable')->willReturnCallback($isBaseField);
-      $classifier->method('fieldIsBaseCustomStorage')->willReturnCallback($isBaseField);
+      $classifier->method('fieldIsBaseStandard')->willReturnCallback($is_base_field);
+      $classifier->method('fieldIsBaseComputedReadOnly')->willReturnCallback($is_base_field);
+      $classifier->method('fieldIsBaseComputedWritable')->willReturnCallback($is_base_field);
+      $classifier->method('fieldIsBaseCustomStorage')->willReturnCallback($is_base_field);
 
       $core = $this->createMock(CoreInterface::class);
       $core->method('classifier')->willReturn($classifier);
@@ -248,9 +248,9 @@ class RawDrupalContextTest extends TestCase {
    * F-rows, so computed-writable base fields like 'moderation_state' (F3)
    * must not trigger the unknown-field error in v3.
    */
-  #[DataProvider('dataProviderNonStandardBaseFields')]
+  #[DataProvider('dataProviderParseEntityFieldsAcceptsNonStandardBaseFields')]
   public function testParseEntityFieldsAcceptsNonStandardBaseFields(string $truePredicate): void {
-    $basePredicates = [
+    $base_predicates = [
       'fieldIsBaseStandard',
       'fieldIsBaseComputedReadOnly',
       'fieldIsBaseComputedWritable',
@@ -260,7 +260,7 @@ class RawDrupalContextTest extends TestCase {
     $classifier = $this->createMock(FieldClassifierInterface::class);
     $classifier->method('fieldIsConfigurable')->willReturn(FALSE);
 
-    foreach ($basePredicates as $predicate) {
+    foreach ($base_predicates as $predicate) {
       $classifier->method($predicate)->willReturn($predicate === $truePredicate);
     }
 
@@ -285,7 +285,7 @@ class RawDrupalContextTest extends TestCase {
   /**
    * Provides data for testParseEntityFieldsAcceptsNonStandardBaseFields().
    */
-  public static function dataProviderNonStandardBaseFields(): \Iterator {
+  public static function dataProviderParseEntityFieldsAcceptsNonStandardBaseFields(): \Iterator {
     yield 'F1 base standard' => ['fieldIsBaseStandard'];
     yield 'F2 base computed read-only' => ['fieldIsBaseComputedReadOnly'];
     yield 'F3 base computed writable' => ['fieldIsBaseComputedWritable'];


### PR DESCRIPTION
## Summary

Switched from a custom `phpcs.xml` ruleset to the full Drupal coding standards
via `drevops/phpcs-standard` 0.7.x, aligning this project with the approach
used by `drupal/drupal-driver`. The upgrade dropped the previous camelCase
local-variable override (snake_case is now enforced by the DrevOps sniff),
added `Generic.PHP.RequireStrictTypes`, and removed the previously excluded
`Drupal.Files.LineLength.TooLong` and `Drupal.Semantics.FunctionTriggerError`
rules. `phpcbf` auto-fixed roughly 1 270 violations across 82 files; a small
set of issues required manual correction. PHPStan level is intentionally left
unchanged - that uplift is reserved for a separate PR.

## Changes

- **Configuration** - `phpcs.xml` rewritten: now uses the `Drupal` ruleset
  with only `Drupal.Commenting.Deprecated` excluded, plus `DrevOps` and
  `Generic.PHP.RequireStrictTypes` rules; per-rule camelCase overrides removed.
  `composer.json` bumps `drevops/phpcs-standard` from `^0.6.2` to `^0.7.0`.
- **Auto-fixed via `phpcbf`** - ~1 270 violations across 82 files: snake_case
  local variables (DrevOps naming sniff), missing `strict_types` declarations,
  whitespace/alignment, and minor doc-comment formatting.
- **Manual: `trigger_error` formatting** - `RawDrupalContext::loggedInWithRole()`,
  `DrupalSubContextBase::getUser()`, and `Reader.php` (2 call-sites) now match
  the strict Drupal deprecation-message format required by
  `Drupal.Semantics.FunctionTriggerError`.
- **Manual: data-provider naming** - Renamed `dataProviderNonStandardBaseFields`,
  `dataProviderProfiles`, and `dataProviderMessageTypes` to names that match
  their corresponding test methods (DrevOps `DataProviderMatchesTestName` sniff).
- **Manual: line-length** - Wrapped or rephrased docblock summary lines that
  exceeded 80 characters in `MinkContext`, `MessageContext`, `DrupalContext`,
  `RawDrupalContext`, `FeatureTrait`, `ScenarioTrait`, `BehatCliTrait`,
  `DrupalAuthenticationManagerTest`, and `scripts/docs.php`.
- **Documentation** - `STEPS.md` regenerated via `ahoy docs`.

## Before / After

```
Before (phpcs.xml)                After (phpcs.xml)
+---------------------------+     +---------------------------+
| rule ref="Drupal"         |     | rule ref="Drupal"         |
|   exclude LineLength      |     |   exclude Deprecated      |
|   exclude TriggerError    |     +---------------------------+
|   exclude Deprecated      |     | rule ref="DrevOps"        |
+---------------------------+     +---------------------------+
| rule ref="DrevOps"        |     | rule ref="Generic.PHP     |
|  (partial - only naming)  |     |   .RequireStrictTypes"    |
+---------------------------+     +---------------------------+
| LocalVariableNaming       |
|   format=camelCase        |
+---------------------------+
| ParameterNaming           |
|   format=camelCase        |
+---------------------------+
```

The new config is stricter (no line-length or trigger-error exclusions,
full DrevOps ruleset, strict-types required) and mirrors the structure used
by `drupal/drupal-driver`.

## Test plan

- [x] `ahoy lint` passes (parallel-lint, phpcs, phpstan, rector dry-run, gherkinlint, docs-lint)
- [x] `ahoy test-phpspec` passes (77 examples)
- [x] `ahoy test-unit` passes (302 tests)
- [x] `ahoy test-bdd` passes (103 blackbox + 147 drupal scenarios)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified step descriptions by tightening wording and removing implementation details.
  * Updated deprecation messaging with version information and issue references.

* **Chores**
  * Updated PHP code standards configuration to enforce additional quality checks.
  * Upgraded development dependency for PHP code standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->