### PR TITLE
Updated code to comply with PHPStan level 7.

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,7 @@
 
 parameters:
 
-  level: 3
+  level: 7
 
   paths:
     - src
@@ -19,6 +19,9 @@ parameters:
     # This class is kept for backwards compatibility.
     - src/Drupal/DrupalExtension/Definition/Proposal/AnnotatedDefinitionProposal.php
     - tests/behat/bootstrap/BehatCliContext.php
+    # BehatCliTrait is only used by BehatCliContext (excluded above), so it
+    # cannot be analysed standalone.
+    - tests/behat/bootstrap/BehatCliTrait.php
 
   ignoreErrors:
     -

--- a/scripts/docs.php
+++ b/scripts/docs.php
@@ -127,8 +127,10 @@ function main(array $options = []): void {
  * @param string $base_path
  *   Base path for the repository.
  *
- * @return array<string,array<string, array<int, array<string, array<int,string>|string>>|string>>
- *   Array of info with 'name', 'steps', 'description', and 'example' keys.
+ * @return array<string, array<string, mixed>>
+ *   Array of info keyed by class name. Each entry has 'name', 'methods'
+ *   (array of method info with 'name', 'steps', 'description', 'example'
+ *   keys), and class-level 'description' / 'description_full' keys.
  *
  * @throws \ReflectionException
  */
@@ -458,7 +460,7 @@ function extract_step_attributes(\ReflectionMethod $method): array {
 /**
  * Convert info to content.
  *
- * @param array<string,array<string, array<int, array<string, array<int,string>|string>>|string>> $info
+ * @param array<string, array<string, mixed>> $info
  *   Array of info items with 'name', 'from', and 'to' keys.
  * @param string $base_path
  *   Base path for the repository.
@@ -494,12 +496,12 @@ function render_info(array $info, string $base_path = '', ?string $path_for_link
       $example_link = sprintf(', [Example](%s)', $example_file);
     }
 
-    $content_output .= sprintf('## %s', $class_info['name_contextual']) . PHP_EOL . PHP_EOL;
+    $content_output .= sprintf('## %s', (string) $class_info['name_contextual']) . PHP_EOL . PHP_EOL;
     $content_output .= sprintf('[Source](%s)%s', $src_file, $example_link) . PHP_EOL . PHP_EOL;
 
     // Add description as markdown-safe accommodating for lists.
     $description_full = '';
-    $lines = explode(PHP_EOL, $class_info['description_full']);
+    $lines = explode(PHP_EOL, (string) $class_info['description_full']);
     $was_list = FALSE;
     $in_code_block = FALSE;
     $code_block = '';
@@ -550,7 +552,7 @@ function render_info(array $info, string $base_path = '', ?string $path_for_link
       }
     }
 
-    $description_full = preg_replace('/^/m', '>  ', $description_full);
+    $description_full = (string) preg_replace('/^/m', '>  ', $description_full);
     $content_output .= $description_full . PHP_EOL . PHP_EOL;
 
     // Add to index.
@@ -559,9 +561,13 @@ function render_info(array $info, string $base_path = '', ?string $path_for_link
       $index_rows_path = $path_for_links . $index_rows_path;
     }
     $index_rows[] = [
-      sprintf('[%s](%s)', $class_info['name_contextual'], $index_rows_path),
-      $class_info['description'],
+      sprintf('[%s](%s)', (string) $class_info['name_contextual'], (string) $index_rows_path),
+      (string) $class_info['description'],
     ];
+
+    if (!is_array($class_info['methods'])) {
+      continue;
+    }
 
     foreach ($class_info['methods'] as $method) {
       $method['steps'] = is_array($method['steps']) ? $method['steps'] : [$method['steps']];
@@ -569,7 +575,7 @@ function render_info(array $info, string $base_path = '', ?string $path_for_link
       $method['example'] = is_string($method['example']) ? $method['example'] : '';
 
       $method['steps'] = array_reduce($method['steps'], fn(string $carry, string $item): string => $carry . sprintf("%s\n", $item), '');
-      $method['steps'] = rtrim((string) $method['steps'], "\n");
+      $method['steps'] = rtrim($method['steps'], "\n");
 
       $method['description'] = rtrim((string) $method['description'], '.');
 
@@ -657,7 +663,7 @@ function find_source_file(string $class_name, string $base_path): ?string {
  * @param string $base_path
  *   Base path for the repository.
  *
- * @return array<string, array<string, array<string, bool|string|array<string, array<string, bool|array<int, string>>>>>>
+ * @return array<string, array{file: array{pass: bool, path: string}, methods: array<string, array<string, array{pass: bool, messages: array<int, string>}>>}>
  *   Structured validation results per class and method.
  */
 function validate(array $info, string $base_path = ''): array {
@@ -683,6 +689,11 @@ function validate(array $info, string $base_path = ''): array {
       ],
       'methods' => [],
     ];
+
+    if (!is_array($class_info['methods'])) {
+      $results[$class_name] = $class_result;
+      continue;
+    }
 
     foreach ($class_info['methods'] as $method) {
       $method['steps'] = is_array($method['steps']) ? $method['steps'] : [$method['steps']];
@@ -767,7 +778,7 @@ function validate(array $info, string $base_path = ''): array {
 /**
  * Check if validation results contain any errors.
  *
- * @param array<string, array<string, array<string, bool|string|array<string, array<string, bool|array<int, string>>>>>> $results
+ * @param array<string, array{file: array{pass: bool, path: string}, methods: array<string, array<string, array{pass: bool, messages: array<int, string>}>>}> $results
  *   Structured validation results from validate().
  *
  * @return bool
@@ -790,7 +801,7 @@ function has_validation_errors(array $results): bool {
 /**
  * Render validation results as a tree with ANSI colors.
  *
- * @param array<string, array<string, array<string, bool|string|array<string, array<string, bool|array<int, string>>>>>> $results
+ * @param array<string, array{file: array{pass: bool, path: string}, methods: array<string, array<string, array{pass: bool, messages: array<int, string>}>>}> $results
  *   Structured validation results from validate().
  *
  * @return string
@@ -1121,7 +1132,7 @@ function replace_content(string $haystack, string $start, string $end, string $r
  *
  * @param array<int, string> $headers
  *   The headers for the table.
- * @param array<string, array<int, string>> $rows
+ * @param array<string|int, array<int|string, string>> $rows
  *   The rows for the table.
  *
  * @return string

--- a/src/Drupal/DrupalDriverManager.php
+++ b/src/Drupal/DrupalDriverManager.php
@@ -18,10 +18,8 @@ class DrupalDriverManager implements DrupalDriverManagerInterface {
 
   /**
    * The name of the default driver.
-   *
-   * @var string
    */
-  private $defaultDriverName;
+  private ?string $defaultDriverName = NULL;
 
   /**
    * All registered drivers.

--- a/src/Drupal/DrupalDriverManagerInterface.php
+++ b/src/Drupal/DrupalDriverManagerInterface.php
@@ -20,7 +20,7 @@ interface DrupalDriverManagerInterface {
    * @param \Drupal\Driver\DriverInterface $driver
    *   An instance of a DriverInterface.
    */
-  public function registerDriver($name, DriverInterface $driver);
+  public function registerDriver($name, DriverInterface $driver): void;
 
   /**
    * Return a registered driver by name, or the default driver.
@@ -54,7 +54,7 @@ interface DrupalDriverManagerInterface {
    * @throws \InvalidArgumentException
    *   Thrown when the driver is not registered.
    */
-  public function setDefaultDriverName($name);
+  public function setDefaultDriverName($name): void;
 
   /**
    * Returns the Behat Environment.
@@ -70,6 +70,6 @@ interface DrupalDriverManagerInterface {
    * @param \Behat\Testwork\Environment\Environment $environment
    *   The Behat Environment to set.
    */
-  public function setEnvironment(Environment $environment);
+  public function setEnvironment(Environment $environment): void;
 
 }

--- a/src/Drupal/DrupalExtension/Context/Annotation/Reader.php
+++ b/src/Drupal/DrupalExtension/Context/Annotation/Reader.php
@@ -30,7 +30,7 @@ class Reader implements AnnotationReader {
   /**
    * Map of annotation names to their hook call class names.
    *
-   * @var string[]
+   * @var array<string, class-string<\Drupal\DrupalExtension\Hook\Call\EntityHook>>
    */
   private static array $classes = [
     'afternodecreate' => AfterNodeCreate::class,

--- a/src/Drupal/DrupalExtension/Context/Attribute/HookAttributeReader.php
+++ b/src/Drupal/DrupalExtension/Context/Attribute/HookAttributeReader.php
@@ -40,6 +40,11 @@ class HookAttributeReader implements AttributeReader {
 
   /**
    * {@inheritdoc}
+   *
+   * @param class-string<\Behat\Behat\Context\Context> $contextClass
+   *   The context class name.
+   * @param \ReflectionMethod $method
+   *   The reflected method.
    */
   public function readCallees(string $contextClass, \ReflectionMethod $method): array {
     $attributes = $method->getAttributes(DrupalHook::class, \ReflectionAttribute::IS_INSTANCEOF);

--- a/src/Drupal/DrupalExtension/Context/BatchContext.php
+++ b/src/Drupal/DrupalExtension/Context/BatchContext.php
@@ -59,7 +59,7 @@ class BatchContext extends RawMinkContext {
     $data = is_string($fields['data']) ? $fields['data'] : (string) json_encode($fields['data']);
     $query = $connection->insert('queue')
       ->fields([
-        'name' => $fields['name'] ?: $password_generator->generate(),
+        'name' => (($fields['name'] ?? '') !== '') ? $fields['name'] : $password_generator->generate(),
         'data' => serialize(json_decode($data)),
         'created' => $fields['created'] ?: $_SERVER['REQUEST_TIME'],
         'expire' => $fields['expire'] ?: 0,

--- a/src/Drupal/DrupalExtension/Context/BatchContext.php
+++ b/src/Drupal/DrupalExtension/Context/BatchContext.php
@@ -54,10 +54,13 @@ class BatchContext extends RawMinkContext {
     // @see SystemQueue::createItem().
     /** @var \Drupal\Core\Database\Connection $connection */
     $connection = \Drupal::service('database');
+    /** @var \Drupal\Core\Password\PasswordGeneratorInterface $password_generator */
+    $password_generator = \Drupal::service('password_generator');
+    $data = is_string($fields['data']) ? $fields['data'] : (string) json_encode($fields['data']);
     $query = $connection->insert('queue')
       ->fields([
-        'name' => $fields['name'] ?: \Drupal::service('password_generator')->generate(),
-        'data' => serialize(json_decode((string) $fields['data'])),
+        'name' => $fields['name'] ?: $password_generator->generate(),
+        'data' => serialize(json_decode($data)),
         'created' => $fields['created'] ?: $_SERVER['REQUEST_TIME'],
         'expire' => $fields['expire'] ?: 0,
       ]);

--- a/src/Drupal/DrupalExtension/Context/ConfigContext.php
+++ b/src/Drupal/DrupalExtension/Context/ConfigContext.php
@@ -30,9 +30,9 @@ class ConfigContext extends RawDrupalContext implements TranslatableContext {
   /**
    * Keep track of any config that was changed so they can easily be reverted.
    *
-   * @var array
+   * @var array<string, array<string, mixed>>
    */
-  protected $config = [];
+  protected array $config = [];
 
   /**
    * Revert any changed config.

--- a/src/Drupal/DrupalExtension/Context/DrupalAwareInterface.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalAwareInterface.php
@@ -19,12 +19,12 @@ interface DrupalAwareInterface extends Context {
   /**
    * Sets Drupal instance.
    */
-  public function setDrupal(DrupalDriverManagerInterface $drupal);
+  public function setDrupal(DrupalDriverManagerInterface $drupal): void;
 
   /**
    * Set event dispatcher.
    */
-  public function setDispatcher(HookDispatcher $dispatcher);
+  public function setDispatcher(HookDispatcher $dispatcher): void;
 
   /**
    * Gets Drupal instance.
@@ -36,13 +36,16 @@ interface DrupalAwareInterface extends Context {
 
   /**
    * Sets parameters provided for Drupal.
+   *
+   * @param array<string, mixed> $parameters
+   *   The Drupal parameters.
    */
-  public function setDrupalParameters(array $parameters);
+  public function setDrupalParameters(array $parameters): void;
 
   /**
    * Sets the Drupal user manager instance.
    */
-  public function setUserManager(DrupalUserManagerInterface $userManager);
+  public function setUserManager(DrupalUserManagerInterface $userManager): void;
 
   /**
    * Gets the Drupal user manager instance.
@@ -55,7 +58,7 @@ interface DrupalAwareInterface extends Context {
   /**
    * Sets the Drupal authentication manager instance.
    */
-  public function setAuthenticationManager(DrupalAuthenticationManagerInterface $authenticationManager);
+  public function setAuthenticationManager(DrupalAuthenticationManagerInterface $authenticationManager): void;
 
   /**
    * Gets the Drupal authentication manager instance.

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -23,10 +23,10 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
   /**
    * Returns list of definition translation resources paths.
    *
-   * @return array
+   * @return array<int, string>
    *   List of translation resource paths.
    */
-  public static function getTranslationResources() {
+  public static function getTranslationResources(): array {
     return self::getDrupalTranslationResources();
   }
 
@@ -81,7 +81,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    *
    * @param string $role
    *   A single role, or multiple comma-separated roles.
-   * @param array $extra_fields
+   * @param array<string, mixed> $extra_fields
    *   Optional associative array of additional fields to set on the user.
    */
   protected function createAndLoginUserWithRole(string $role, array $extra_fields = []): void {
@@ -111,7 +111,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    *
    * @param string $role
    *   The role to assign.
-   * @param array $extra_fields
+   * @param array<string, mixed> $extra_fields
    *   Optional additional fields.
    */
   protected function createUserStub(string $role, array $extra_fields = []): \stdClass {
@@ -380,11 +380,15 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
       throw new \Exception('There is no current logged in user to create a node for.');
     }
 
+    $current_user = $this->getUserManager()->getCurrentUser();
+    if (!$current_user instanceof \stdClass) {
+      throw new \Exception('There is no current logged in user to create a node for.');
+    }
     $node = (object) [
       'title' => $title,
       'type' => $type,
       'body' => $this->getRandom()->name(255),
-      'uid' => $this->getUserManager()->getCurrentUser()->uid,
+      'uid' => $current_user->uid,
     ];
     $saved = $this->nodeCreate($node);
 
@@ -584,7 +588,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
   public function iPutABreakpoint(): void {
     fwrite(STDOUT, "\033[s \033[93m[Breakpoint] Press \033[1;93m[RETURN]\033[0;93m to continue, or 'q' to quit...\033[0m");
     do {
-      $line = trim(fgets(STDIN, 1024));
+      $line = trim((string) fgets(STDIN, 1024));
       // Note: this assumes ASCII encoding.  Should probably be revamped to
       // handle other character sets.
       $char_code = ord($line);

--- a/src/Drupal/DrupalExtension/Context/DrupalSubContextBase.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalSubContextBase.php
@@ -27,12 +27,12 @@ abstract class DrupalSubContextBase extends RawDrupalContext implements DrupalSu
    *
    * @see \Drupal\DrupalExtension\Context\RawDrupalContext::getUserManager()
    */
-  protected function getUser() {
+  protected function getUser(): \stdClass {
     @trigger_error('DrupalSubContextBase::getUser() is deprecated in drupalextension:4.0.0 and is removed from drupalextension:5.0.0. Use RawDrupalContext::getUserManager()->getCurrentUser() instead. See https://www.drupal.org/project/drupalextension/issues/676', E_USER_DEPRECATED);
 
     $user = $this->getUserManager()->getCurrentUser();
 
-    if (empty($user)) {
+    if (!$user instanceof \stdClass) {
       throw new \Exception('No user is logged in.');
     }
 

--- a/src/Drupal/DrupalExtension/Context/DrushContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrushContext.php
@@ -15,10 +15,9 @@ class DrushContext extends RawDrupalContext implements TranslatableContext {
 
   /**
    * Keep track of drush output.
-   *
-   * @var string|bool
    */
-  protected $drushOutput;
+  // phpcs:ignore DrevOps.NamingConventions.LocalVariableNaming.NotSnakeCase
+  protected string|bool|null $drushOutput = NULL;
 
   /**
    * {@inheritdoc}
@@ -30,10 +29,10 @@ class DrushContext extends RawDrupalContext implements TranslatableContext {
   /**
    * Return the most recent drush command output.
    *
-   * @return string
+   * @return string|bool
    *   The most recent drush command output.
    */
-  public function readDrushOutput() {
+  public function readDrushOutput(): string|bool {
     if ($this->drushOutput === NULL) {
       throw new \RuntimeException('No drush output was found.');
     }

--- a/src/Drupal/DrupalExtension/Context/Environment/Reader/Reader.php
+++ b/src/Drupal/DrupalExtension/Context/Environment/Reader/Reader.php
@@ -188,7 +188,7 @@ final class Reader implements EnvironmentReader {
    * @return string[]
    *   An array of file paths keyed by real path.
    */
-  protected function findAvailableSubContexts(string $path, string $pattern = '/^.+\.behat\.inc/i') {
+  protected function findAvailableSubContexts(string $path, string $pattern = '/^.+\.behat\.inc/i'): array {
 
     if (isset(self::$subContexts[$pattern][$path])) {
       return self::$subContexts[$pattern][$path];

--- a/src/Drupal/DrupalExtension/Context/Environment/Reader/Reader.php
+++ b/src/Drupal/DrupalExtension/Context/Environment/Reader/Reader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Context\Environment\Reader;
 
+use Behat\Behat\Context\Context;
 use Behat\Behat\Context\Environment\UninitializedContextEnvironment;
 use Behat\Behat\Context\Environment\ContextEnvironment;
 use Behat\Behat\Context\Reader\ContextReader;
@@ -31,21 +32,20 @@ final class Reader implements EnvironmentReader {
   /**
    * Statically cached lists of subcontexts by path.
    *
-   * @var array
+   * @var array<string, array<string, array<string, string>>>
    */
-  protected static $subContexts;
+  protected static array $subContexts = [];
 
   /**
    * Register the Drupal driver manager.
+   *
+   * @param \Drupal\DrupalDriverManager $drupalDriverManager
+   *   Drupal driver manager.
+   * @param array<string, mixed> $parameters
+   *   Configuration parameters for this suite.
    */
   public function __construct(
-    /**
-     * Drupal driver manager.
-     */
     private readonly DrupalDriverManager $drupalDriverManager,
-    /**
-     * Configuration parameters for this suite.
-     */
     private array $parameters,
   ) {
   }
@@ -127,7 +127,7 @@ final class Reader implements EnvironmentReader {
   /**
    * Finds and loads available subcontext classes.
    *
-   * @return class-string[]
+   * @return array<int, class-string<Context>>
    *   An array of fully-qualified class names.
    */
   protected function findSubContextClasses(): array {
@@ -167,7 +167,7 @@ final class Reader implements EnvironmentReader {
       $classes = get_declared_classes();
       foreach ($classes as $class) {
         $reflect = new \ReflectionClass($class);
-        if (!$reflect->isAbstract() && $reflect->implementsInterface(DrupalSubContextInterface::class)) {
+        if (!$reflect->isAbstract() && $reflect->implementsInterface(DrupalSubContextInterface::class) && is_subclass_of($class, Context::class)) {
           @trigger_error('Sub-context support is deprecated in drupalextension:4.0.0 and is removed from drupalextension:4.1.0. Class ' . $class . ' is a sub-context. This logic should be moved to a normal Behat context and loaded via behat.yml. See https://www.drupal.org/project/drupalextension/issues/676', E_USER_DEPRECATED);
           $class_names[] = $class;
         }
@@ -213,10 +213,10 @@ final class Reader implements EnvironmentReader {
   /**
    * Load each subcontext file.
    *
-   * @param array $subcontexts
+   * @param array<string, string> $subcontexts
    *   An array of files to include.
    */
-  protected function loadSubContexts($subcontexts): void {
+  protected function loadSubContexts(array $subcontexts): void {
     foreach ($subcontexts as $path => $subcontext) {
       if (!file_exists($path)) {
         throw new \RuntimeException(sprintf('Subcontext path %s path does not exist.', $path));

--- a/src/Drupal/DrupalExtension/Context/Initializer/DrupalAwareInitializer.php
+++ b/src/Drupal/DrupalExtension/Context/Initializer/DrupalAwareInitializer.php
@@ -23,7 +23,7 @@ class DrupalAwareInitializer implements ContextInitializer {
    *
    * @param \Drupal\DrupalDriverManager $drupalDriverManager
    *   The Drupal driver manager.
-   * @param array $parameters
+   * @param array<string, mixed> $parameters
    *   Configuration parameters.
    * @param \Behat\Testwork\Hook\HookDispatcher $hookDispatcher
    *   The hook dispatcher.

--- a/src/Drupal/DrupalExtension/Context/MailContext.php
+++ b/src/Drupal/DrupalExtension/Context/MailContext.php
@@ -96,7 +96,7 @@ class MailContext extends RawMailContext {
     ];
 
     foreach ($fields->getRowsHash() as $field => $value) {
-      $mail[$field] = $value;
+      $mail[$field] = is_array($value) ? implode("\n", $value) : (string) $value;
     }
 
     $driver = $this->getDriver();
@@ -129,7 +129,7 @@ class MailContext extends RawMailContext {
   #[Then('(a )(an )(e)mail(s) has/have been sent to :to with the subject :subject:')]
   public function mailHasBeenSent(TableNode $expectedMailTable, string $to = '', string $subject = ''): void {
     $expected = $expectedMailTable->getHash();
-    $actual = $this->getMail(['to' => $to, 'subject' => $subject]);
+    $actual = array_values($this->getMail(['to' => $to, 'subject' => $subject]));
     $this->compareMessages($actual, $expected);
   }
 
@@ -151,7 +151,7 @@ class MailContext extends RawMailContext {
   #[Then('(a )(an )new (e)mail(s) is/are sent to :to with the subject :subject:')]
   public function newMailIsSent(TableNode $expectedMailTable, string $to = '', string $subject = ''): void {
     $expected = $expectedMailTable->getHash();
-    $actual = $this->getMail(['to' => $to, 'subject' => $subject], TRUE);
+    $actual = array_values($this->getMail(['to' => $to, 'subject' => $subject], TRUE));
     $this->compareMessages($actual, $expected);
   }
 
@@ -169,7 +169,7 @@ class MailContext extends RawMailContext {
   #[Then(':count (e)mail(s) has/have been sent with the subject :subject')]
   #[Then(':count (e)mail(s) has/have been sent to :to with the subject :subject')]
   public function noMailHasBeenSent(string $count, string $to = '', string $subject = ''): void {
-    $actual = $this->getMail(['to' => $to, 'subject' => $subject]);
+    $actual = array_values($this->getMail(['to' => $to, 'subject' => $subject]));
     $expected_count = match ($count) {
       'no' => 0,
             'a', 'an' => NULL,
@@ -191,7 +191,7 @@ class MailContext extends RawMailContext {
   #[Then(':count new (e)mail(s) is/are sent with the subject :subject')]
   #[Then(':count new (e)mail(s) is/are sent to :to with the subject :subject')]
   public function noNewMailIsSent(string $count, string $to = '', string $subject = ''): void {
-    $actual = $this->getMail(['to' => $to, 'subject' => $subject], TRUE);
+    $actual = array_values($this->getMail(['to' => $to, 'subject' => $subject], TRUE));
     $expected_count = match ($count) {
       'no' => 0,
             'a', 'an' => 1,

--- a/src/Drupal/DrupalExtension/Context/MessageContext.php
+++ b/src/Drupal/DrupalExtension/Context/MessageContext.php
@@ -336,7 +336,7 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
    * @param string $expected_header
    *   The header that should be present in the list.
    */
-  protected function assertValidMessageTable(TableNode $messages, string $expected_header) {
+  protected function assertValidMessageTable(TableNode $messages, string $expected_header): void {
     // Check that the table only contains a single column.
     $header_row = $messages->getRow(0);
 
@@ -347,7 +347,7 @@ class MessageContext extends RawDrupalContext implements TranslatableContext {
 
     // Check that the correct header is used.
     $actual_header = reset($header_row);
-    if (strtolower(trim($actual_header)) !== $expected_header) {
+    if (strtolower(trim((string) $actual_header)) !== $expected_header) {
       $capitalized_header = ucfirst($expected_header);
       throw new \RuntimeException(sprintf("The list of %s should have the header '%s', but found '%s'.", $expected_header, $capitalized_header, $actual_header));
     }

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -33,7 +33,10 @@ class MinkContext extends MinkExtension implements TranslatableContext {
    *   List of translation resource paths.
    */
   public static function getTranslationResources(): array {
-    return self::getMinkTranslationResources() + (glob(__DIR__ . '/../../../../i18n/*.xliff') ?: []);
+    return array_merge(
+      self::getMinkTranslationResources(),
+      glob(__DIR__ . '/../../../../i18n/*.xliff') ?: [],
+    );
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -29,11 +29,11 @@ class MinkContext extends MinkExtension implements TranslatableContext {
   /**
    * Returns list of definition translation resources paths.
    *
-   * @return array
+   * @return array<int, string>
    *   List of translation resource paths.
    */
-  public static function getTranslationResources() {
-    return self::getMinkTranslationResources() + glob(__DIR__ . '/../../../../i18n/*.xliff');
+  public static function getTranslationResources(): array {
+    return self::getMinkTranslationResources() + (glob(__DIR__ . '/../../../../i18n/*.xliff') ?: []);
   }
 
   /**
@@ -186,7 +186,7 @@ JS;
    * @endcode
    */
   #[When('I press the :button button')]
-  public function pressButton(mixed $button) {
+  public function pressButton(mixed $button): void {
     // Wait for any open autocomplete boxes to finish closing.  They block
     // form-submission if they are still open.
     // Use a step 'I press the "Esc" key in the "LABEL" field' to close
@@ -202,7 +202,7 @@ JS;
     }
 
     // Use the Mink Extension step definition.
-    return parent::pressButton($button);
+    parent::pressButton($button);
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Context/RandomContext.php
+++ b/src/Drupal/DrupalExtension/Context/RandomContext.php
@@ -17,9 +17,9 @@ class RandomContext extends RawDrupalContext {
   /**
    * Tracks variable names for consistent replacement during a given scenario.
    *
-   * @var array
+   * @var array<string, string>
    */
-  protected $values = [];
+  protected array $values = [];
 
   /**
    * The regex to use for variable replacement.
@@ -30,6 +30,9 @@ class RandomContext extends RawDrupalContext {
 
   /**
    * Transform random variables.
+   *
+   * @return string|array<int, string>|null
+   *   The transformed message.
    */
   #[Transform('#([^<]*\<\?.*\>[^>]*)#')]
   public function transformVariables(string $message): string|array|null {
@@ -52,7 +55,8 @@ class RandomContext extends RawDrupalContext {
   public function transformTable(TableNode $table): TableNode {
     $rows = [];
     foreach ($table->getRows() as $row) {
-      $rows[] = array_map($this->transformVariables(...), $row);
+      $transformed = array_map($this->transformVariables(...), $row);
+      $rows[] = array_map(static fn (array|string|null $v): string => is_array($v) ? implode(',', $v) : (string) $v, $transformed);
     }
     return new TableNode($rows);
   }

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -69,30 +69,30 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   /**
    * Keep track of nodes so they can be cleaned up.
    *
-   * @var array
+   * @var array<int, \stdClass>
    */
-  protected $nodes = [];
+  protected array $nodes = [];
 
   /**
    * Keep track of all terms that are created so they can easily be removed.
    *
-   * @var array
+   * @var array<int, \stdClass>
    */
-  protected $terms = [];
+  protected array $terms = [];
 
   /**
    * Keep track of any roles that are created so they can easily be removed.
    *
-   * @var array
+   * @var array<int, string>
    */
-  protected $roles = [];
+  protected array $roles = [];
 
   /**
    * Keep track of any languages that are created so they can easily be removed.
    *
-   * @var array
+   * @var array<int, \stdClass>
    */
-  protected $languages = [];
+  protected array $languages = [];
 
   /**
    * {@inheritdoc}
@@ -331,12 +331,12 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   /**
    * Dispatch scope hooks.
    *
-   * @param class-string $scopeClass
+   * @param class-string<\Behat\Testwork\Hook\Scope\HookScope> $scopeClass
    *   The fully-qualified scope class name.
    * @param \stdClass $entity
    *   The entity.
    */
-  protected function dispatchHooks(string $scopeClass, \stdClass $entity) {
+  protected function dispatchHooks(string $scopeClass, \stdClass $entity): void {
     $scope = new $scopeClass($this->getDrupal()->getEnvironment(), $this, $entity);
     $call_results = $this->dispatcher->dispatchScopeHooks($scope);
 
@@ -352,10 +352,10 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   /**
    * Create a node.
    *
-   * @return object
+   * @return \stdClass
    *   The created node.
    */
-  public function nodeCreate(\stdClass $node): object {
+  public function nodeCreate(\stdClass $node): \stdClass {
     $this->dispatchHooks(BeforeNodeCreateScope::class, $node);
     $this->parseEntityFields('node', $node, ['author']);
 
@@ -367,6 +367,11 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
 
     $scalars = $this->captureScalarBaseFields($node);
     $saved = $driver->nodeCreate($node);
+
+    if (!$saved instanceof \stdClass) {
+      throw new \RuntimeException(sprintf('The Drupal driver "%s" returned a non-stdClass object from nodeCreate().', $driver::class));
+    }
+
     $this->restoreScalarBaseFields($saved, $scalars);
 
     $this->dispatchHooks(AfterNodeCreateScope::class, $saved);
@@ -561,12 +566,11 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
       }
     }
 
-    // Add the multicolumn fields to the entity.
+    // Add the multicolumn fields to the entity. Each entry in
+    // 'multicolumn_fields' is only set when there is at least one non-blank
+    // cell (see the population logic above).
     foreach ($multicolumn_fields as $field_name => $columns) {
-      // Don't specify any value if the step author has left it blank.
-      if (count(array_filter($columns, fn($var): bool => $var !== '')) > 0) {
-        $entity->$field_name = $columns;
-      }
+      $entity->$field_name = $columns;
     }
   }
 
@@ -599,10 +603,10 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   /**
    * Create a term.
    *
-   * @return object
+   * @return \stdClass
    *   The created term.
    */
-  public function termCreate(\stdClass $term): object {
+  public function termCreate(\stdClass $term): \stdClass {
     // The 3.x DrupalDriver only loads vocabularies by machine name. Allow
     // the Gherkin author to pass either the machine name or the human
     // label by resolving the label to a machine name when the literal
@@ -633,6 +637,11 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
 
     $scalars = $this->captureScalarBaseFields($term);
     $saved = $driver->termCreate($term);
+
+    if (!$saved instanceof \stdClass) {
+      throw new \RuntimeException(sprintf('The Drupal driver "%s" returned a non-stdClass object from termCreate().', $driver::class));
+    }
+
     $this->restoreScalarBaseFields($saved, $scalars);
 
     $this->dispatchHooks(AfterTermCreateScope::class, $saved);
@@ -818,7 +827,6 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    *   cannot yet be retrieved.
    */
   protected function getContext($class): object|false {
-    /** @var \Behat\Behat\Context\Environment\InitializedContextEnvironment $environment */
     $environment = $this->drupalDriverManager->getEnvironment();
     // Throw an exception if the environment is not yet initialized. To make
     // sure state doesn't leak between test scenarios, the environment is
@@ -840,11 +848,11 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   /**
    * Returns the paths to the translation resources for the Drupal extension.
    *
-   * @return array
+   * @return array<int, string>
    *   List of translation resource paths.
    */
   protected static function getDrupalTranslationResources(): array {
-    return glob(__DIR__ . '/../../../../i18n/*.xliff');
+    return glob(__DIR__ . '/../../../../i18n/*.xliff') ?: [];
   }
 
 }

--- a/src/Drupal/DrupalExtension/Context/RawMailContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawMailContext.php
@@ -15,28 +15,26 @@ class RawMailContext extends RawDrupalContext {
 
   /**
    * The mail manager.
-   *
-   * @var \Drupal\DrupalMailManagerInterface
    */
-  protected $mailManager;
+  protected ?DrupalMailManager $mailManager = NULL;
 
   /**
    * The number of mails received so far in this scenario, for each mail store.
    *
-   * @var array
+   * @var array<string, int>
    */
-  protected $mailMessageCount = [];
+  protected array $mailMessageCount = [];
 
   /**
    * Get the mail manager service that handles stored test mail.
    *
-   * @return \Drupal\DrupalMailManagerInterface
+   * @return \Drupal\DrupalMailManager
    *   The mail manager service.
    */
-  protected function getMailManager() {
+  protected function getMailManager(): DrupalMailManager {
     // Persist the mail manager between invocations. This is necessary for
     // remembering and reinstating the original mail backend.
-    if (is_null($this->mailManager)) {
+    if (!$this->mailManager instanceof DrupalMailManager) {
       $driver = $this->getDriver();
 
       if (!$driver instanceof MailCapabilityInterface) {
@@ -52,7 +50,7 @@ class RawMailContext extends RawDrupalContext {
   /**
    * Get collected mail, matching certain specifications.
    *
-   * @param array $criteria
+   * @param array<string, string> $criteria
    *   Associative array of mail fields and the values to filter by.
    * @param bool $new
    *   Whether to ignore previously seen mail.
@@ -94,7 +92,7 @@ class RawMailContext extends RawDrupalContext {
    * @return int
    *   The number of mails received during this scenario.
    */
-  protected function getMailMessageCount(string $store) {
+  protected function getMailMessageCount(string $store): int {
     if (array_key_exists($store, $this->mailMessageCount)) {
       return $this->mailMessageCount[$store];
     }
@@ -105,9 +103,9 @@ class RawMailContext extends RawDrupalContext {
   /**
    * Determine if a mail meets criteria.
    *
-   * @param array $message
+   * @param array<string, mixed> $message
    *   The mail message as an associative array of mail fields.
-   * @param array $criteria
+   * @param array<string, mixed> $criteria
    *   The criteria: an associative array of mail fields and desired values.
    *
    * @return bool
@@ -115,7 +113,7 @@ class RawMailContext extends RawDrupalContext {
    */
   protected function matchMessage(array $message, array $criteria): bool {
     // Discard criteria that are just zero-length strings.
-    $criteria = array_filter($criteria, strlen(...));
+    $criteria = array_filter($criteria, static fn ($value): bool => (string) $value !== '');
 
     // For each criteria, check the specified mail field contains the value.
     foreach ($criteria as $field => $value) {
@@ -131,12 +129,12 @@ class RawMailContext extends RawDrupalContext {
   /**
    * Compare actual mail with expected mail.
    *
-   * @param array $actualMessages
+   * @param array<int, array<string, mixed>> $actualMessages
    *   An array of actual mail.
-   * @param array $expectedMessages
+   * @param array<int, array<string, mixed>> $expectedMessages
    *   An array of expected mail.
    */
-  protected function compareMessages(array $actualMessages, array $expectedMessages) {
+  protected function compareMessages(array $actualMessages, array $expectedMessages): void {
     // Make sure there is the same number of actual and expected.
     $expected_count = count($expectedMessages);
     $this->assertMessageCount($actualMessages, $expected_count);
@@ -160,12 +158,12 @@ class RawMailContext extends RawDrupalContext {
   /**
    * Assert there is the expected number of mail messages.
    *
-   * @param array $actualMessages
+   * @param array<int, array<string, mixed>> $actualMessages
    *   An array of actual mail.
    * @param int $expectedCount
    *   Optional. The number of mails expected.
    */
-  protected function assertMessageCount(array $actualMessages, ?int $expectedCount = NULL) {
+  protected function assertMessageCount(array $actualMessages, ?int $expectedCount = NULL): void {
     $actual_count = count($actualMessages);
     if (is_null($expectedCount)) {
       // If number to expect is not specified, expect more than zero.
@@ -189,10 +187,10 @@ class RawMailContext extends RawDrupalContext {
   /**
    * Sort mail by to, subject and body.
    *
-   * @param array $messages
+   * @param array<int, array<string, mixed>> $messages
    *   An array of mail messages to sort.
    *
-   * @return array
+   * @return array<int, array<string, mixed>>
    *   The same mail, but sorted.
    */
   protected function sortMessages(array $messages): array {
@@ -211,10 +209,10 @@ class RawMailContext extends RawDrupalContext {
   /**
    * Get the mink context, so we can visit pages using the mink session.
    */
-  protected function getMinkContext(): object {
+  protected function getMinkContext(): RawMinkContext {
     $mink_context = $this->getContext(RawMinkContext::class);
 
-    if ($mink_context === FALSE) {
+    if (!$mink_context instanceof RawMinkContext) {
       throw new \Exception('No mink context found.');
     }
 

--- a/src/Drupal/DrupalExtension/DrupalParametersTrait.php
+++ b/src/Drupal/DrupalExtension/DrupalParametersTrait.php
@@ -16,14 +16,14 @@ trait DrupalParametersTrait {
   /**
    * Test parameters.
    *
-   * @var array
+   * @var array<string, mixed>
    */
-  protected $drupalParameters;
+  protected array $drupalParameters = [];
 
   /**
    * Set parameters provided for Drupal.
    *
-   * @param array $parameters
+   * @param array<string, mixed> $parameters
    *   The parameters to set.
    */
   public function setDrupalParameters(array $parameters): void {

--- a/src/Drupal/DrupalExtension/Listener/DriverListener.php
+++ b/src/Drupal/DrupalExtension/Listener/DriverListener.php
@@ -21,14 +21,16 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class DriverListener implements EventSubscriberInterface {
 
+  /**
+   * Constructs a DriverListener.
+   *
+   * @param \Drupal\DrupalDriverManager $drupalDriverManager
+   *   Drupal driver manager.
+   * @param array<string, mixed> $parameters
+   *   Test parameters.
+   */
   public function __construct(
-    /**
-     * Drupal driver manager.
-     */
     private readonly DrupalDriverManager $drupalDriverManager,
-    /**
-     * Test parameters.
-     */
     private array $parameters,
   ) {
   }

--- a/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Manager;
 
+use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Element\DocumentElement;
 use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Mink;
@@ -22,6 +23,17 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
 
   /**
    * Constructs a DrupalAuthenticationManager object.
+   *
+   * @param \Behat\Mink\Mink $mink
+   *   The Mink instance.
+   * @param \Drupal\DrupalExtension\Manager\DrupalUserManagerInterface $userManager
+   *   The Drupal user manager.
+   * @param \Drupal\DrupalDriverManagerInterface $driverManager
+   *   The Drupal driver manager.
+   * @param array<string, mixed> $minkParameters
+   *   Mink configuration parameters.
+   * @param array<string, mixed> $drupalParameters
+   *   Drupal configuration parameters.
    */
   public function __construct(
     Mink $mink,
@@ -55,7 +67,7 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
 
     // Submit the login form.
     $login_element = $this->getLoginElement($page);
-    if (empty($login_element)) {
+    if (!$login_element instanceof NodeElement) {
       throw new \Exception(sprintf('No submit button at %s', $session->getCurrentUrl()));
     }
     $login_element->click();
@@ -111,7 +123,7 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
     if ($session->getCurrentUrl() === $logout_confirm_url) {
       $logout_element = $this->getLogoutConfirmElement($session->getPage());
 
-      if (empty($logout_element)) {
+      if (!$logout_element instanceof NodeElement) {
         throw new \Exception(sprintf("Unable to determine if logged out because '%s' button cannot be found on the logout confirmation page at %s", $this->getDrupalText('log_out'), $session->getCurrentUrl()));
       }
 
@@ -137,8 +149,12 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
     }
 
     // If the page is not available, then there is no user logged in.
+    // Using a nullsafe call here so PHPStan does not flag the non-nullable
+    // 'getPage()' return type while still allowing test doubles that return
+    // 'NULL' to short-circuit safely.
     $page = $session->getPage();
-    if (!$page) {
+    // @phpstan-ignore identical.alwaysFalse
+    if ($page === NULL) {
       return FALSE;
     }
 
@@ -167,7 +183,7 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
     // While not perfect, this is how Drupal SimpleTests currently work as
     // well.
     $session->visit($this->locatePath('/'));
-    if ($this->getLogoutElement()) {
+    if ($this->getLogoutElement() instanceof NodeElement) {
       return TRUE;
     }
 
@@ -198,7 +214,7 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
   /**
    * Get the login element from the page.
    */
-  protected function getLoginElement(DocumentElement $element) {
+  protected function getLoginElement(DocumentElement $element): ?NodeElement {
     // @todo v6: Rename `log_in` to `login_text`.
     return $element->findButton($this->getDrupalText('log_in'));
   }
@@ -206,7 +222,7 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
   /**
    * Get the logout element from the page.
    */
-  public function getLogoutElement() {
+  public function getLogoutElement(): ?NodeElement {
     // @todo v6: Rename `log_out` to `logout_text`.
     return $this->getSession()->getPage()->findLink($this->getDrupalText('log_out'));
   }
@@ -214,7 +230,7 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
   /**
    * Get the logout confirm element from the page.
    */
-  protected function getLogoutConfirmElement(DocumentElement $element) {
+  protected function getLogoutConfirmElement(DocumentElement $element): ?NodeElement {
     // @todo v6: Rename `log_out` to `logout_text`.
     return $element->findButton($this->getDrupalText('log_out'));
   }

--- a/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManagerInterface.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManagerInterface.php
@@ -15,12 +15,12 @@ interface DrupalAuthenticationManagerInterface {
    * @param \stdClass $user
    *   The user to log in.
    */
-  public function logIn(\stdClass $user);
+  public function logIn(\stdClass $user): void;
 
   /**
    * Logs the current user out.
    */
-  public function logOut();
+  public function logOut(): void;
 
   /**
    * Determine if a user is already logged in.

--- a/src/Drupal/DrupalExtension/Manager/DrupalUserManager.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalUserManager.php
@@ -11,22 +11,20 @@ class DrupalUserManager implements DrupalUserManagerInterface {
 
   /**
    * The user object representing the currently logged in user.
-   *
-   * @var \stdClass|false
    */
-  protected $user = FALSE;
+  protected \stdClass|bool $user = FALSE;
 
   /**
    * An array of user objects representing users created during the test.
    *
    * @var \stdClass[]
    */
-  protected $users = [];
+  protected array $users = [];
 
   /**
    * {@inheritdoc}
    */
-  public function getCurrentUser() {
+  public function getCurrentUser(): \stdClass|bool {
     return $this->user;
   }
 
@@ -64,7 +62,7 @@ class DrupalUserManager implements DrupalUserManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getUsers() {
+  public function getUsers(): array {
     return $this->users;
   }
 

--- a/src/Drupal/DrupalExtension/Manager/DrupalUserManagerInterface.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalUserManagerInterface.php
@@ -23,7 +23,7 @@ interface DrupalUserManagerInterface {
    * @param \stdClass|bool $user
    *   The user object, or FALSE if the user has been logged out.
    */
-  public function setCurrentUser(\stdClass|bool $user);
+  public function setCurrentUser(\stdClass|bool $user): void;
 
   /**
    * Adds a new user.
@@ -37,7 +37,7 @@ interface DrupalUserManagerInterface {
    *
    * @see \Drupal\DrupalExtension\Context\RawDrupalContext::cleanUsers()
    */
-  public function addUser(\stdClass $user);
+  public function addUser(\stdClass $user): void;
 
   /**
    * Removes a user from the list of users that were created in the test.
@@ -45,7 +45,7 @@ interface DrupalUserManagerInterface {
    * @param string $userName
    *   The name of the user to remove.
    */
-  public function removeUser(string $userName);
+  public function removeUser(string $userName): void;
 
   /**
    * Returns the list of users that were created in the test.
@@ -72,7 +72,7 @@ interface DrupalUserManagerInterface {
   /**
    * Clears the list of users that were created in the test.
    */
-  public function clearUsers();
+  public function clearUsers(): void;
 
   /**
    * Returns whether or not any users were created in the test.

--- a/src/Drupal/DrupalExtension/Manager/FastLogoutInterface.php
+++ b/src/Drupal/DrupalExtension/Manager/FastLogoutInterface.php
@@ -17,6 +17,6 @@ interface FastLogoutInterface {
    *
    * @todo v6: Rename to logoutFast().
    */
-  public function fastLogout();
+  public function fastLogout(): void;
 
 }

--- a/src/Drupal/DrupalExtension/MinkAwareTrait.php
+++ b/src/Drupal/DrupalExtension/MinkAwareTrait.php
@@ -18,17 +18,15 @@ trait MinkAwareTrait {
 
   /**
    * The Mink sessions manager.
-   *
-   * @var \Behat\Mink\Mink
    */
-  protected $mink;
+  protected Mink $mink;
 
   /**
    * The parameters for the Mink extension.
    *
-   * @var array
+   * @var array<string, mixed>
    */
-  protected $minkParameters;
+  protected array $minkParameters = [];
 
   /**
    * Sets the Mink sessions manager.
@@ -67,15 +65,18 @@ trait MinkAwareTrait {
   /**
    * Returns the parameters provided for Mink.
    *
-   * @return array
+   * @return array<string, mixed>
    *   An array of Mink parameters.
    */
-  public function getMinkParameters() {
+  public function getMinkParameters(): array {
     return $this->minkParameters;
   }
 
   /**
    * Sets parameters provided for Mink.
+   *
+   * @param array<string, mixed> $parameters
+   *   The Mink parameters to set.
    */
   public function setMinkParameters(array $parameters): void {
     $this->minkParameters = $parameters;
@@ -130,7 +131,7 @@ trait MinkAwareTrait {
    * Override to provide custom routing mechanism.
    */
   public function locatePath(string $path): string {
-    $start_url = rtrim($this->getMinkParameter('base_url'), '/') . '/';
+    $start_url = rtrim((string) $this->getMinkParameter('base_url'), '/') . '/';
 
     return str_starts_with($path, 'http') ? $path : $start_url . ltrim($path, '/');
   }
@@ -147,7 +148,7 @@ trait MinkAwareTrait {
   public function saveScreenshot(?string $filename = NULL, ?string $filepath = NULL): void {
     // Under Cygwin, uniqid with more_entropy must be set to true.
     // No effect in other environments.
-    $filename = $filename ?: sprintf('%s_%s_%s.%s', $this->getMinkParameter('browser_name'), date('c'), uniqid('', TRUE), 'png');
+    $filename = $filename ?: sprintf('%s_%s_%s.%s', (string) $this->getMinkParameter('browser_name'), date('c'), uniqid('', TRUE), 'png');
     $filepath = $filepath ?: ((ini_get('upload_tmp_dir') ?: sys_get_temp_dir()));
     file_put_contents($filepath . '/' . $filename, $this->getSession()->getScreenshot());
   }

--- a/src/Drupal/DrupalExtension/Selector/RegionSelector.php
+++ b/src/Drupal/DrupalExtension/Selector/RegionSelector.php
@@ -12,6 +12,14 @@ use Behat\Mink\Selector\CssSelector;
  */
 class RegionSelector implements SelectorInterface {
 
+  /**
+   * Constructs a RegionSelector.
+   *
+   * @param \Behat\Mink\Selector\CssSelector $cssSelector
+   *   The CSS selector.
+   * @param array<string, string> $regionMap
+   *   Map of region names to CSS selectors.
+   */
   public function __construct(private readonly CssSelector $cssSelector, private array $regionMap) {
   }
 

--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -57,7 +57,7 @@ class DrupalExtension implements ExtensionInterface {
   /**
    * {@inheritdoc}
    */
-  public function initialize(ExtensionManager $extensionManager) {
+  public function initialize(ExtensionManager $extensionManager): void {
   }
 
   /**
@@ -223,6 +223,11 @@ class DrupalExtension implements ExtensionInterface {
 
   /**
    * Load test parameters.
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+   *   The container builder.
+   * @param array<string, mixed> $config
+   *   The extension configuration.
    */
   protected function loadParameters(ContainerBuilder $container, array $config): void {
     $container->setParameter('drupal.parameters', $config);
@@ -239,6 +244,13 @@ class DrupalExtension implements ExtensionInterface {
 
   /**
    * Load the Drupal driver.
+   *
+   * @param \Symfony\Component\DependencyInjection\Loader\FileLoader $loader
+   *   The file loader.
+   * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+   *   The container builder.
+   * @param array<string, mixed> $config
+   *   The extension configuration.
    */
   protected function loadDrupal(FileLoader $loader, ContainerBuilder $container, array $config): void {
     if (isset($config['drupal'])) {
@@ -249,6 +261,13 @@ class DrupalExtension implements ExtensionInterface {
 
   /**
    * Load the Drush driver.
+   *
+   * @param \Symfony\Component\DependencyInjection\Loader\FileLoader $loader
+   *   The file loader.
+   * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+   *   The container builder.
+   * @param array<string, mixed> $config
+   *   The extension configuration.
    */
   protected function loadDrush(FileLoader $loader, ContainerBuilder $container, array $config): void {
     if (isset($config['drush'])) {
@@ -312,6 +331,11 @@ class DrupalExtension implements ExtensionInterface {
 
   /**
    * Set global drush arguments.
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+   *   The container builder.
+   * @param array<string, mixed> $config
+   *   The extension configuration.
    */
   protected function setDrushOptions(ContainerBuilder $container, array $config): void {
     if (isset($config['drush']['global_options'])) {

--- a/src/Drupal/DrupalMailManager.php
+++ b/src/Drupal/DrupalMailManager.php
@@ -64,7 +64,7 @@ class DrupalMailManager implements DrupalMailManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function clearMail($store = 'default'): void {
+  public function clearMail(string $store = 'default'): void {
     $this->assertDefaultStore($store);
 
     $this->driver->mailClear();

--- a/src/Drupal/DrupalMailManagerInterface.php
+++ b/src/Drupal/DrupalMailManagerInterface.php
@@ -12,22 +12,22 @@ interface DrupalMailManagerInterface {
   /**
    * Collect outbound mail for analysis.
    */
-  public function startCollectingMail();
+  public function startCollectingMail(): void;
 
   /**
    * Stop collecting outbound mail.
    */
-  public function stopCollectingMail();
+  public function stopCollectingMail(): void;
 
   /**
    * Allow mail to be actually sent out.
    */
-  public function enableMail();
+  public function enableMail(): void;
 
   /**
    * Prevent mail from being actually sent out.
    */
-  public function disableMail();
+  public function disableMail(): void;
 
   /**
    * Get all collected mail.
@@ -40,11 +40,14 @@ interface DrupalMailManagerInterface {
    *   array as produced by 'MailInterface::mail()' - the keys include
    *   'to', 'subject', 'body', 'headers', etc.
    */
-  public function getMail($store);
+  public function getMail(string $store);
 
   /**
    * Empty the store of collected mail.
+   *
+   * @param string $store
+   *   The name of the mail store to clear.
    */
-  public function clearMail($store);
+  public function clearMail(string $store): void;
 
 }

--- a/src/Drupal/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
+++ b/src/Drupal/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
@@ -65,7 +65,13 @@ class BrowserKitFactory extends BrowserKitFactoryOriginal {
    * @codeCoverageIgnore
    */
   protected function getCwd(): string {
-    return (string) getcwd();
+    $cwd = getcwd();
+
+    if ($cwd === FALSE) {
+      throw new \RuntimeException('Unable to determine the current working directory.');
+    }
+
+    return $cwd;
   }
 
   /**

--- a/src/Drupal/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
+++ b/src/Drupal/MinkExtension/ServiceContainer/Driver/BrowserKitFactory.php
@@ -18,6 +18,9 @@ class BrowserKitFactory extends BrowserKitFactoryOriginal {
 
   /**
    * {@inheritdoc}
+   *
+   * @param array<string, mixed> $config
+   *   Driver configuration.
    */
   public function buildDriver(array $config): Definition {
     if (!class_exists(BrowserKitDriver::class)) {
@@ -62,7 +65,7 @@ class BrowserKitFactory extends BrowserKitFactoryOriginal {
    * @codeCoverageIgnore
    */
   protected function getCwd(): string {
-    return getcwd();
+    return (string) getcwd();
   }
 
   /**

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -176,7 +176,8 @@ class FeatureContext extends RawDrupalContext {
    */
   #[AfterNodeCreate]
   public static function testAfterNodeCreate(EntityScope $scope): void {
-    if (!$node = $scope->getEntity()) {
+    $node = $scope->getEntity();
+    if (empty((array) $node)) {
       throw new \Exception('Failed to find a node in @afterNodeCreate hook.');
     }
   }
@@ -186,7 +187,8 @@ class FeatureContext extends RawDrupalContext {
    */
   #[AfterTermCreate]
   public static function testAfterTermCreate(EntityScope $scope): void {
-    if (!$term = $scope->getEntity()) {
+    $term = $scope->getEntity();
+    if (empty((array) $term)) {
       throw new \Exception('Failed to find a term in @afterTermCreate hook.');
     }
   }
@@ -196,7 +198,8 @@ class FeatureContext extends RawDrupalContext {
    */
   #[AfterUserCreate]
   public static function testAfterUserCreate(EntityScope $scope): void {
-    if (!$user = $scope->getEntity()) {
+    $user = $scope->getEntity();
+    if (empty((array) $user)) {
       throw new \Exception('Failed to find a user in @afterUserCreate hook.');
     }
   }
@@ -219,6 +222,10 @@ class FeatureContext extends RawDrupalContext {
     // The first row of the table contains the field names.
     $table = $user_table->getTable();
     $first_row = array_key_first($table);
+
+    if ($first_row === NULL) {
+      return new TableNode($table);
+    }
 
     // Replace the aliased field names with the actual ones.
     foreach ($table[$first_row] as $key => $alias) {
@@ -278,7 +285,7 @@ class FeatureContext extends RawDrupalContext {
    * d10.feature.
    */
   #[Given('I am logged in as a user with name :name and password :password')]
-  public function testAssertAuthenticatedByUsernameAndPassword($name, $password): void {
+  public function testAssertAuthenticatedByUsernameAndPassword(string $name, string $password): void {
     $user = (object) [
       'name' => $name,
       'pass' => $password,
@@ -292,7 +299,8 @@ class FeatureContext extends RawDrupalContext {
    */
   #[Then('I should be logged in on the backend')]
   public function testAssertBackendLogin(): void {
-    if (!$user = $this->getUserManager()->getCurrentUser()) {
+    $user = $this->getUserManager()->getCurrentUser();
+    if (!$user instanceof \stdClass) {
       throw new \LogicException('No current user in the user manager.');
     }
     if (!$account = \Drupal::entityTypeManager()->getStorage('user')->load($user->uid)) {
@@ -378,7 +386,7 @@ class FeatureContext extends RawDrupalContext {
   #[Given('I remember the current user name')]
   public function testRememberCurrentUserName(): void {
     $user = $this->getUserManager()->getCurrentUser();
-    if (!$user) {
+    if (!$user instanceof \stdClass) {
       throw new \LogicException('No current user in the user manager.');
     }
     $this->previousUserName = $user->name;
@@ -390,7 +398,7 @@ class FeatureContext extends RawDrupalContext {
   #[Then('the current user should be different from the remembered user')]
   public function testAssertDifferentUser(): void {
     $user = $this->getUserManager()->getCurrentUser();
-    if (!$user) {
+    if (!$user instanceof \stdClass) {
       throw new \LogicException('No current user in the user manager.');
     }
     if ($user->name === $this->previousUserName) {
@@ -587,7 +595,11 @@ class FeatureContext extends RawDrupalContext {
       throw new \RuntimeException(sprintf("Assertion exception class '%s' does not exist.", $name));
     }
 
-    throw new $name($message);
+    $exception = new $name($message);
+    if (!$exception instanceof \Throwable) {
+      throw new \RuntimeException(sprintf("Class '%s' is not throwable.", $name));
+    }
+    throw $exception;
   }
 
   /**

--- a/tests/phpunit/src/BehatDistYmlTest.php
+++ b/tests/phpunit/src/BehatDistYmlTest.php
@@ -24,6 +24,8 @@ class BehatDistYmlTest extends TestCase {
 
   /**
    * Parsed behat.dist.yml contents.
+   *
+   * @var array<string, mixed>
    */
   private static array $distConfig;
 
@@ -54,9 +56,6 @@ class BehatDistYmlTest extends TestCase {
   #[DataProvider('dataProviderDrupalExtensionConfigIsValid')]
   public function testDrupalExtensionConfigIsValid(string $profile): void {
     $dist_values = self::$distConfig[$profile]['extensions']['Drupal\DrupalExtension'] ?? [];
-    if ($dist_values === NULL) {
-      $dist_values = [];
-    }
 
     $tree = $this->buildDrupalExtensionTree();
 

--- a/tests/phpunit/src/BrowserKitFactoryTest.php
+++ b/tests/phpunit/src/BrowserKitFactoryTest.php
@@ -29,9 +29,14 @@ class BrowserKitFactoryTest extends TestCase {
 
   /**
    * Tests the configure method.
+   *
+   * @param array<string, mixed> $input
+   *   The configuration input.
+   * @param array<string, mixed> $expected
+   *   The expected guzzle request options.
    */
   #[DataProvider('dataProviderConfigure')]
-  public function testConfigure(array $input, mixed $expected): void {
+  public function testConfigure(array $input, array $expected): void {
     $builder = new ArrayNodeDefinition('test');
     $factory = new BrowserKitFactory();
     $factory->configure($builder);
@@ -59,6 +64,11 @@ class BrowserKitFactoryTest extends TestCase {
 
   /**
    * Tests the buildDriver method.
+   *
+   * @param array<string, mixed> $config
+   *   Driver configuration.
+   * @param array<string, mixed> $expected_guzzle_options
+   *   Expected guzzle options.
    */
   #[DataProvider('dataProviderBuildDriver')]
   public function testBuildDriver(array $config, array $expected_guzzle_options): void {

--- a/tests/phpunit/src/ConfigContextTest.php
+++ b/tests/phpunit/src/ConfigContextTest.php
@@ -42,6 +42,11 @@ class ConfigContextTest extends TestCase {
 
   /**
    * Tests that setBasicConfig stores backup values correctly.
+   *
+   * @param array<int, array<string, mixed>> $operations
+   *   The operations to perform.
+   * @param array<string, array<string, mixed>> $expected_backup
+   *   The expected backup state.
    */
   #[DataProvider('dataProviderSetBasicConfigBackup')]
   public function testSetBasicConfigBackup(array $operations, array $expected_backup): void {

--- a/tests/phpunit/src/DocsTest.php
+++ b/tests/phpunit/src/DocsTest.php
@@ -91,6 +91,12 @@ class DocsTest extends TestCase {
     rmdir($dir);
   }
 
+  /**
+   * Tests parse_method_comment().
+   *
+   * @param array<string, mixed>|null $expected
+   *   The expected parsed result.
+   */
   #[DataProvider('dataProviderParseMethodComment')]
   public function testParseMethodComment(string $comment, ?array $expected, ?string $exception = NULL): void {
     if ($exception) {
@@ -365,6 +371,14 @@ EOD,
     ];
   }
 
+  /**
+   * Tests array_to_markdown_table().
+   *
+   * @param array<int, string> $headers
+   *   Table headers.
+   * @param array<string, array<int, string>> $rows
+   *   Table rows.
+   */
   #[DataProvider('dataProviderArrayToMarkdownTable')]
   public function testArrayToMarkdownTable(array $headers, array $rows, string $expected): void {
     $actual = array_to_markdown_table($headers, $rows);
@@ -422,6 +436,12 @@ EOD,
     ];
   }
 
+  /**
+   * Tests render_info().
+   *
+   * @param array<string, mixed> $info
+   *   Class info to render.
+   */
   #[DataProvider('dataProviderRenderInfo')]
   public function testRenderInfo(array $info, string $expected, ?string $exception = NULL): void {
     if ($exception) {
@@ -477,7 +497,7 @@ EOD,
       // Verify index table exists.
       foreach ($info as $class => $data) {
         $name_contextual = $data['name_contextual'] ?? $class;
-        $link_id = strtolower(preg_replace('/[^A-Za-z0-9_\-]/', '', $name_contextual));
+        $link_id = strtolower((string) preg_replace('/[^A-Za-z0-9_\-]/', '', (string) $name_contextual));
         $this->assertStringContainsString(sprintf("[%s](#%s)", $name_contextual, $link_id), $actual);
         $this->assertStringContainsString($data['description'], $actual);
       }
@@ -626,6 +646,12 @@ EOD,
     ];
   }
 
+  /**
+   * Tests render_info() with path for links.
+   *
+   * @param array<string, mixed> $info
+   *   Class info to render.
+   */
   #[DataProvider('dataProviderRenderInfoWithPathForLinks')]
   public function testRenderInfoWithPathForLinks(array $info, string $path_for_links): void {
     $base_path = static::$tmp;
@@ -661,7 +687,7 @@ EOD,
     // Verify that the path_for_links is used in the index.
     foreach ($info as $class => $data) {
       $name_contextual = $data['name_contextual'] ?? $class;
-      $link_id = strtolower(preg_replace('/[^A-Za-z0-9_\-]/', '', $name_contextual));
+      $link_id = strtolower((string) preg_replace('/[^A-Za-z0-9_\-]/', '', (string) $name_contextual));
       $expected_link = sprintf("%s#%s", $path_for_links, $link_id);
       $this->assertStringContainsString($expected_link, $actual);
     }
@@ -712,6 +738,14 @@ EOD,
     ];
   }
 
+  /**
+   * Tests validate().
+   *
+   * @param array<string, mixed> $info
+   *   Class info to validate.
+   * @param array<int, string> $expected_messages
+   *   The expected validation messages.
+   */
   #[DataProvider('dataProviderValidate')]
   public function testValidate(array $info, string $method_name, string $check_key, bool $expected_pass, array $expected_messages): void {
     $results = validate($info, static::$tmp);
@@ -1177,6 +1211,12 @@ EOD,
     $this->assertSame('tests/behat/features/test.feature', $results['TestContext']['file']['path']);
   }
 
+  /**
+   * Tests has_validation_errors().
+   *
+   * @param array<string, array{file: array{pass: bool, path: string}, methods: array<string, array<string, array{pass: bool, messages: array<int, string>}>>}> $results
+   *   Validation results.
+   */
   #[DataProvider('dataProviderHasValidationErrors')]
   public function testHasValidationErrors(array $results, bool $expected): void {
     $this->assertSame($expected, has_validation_errors($results));
@@ -1478,6 +1518,12 @@ EOD,
     ];
   }
 
+  /**
+   * Tests parse_class_comment().
+   *
+   * @param array<string, mixed> $expected
+   *   Expected parsed result.
+   */
   #[DataProvider('dataProviderParseClassComment')]
   public function testParseClassComment(string $class_name, string $comment, array $expected, ?string $exception = NULL): void {
     if ($exception) {
@@ -1593,6 +1639,13 @@ EOD,
 
   /**
    * Test the extract_info function with actual reflection.
+   *
+   * @param array<int, string> $class_names
+   *   The fixture class names to test with.
+   * @param array<int, string> $exclude
+   *   Class names to exclude.
+   * @param array<int, string> $expected_class_names
+   *   The expected class names that should be extracted.
    */
   #[DataProvider('dataProviderExtractInfo')]
   public function testExtractInfo(
@@ -1663,7 +1716,6 @@ EOD,
     $result = extract_info($context_dir, [], $base_path, 'Drupal\\DrupalExtension\\Tests\\Fixtures');
 
     $this->assertArrayHasKey($class_name, $result);
-    $this->assertIsArray($result[$class_name]['methods']);
     $this->assertCount(3, $result[$class_name]['methods']);
 
     // Check order: Given, When, Then.
@@ -1876,8 +1928,8 @@ EOD,
     $this->assertFileExists($log_dir . '/validation-summary.txt');
     $this->assertFileExists($log_dir . '/validation-details.txt');
 
-    $summary = file_get_contents($log_dir . '/validation-summary.txt');
-    $details = file_get_contents($log_dir . '/validation-details.txt');
+    $summary = (string) file_get_contents($log_dir . '/validation-summary.txt');
+    $details = (string) file_get_contents($log_dir . '/validation-details.txt');
 
     // Summary should contain the summary block without ANSI.
     $this->assertStringContainsString('Summary:', $summary);

--- a/tests/phpunit/src/DrupalAuthenticationManagerTest.php
+++ b/tests/phpunit/src/DrupalAuthenticationManagerTest.php
@@ -394,8 +394,12 @@ class DrupalAuthenticationManagerTest extends TestCase {
 
   /**
    * Creates a mock for the AuthenticationCapability and DriverInterface.
+   *
+   * @return \Drupal\Driver\Capability\AuthenticationCapabilityInterface&\Drupal\Driver\DriverInterface&\PHPUnit\Framework\MockObject\MockObject
+   *   The mocked driver.
    */
-  private function createAuthDriverMock(): AuthenticationCapabilityInterface|DriverInterface|MockObject {
+  private function createAuthDriverMock(): AuthenticationCapabilityInterface&DriverInterface&MockObject {
+    /** @var \Drupal\Driver\Capability\AuthenticationCapabilityInterface&\Drupal\Driver\DriverInterface&\PHPUnit\Framework\MockObject\MockObject $driver */
     $driver = $this->createMockForIntersectionOfInterfaces([
       AuthenticationCapabilityInterface::class,
       DriverInterface::class,
@@ -437,9 +441,6 @@ class DrupalAuthenticationManagerTest extends TestCase {
 
     $manager = $this->createManager($session, NULL, NULL, $params);
     $manager->logIn((object) ['name' => 'admin', 'pass' => 'password']);
-
-    // If we get here without hanging, the wait was skipped.
-    $this->assertTrue(TRUE);
   }
 
   /**
@@ -520,6 +521,15 @@ class DrupalAuthenticationManagerTest extends TestCase {
 
   /**
    * Creates a DrupalAuthenticationManager with optional overrides.
+   *
+   * @param \Behat\Mink\Session|null $session
+   *   Optional Mink session override.
+   * @param \Drupal\DrupalExtension\Manager\DrupalUserManagerInterface|null $user_manager
+   *   Optional user manager override.
+   * @param \Drupal\DrupalDriverManagerInterface|null $driver_manager
+   *   Optional driver manager override.
+   * @param array<string, mixed>|null $drupal_params
+   *   Optional Drupal parameters override.
    */
   private function createManager(?Session $session = NULL, ?DrupalUserManagerInterface $user_manager = NULL, ?DrupalDriverManagerInterface $driver_manager = NULL, ?array $drupal_params = NULL): DrupalAuthenticationManager {
     $session ??= $this->createSessionMock();

--- a/tests/phpunit/src/DrupalMailManagerTest.php
+++ b/tests/phpunit/src/DrupalMailManagerTest.php
@@ -18,6 +18,13 @@ class DrupalMailManagerTest extends TestCase {
 
   /**
    * Tests that manager methods delegate to the driver.
+   *
+   * @param string $method
+   *   The manager method to invoke.
+   * @param string $driver_method
+   *   The driver method expected to be called.
+   * @param array<int, string> $extra_driver_methods
+   *   Additional driver methods that should be called.
    */
   #[DataProvider('dataProviderDriverDelegation')]
   public function testDriverDelegation(string $method, string $driver_method, array $extra_driver_methods = []): void {

--- a/tests/phpunit/src/DrupalUserManagerTest.php
+++ b/tests/phpunit/src/DrupalUserManagerTest.php
@@ -120,6 +120,11 @@ class DrupalUserManagerTest extends TestCase {
 
   /**
    * Tests the hasUsers method.
+   *
+   * @param array<int, \stdClass> $users
+   *   Users to add to the manager.
+   * @param bool $expected
+   *   Expected hasUsers() result.
    */
   #[DataProvider('dataProviderHasUsers')]
   public function testHasUsers(array $users, bool $expected): void {

--- a/tests/phpunit/src/MinkExtensionTest.php
+++ b/tests/phpunit/src/MinkExtensionTest.php
@@ -32,6 +32,11 @@ class MinkExtensionTest extends TestCase {
 
   /**
    * Tests the configure method with various inputs.
+   *
+   * @param array<string, mixed> $input
+   *   The input configuration.
+   * @param mixed $expected
+   *   The expected processed value.
    */
   #[DataProvider('dataProviderConfigure')]
   public function testConfigure(array $input, mixed $expected): void {

--- a/tests/phpunit/src/RawDrupalContextTest.php
+++ b/tests/phpunit/src/RawDrupalContextTest.php
@@ -47,6 +47,19 @@ class RawDrupalContextTest extends TestCase {
 
   /**
    * Tests parsing entity fields.
+   *
+   * @param array<string, mixed> $input
+   *   The input entity fields.
+   * @param array<string, mixed> $expected
+   *   The expected entity fields after parsing.
+   * @param array<int, string>|null $fields
+   *   The configurable fields.
+   * @param array<int, string>|null $baseFields
+   *   The base fields.
+   * @param string|null $exception
+   *   Expected exception message.
+   * @param array<int, string> $ignored_properties
+   *   The ignored properties.
    */
   #[DataProvider('dataProviderParseEntityFields')]
   public function testParseEntityFields(array $input, array $expected, ?array $fields = NULL, ?array $baseFields = NULL, ?string $exception = NULL, array $ignored_properties = []): void {

--- a/tests/phpunit/src/RawMailContextTest.php
+++ b/tests/phpunit/src/RawMailContextTest.php
@@ -53,6 +53,13 @@ class RawMailContextTest extends TestCase {
 
   /**
    * Tests that matchMessage() returns expected results for various criteria.
+   *
+   * @param bool $expected
+   *   The expected match result.
+   * @param array<string, mixed> $message
+   *   The mail message data.
+   * @param array<string, mixed> $criteria
+   *   The criteria to match against.
    */
   #[DataProvider('dataProviderMatchMessage')]
   public function testMatchMessage(bool $expected, array $message, array $criteria): void {
@@ -96,6 +103,17 @@ class RawMailContextTest extends TestCase {
 
   /**
    * Tests that sortMessages() correctly sorts messages.
+   *
+   * @param array<int, array<string, string>> $input
+   *   The input mail messages.
+   * @param string $first_key
+   *   First message expected key to assert against.
+   * @param string $first_value
+   *   First message expected value.
+   * @param string $second_key
+   *   Second message expected key to assert against.
+   * @param string $second_value
+   *   Second message expected value.
    */
   #[DataProvider('dataProviderSortMessages')]
   public function testSortMessages(array $input, string $first_key, string $first_value, string $second_key, string $second_value): void {
@@ -152,6 +170,15 @@ class RawMailContextTest extends TestCase {
 
   /**
    * Tests that assertMessageCount() behaves as expected.
+   *
+   * @param array<int, array<string, string>> $messages
+   *   The mail messages to count.
+   * @param int|null $expected
+   *   Expected count.
+   * @param bool $should_throw
+   *   Whether the assertion should throw.
+   * @param string $exception_message
+   *   Expected exception message.
    */
   #[DataProvider('dataProviderAssertMessageCount')]
   public function testAssertMessageCount(array $messages, ?int $expected, bool $should_throw, string $exception_message = ''): void {
@@ -178,6 +205,15 @@ class RawMailContextTest extends TestCase {
 
   /**
    * Tests that compareMessages() compares messages as expected.
+   *
+   * @param array<int, array<string, string>> $actual
+   *   Actual messages.
+   * @param array<int, array<string, string>> $expected
+   *   Expected messages.
+   * @param bool $should_throw
+   *   Whether the assertion should throw.
+   * @param string $exception_message
+   *   Expected exception message.
    */
   #[DataProvider('dataProviderCompareMessages')]
   public function testCompareMessages(array $actual, array $expected, bool $should_throw, string $exception_message = ''): void {


### PR DESCRIPTION
## Summary

Raises the PHPStan static-analysis level from 3 to 7 across the entire codebase, resolving all 180 violations that surfaced. The fixes span interfaces, concrete classes, context classes, manager classes, service container wiring, and test helpers. No public API behaviour has changed - every fix is a type annotation, return-type declaration, or narrowing cast that makes existing semantics explicit to the analyser.

## Changes

### Config (`phpstan.neon`)
- Bumped `level` from `3` to `7`.
- Added `tests/behat/bootstrap/BehatCliTrait.php` to `excludePaths` because its only consumer (`BehatCliContext.php`) is already excluded and the trait cannot be analysed standalone.

### Interface return types
- `DrupalDriverManagerInterface` - added `void` and typed-array return types.
- `DrupalMailManagerInterface` - added `void`, `array`, and `?object` return types.
- `DrupalAwareInterface` - typed all setter/getter signatures.
- `DrupalAuthenticationManagerInterface`, `DrupalUserManagerInterface`, `FastLogoutInterface` - completed missing return-type declarations.

### Property typing
- Replaced untyped `protected $foo;` declarations with typed properties across all context classes (`RawDrupalContext`, `RawMailContext`, `DrupalContext`, `BatchContext`, `ConfigContext`, `MailContext`, `MessageContext`, `MinkContext`, `RandomContext`, `DrushContext`, `DrupalSubContextBase`).
- Added explicit `= []` or `= NULL` initialisers as required by PHPStan level 7.

### Type narrowing in context and manager classes
- `RawDrupalContext::nodeCreate()` / `termCreate()`: narrowed `object` PHPDoc return to `\stdClass`; added `instanceof \stdClass` runtime guard before callers access `->nid` / `->tid` / `->uid`.
- `DrupalContext`: replaced `if (!$user)` (flagged always-false from PHPDoc) with `if (!$user instanceof \stdClass)`.
- `DrupalAuthenticationManager::loggedIn()`: removed dead `if (!$page)` and replaced with `if ($page === NULL)` plus a targeted `@phpstan-ignore identical.alwaysFalse` for the test-mock case.

### Array and string return types
- Added generic-style PHPDoc hints (`array<int, \stdClass>`, `array<string, mixed>`, `array<int, string>`) throughout context classes and managers.
- Cast `string|false` returns from `glob()`, `getcwd()`, `fgets()`, `file_get_contents()` to `(string)` or applied `?: []` fallbacks.

### Hook reader / annotation reader
- Used `class-string<\Behat\Behat\Context\Context>` in PHPDoc to satisfy callable-array typing in `Annotation\Reader` and `Attribute\HookAttributeReader`.

### Service container and supporting classes
- `DrupalExtension` service container: added return types and typed array properties.
- `RegionSelector`, `DriverListener`, `DrupalParametersTrait`, `MinkAwareTrait`: added missing return types and typed properties.
- `BrowserKitFactory`: cast `string|false` from `getcwd()`.
- `scripts/docs.php`: cast `string|false` from `fgets()` / `file_get_contents()`.

### Test files
- `FeatureContext`: added typed properties and return types.
- All `tests/phpunit/src/*Test.php` files: annotated `createMockForIntersectionOfInterfaces()` returns with `@var` intersection types; added return types to helper methods.

## Before / After

```
Before                          After
────────────────────────────────────────────────────────────────────
PHPStan level    3              PHPStan level    7
Violations       180            Violations       0
```

```
Category of fix                                Files touched
┌──────────────────────────────────────────────┬────────────┐
│ Config (phpstan.neon)                        │     1      │
│ Interface return types                       │     6      │
│ Property typing (typed props + initialisers) │    11      │
│ Type narrowing (\stdClass guards, instanceof)│     3      │
│ Array / string return types & casts          │    12      │
│ Hook / annotation reader PHPDoc              │     2      │
│ Service container & support classes          │     7      │
│ Test files (PHPUnit + FeatureContext)         │    10      │
└──────────────────────────────────────────────┴────────────┘
Total                                               44 files
   428 insertions(+)  183 deletions(-)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced codebase type safety and static analysis strictness, improving code reliability.
  * Added explicit return type declarations across core methods for better contract enforcement.
  * Strengthened property typing with more precise data structure documentation.

* **Bug Fixes**
  * Improved defensive coding practices with explicit type validation and null checks.
  * Enhanced error handling for edge cases in data processing and transformations.

* **Tests**
  * Expanded test documentation with comprehensive parameter type specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->