### PR TITLE
[#752] Replaced generic exceptions with typed Mink exceptions across bundled contexts.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -397,7 +397,7 @@ used.
 
 Example messages:
 
-```
+```text
 Element matching css "#my-element" not found.
 Link with id|title|alt|text "About us" not found.
 Field with id|name|label|value|placeholder "Search" not found.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -374,6 +374,36 @@ Every negative test follows the same four-step pattern:
 | `Then it should fail with a "<Class>" exception:` | Step threw a specific exception class (e.g., `InvalidArgumentException`). |
 | `Then it should fail` | Step failed (any reason, no message check). |
 
+## Exception conventions
+
+Step definitions and helper classes throw exceptions in a consistent,
+typed way so callers can distinguish assertion failures from runtime
+problems and so feature tests can assert on the failure mode without
+parsing free-form messages.
+
+| Exception                                         | When thrown                                          |
+|---------------------------------------------------|------------------------------------------------------|
+| `Behat\Mink\Exception\ElementNotFoundException`   | Element, field, link, button, or selector not found  |
+| `Behat\Mink\Exception\ExpectationException`       | Assertion fails (value mismatch, state verification) |
+| `Behat\Mink\Exception\UnsupportedDriverActionException` | Feature requires a specific driver (e.g. JavaScript) |
+| `\RuntimeException`                               | Invalid input or processing error (not an assertion) |
+| `\InvalidArgumentException`                       | Invalid argument value passed to an API method       |
+
+`ElementNotFoundException` extends `ExpectationException`, so catching
+`ExpectationException` covers both. The Mink classes auto-render the
+URL and a snippet of the page in their `__toString()`, so do not embed
+the URL in the message when an `ExpectationException`-based class is
+used.
+
+Example messages:
+
+```
+Element matching css "#my-element" not found.
+Link with id|title|alt|text "About us" not found.
+Field with id|name|label|value|placeholder "Search" not found.
+Region with name "footer" not found.
+```
+
 ## Step definition conventions
 
 `scripts/docs.php` validates step definitions against the conventions enforced

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -41,6 +41,27 @@ Update each occurrence in your `.feature` files.
 | ------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------- |
 | `When I visit :path` | Implicitly asserted HTTP 200 on the response.          | Plain navigation. Use `Then I should get a :code HTTP response` to assert status. |
 
+## Exception classes
+
+6.0 narrows the exceptions thrown by bundled contexts. Generic `\Exception`
+throws have been replaced with typed exceptions so callers can distinguish
+"element not found" from "assertion failed" from "runtime error".
+
+| Situation                                            | 5.x                | 6.0                                              |
+|------------------------------------------------------|--------------------|--------------------------------------------------|
+| Element / field / link / button / region not found   | `\Exception`       | `Behat\Mink\Exception\ElementNotFoundException`  |
+| Assertion fails (value mismatch, state verification) | `\Exception`       | `Behat\Mink\Exception\ExpectationException`      |
+| Configuration / processing error (non-assertion)     | `\Exception`       | `\RuntimeException`                              |
+
+The auto-generated `ElementNotFoundException` messages are different from
+the 5.x free-form text — for example
+`No link to "About" on the page <url>` becomes
+`Link with id|title|alt|text "About" not found.`. Update any feature
+tests or `try`/`catch` blocks that rely on the 5.x message text.
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md#exception-conventions) for the
+full convention.
+
 ## Method renames
 
 If you subclass any of the bundled contexts and override an `@Then` method,

--- a/src/Drupal/DrupalExtension/Context/BatchContext.php
+++ b/src/Drupal/DrupalExtension/Context/BatchContext.php
@@ -66,7 +66,7 @@ class BatchContext extends RawMinkContext {
       ]);
 
     if (!$query->execute()) {
-      throw new \Exception('Unable to create the queue item.');
+      throw new \RuntimeException('Unable to create the queue item.');
     }
   }
 

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -273,12 +273,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
     if ($this->getTableRow($page, $rowText)->findLink($link)) {
       return;
     }
-    throw new ElementNotFoundException(
-      $this->getSession()->getDriver(),
-      sprintf('link in the "%s" row', $rowText),
-      'id|title|alt|text',
-      $link
-    );
+    throw new ElementNotFoundException($this->getSession()->getDriver(), sprintf('link in the "%s" row', $rowText), 'id|title|alt|text', $link);
   }
 
   /**
@@ -317,12 +312,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
       $link_element->click();
       return;
     }
-    throw new ElementNotFoundException(
-      $this->getSession()->getDriver(),
-      sprintf('link in the "%s" row', $rowText),
-      'id|title|alt|text',
-      $link
-    );
+    throw new ElementNotFoundException($this->getSession()->getDriver(), sprintf('link in the "%s" row', $rowText), 'id|title|alt|text', $link);
   }
 
   /**
@@ -344,12 +334,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
       $button_element->press();
       return;
     }
-    throw new ElementNotFoundException(
-      $this->getSession()->getDriver(),
-      sprintf('button in the "%s" row', $rowText),
-      'id|name|title|alt|value',
-      $button
-    );
+    throw new ElementNotFoundException($this->getSession()->getDriver(), sprintf('button in the "%s" row', $rowText), 'id|name|title|alt|value', $button);
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -9,6 +9,8 @@ use Behat\Step\Then;
 use Behat\Step\When;
 use Behat\Behat\Context\TranslatableContext;
 use Behat\Mink\Element\Element;
+use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Mink\Exception\ExpectationException;
 
 use Behat\Gherkin\Node\TableNode;
 use Drupal\Driver\Capability\CacheCapabilityInterface;
@@ -215,14 +217,14 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
   public function getTableRow(Element $element, string $search) {
     $rows = $element->findAll('css', 'tr');
     if (empty($rows)) {
-      throw new \Exception(sprintf('No rows found on the page %s', $this->getSession()->getCurrentUrl()));
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'row', 'css', 'tr');
     }
     foreach ($rows as $row) {
       if (str_contains($row->getText(), $search)) {
         return $row;
       }
     }
-    throw new \Exception(sprintf('Failed to find a row containing "%s" on the page %s', $search, $this->getSession()->getCurrentUrl()));
+    throw new ElementNotFoundException($this->getSession()->getDriver(), 'row', 'text', $search);
   }
 
   /**
@@ -236,7 +238,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
   public function tableRowTextAssertIsVisible(string $text, string $rowText): void {
     $row = $this->getTableRow($this->getSession()->getPage(), $rowText);
     if (!str_contains($row->getText(), $text)) {
-      throw new \Exception(sprintf('Found a row containing "%s", but it did not contain the text "%s".', $rowText, $text));
+      throw new ExpectationException(sprintf('Found a row containing "%s", but it did not contain the text "%s".', $rowText, $text), $this->getSession()->getDriver());
     }
   }
 
@@ -251,7 +253,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
   public function tableRowTextAssertIsNotVisible(string $text, string $rowText): void {
     $row = $this->getTableRow($this->getSession()->getPage(), $rowText);
     if (str_contains($row->getText(), $text)) {
-      throw new \Exception(sprintf('Found a row containing "%s", but it contained the text "%s".', $rowText, $text));
+      throw new ExpectationException(sprintf('Found a row containing "%s", but it contained the text "%s".', $rowText, $text), $this->getSession()->getDriver());
     }
   }
 
@@ -271,7 +273,12 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
     if ($this->getTableRow($page, $rowText)->findLink($link)) {
       return;
     }
-    throw new \Exception(sprintf('Found a row containing "%s", but no "%s" link on the page %s', $rowText, $link, $this->getSession()->getCurrentUrl()));
+    throw new ElementNotFoundException(
+      $this->getSession()->getDriver(),
+      sprintf('link in the "%s" row', $rowText),
+      'id|title|alt|text',
+      $link
+    );
   }
 
   /**
@@ -288,7 +295,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
   public function tableRowLinkAssertNotExists(string $link, string $rowText): void {
     $page = $this->getSession()->getPage();
     if ($this->getTableRow($page, $rowText)->findLink($link)) {
-      throw new \Exception(sprintf('Found a row containing "%s" with a "%s" link on the page %s', $rowText, $link, $this->getSession()->getCurrentUrl()));
+      throw new ExpectationException(sprintf('Found a row containing "%s" with a "%s" link on the page %s', $rowText, $link, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
     }
   }
 
@@ -310,7 +317,12 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
       $link_element->click();
       return;
     }
-    throw new \Exception(sprintf('Found a row containing "%s", but no "%s" link on the page %s', $rowText, $link, $this->getSession()->getCurrentUrl()));
+    throw new ElementNotFoundException(
+      $this->getSession()->getDriver(),
+      sprintf('link in the "%s" row', $rowText),
+      'id|title|alt|text',
+      $link
+    );
   }
 
   /**
@@ -332,7 +344,12 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
       $button_element->press();
       return;
     }
-    throw new \Exception(sprintf('Found a row containing "%s", but no "%s" button on the page %s', $rowText, $button, $this->getSession()->getCurrentUrl()));
+    throw new ElementNotFoundException(
+      $this->getSession()->getDriver(),
+      sprintf('button in the "%s" row', $rowText),
+      'id|name|title|alt|value',
+      $button
+    );
   }
 
   /**
@@ -653,7 +670,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
         case 113:
           // Q.
         case 81:
-          throw new \Exception("Exiting test intentionally.");
+          throw new \RuntimeException("Exiting test intentionally.");
 
         default:
           fwrite(STDOUT, sprintf("\nInvalid entry '%s'.  Please enter 'y', 'q', or the enter key.\n", $line));
@@ -680,12 +697,12 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    */
   protected function createAndVisitMyNode(string $type, string $title): void {
     if ($this->getUserManager()->currentUserIsAnonymous()) {
-      throw new \Exception('There is no current logged in user to create a node for.');
+      throw new \RuntimeException('There is no current logged in user to create a node for.');
     }
 
     $current_user = $this->getUserManager()->getCurrentUser();
     if (!$current_user instanceof \stdClass) {
-      throw new \Exception('There is no current logged in user to create a node for.');
+      throw new \RuntimeException('There is no current logged in user to create a node for.');
     }
     $node = (object) [
       'title' => $title,

--- a/src/Drupal/DrupalExtension/Context/DrushContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrushContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Context;
 
+use Behat\Mink\Exception\ExpectationException;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
@@ -79,7 +80,7 @@ class DrushContext extends RawDrupalContext implements TranslatableContext {
   #[Then('the drush output should contain :output')]
   public function drushOutputAssertContains(string $output): void {
     if (!str_contains((string) $this->readDrushOutput(), $this->fixStepArgument($output))) {
-      throw new \Exception(sprintf("The last drush command output did not contain '%s'.\nInstead, it was:\n\n%s'", $output, $this->drushOutput));
+      throw new ExpectationException(sprintf("The last drush command output did not contain '%s'.\nInstead, it was:\n\n%s'", $output, $this->drushOutput), $this->getSession()->getDriver());
     }
   }
 
@@ -93,7 +94,7 @@ class DrushContext extends RawDrupalContext implements TranslatableContext {
   #[Then('the drush output should match :regex')]
   public function drushOutputAssertMatches(string $regex): void {
     if (!preg_match($regex, (string) $this->readDrushOutput())) {
-      throw new \Exception(sprintf("The pattern %s was not found anywhere in the drush output.\nOutput:\n\n%s", $regex, $this->drushOutput));
+      throw new ExpectationException(sprintf("The pattern %s was not found anywhere in the drush output.\nOutput:\n\n%s", $regex, $this->drushOutput), $this->getSession()->getDriver());
     }
   }
 
@@ -107,7 +108,7 @@ class DrushContext extends RawDrupalContext implements TranslatableContext {
   #[Then('the drush output should not contain :output')]
   public function drushOutputAssertNotContains(string $output): void {
     if (str_contains((string) $this->readDrushOutput(), $this->fixStepArgument($output))) {
-      throw new \Exception(sprintf("The last drush command output did contain '%s' although it should not.\nOutput:\n\n%s'", $output, $this->drushOutput));
+      throw new ExpectationException(sprintf("The last drush command output did contain '%s' although it should not.\nOutput:\n\n%s'", $output, $this->drushOutput), $this->getSession()->getDriver());
     }
   }
 

--- a/src/Drupal/DrupalExtension/Context/DrushContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrushContext.php
@@ -108,7 +108,7 @@ class DrushContext extends RawDrupalContext implements TranslatableContext {
   #[Then('the drush output should not contain :output')]
   public function drushOutputAssertNotContains(string $output): void {
     if (str_contains((string) $this->readDrushOutput(), $this->fixStepArgument($output))) {
-      throw new ExpectationException(sprintf("The last drush command output did contain '%s' although it should not.\nOutput:\n\n%s'", $output, $this->drushOutput), $this->getSession()->getDriver());
+      throw new ExpectationException(sprintf("The last drush command output did contain '%s' although it should not.\nOutput:\n\n%s", $output, $this->drushOutput), $this->getSession()->getDriver());
     }
   }
 

--- a/src/Drupal/DrupalExtension/Context/MailContext.php
+++ b/src/Drupal/DrupalExtension/Context/MailContext.php
@@ -6,6 +6,7 @@ namespace Drupal\DrupalExtension\Context;
 
 use Behat\Hook\BeforeScenario;
 use Behat\Hook\AfterScenario;
+use Behat\Mink\Exception\ExpectationException;
 use Behat\Step\When;
 use Behat\Step\Then;
 use Behat\Behat\Hook\Scope\ScenarioScope;
@@ -489,7 +490,7 @@ class MailContext extends RawMailContext {
     $filters = ['to' => $to, 'subject' => $subject];
     $mail = $this->getMail($filters, FALSE, -1);
     if (count($mail) === 0) {
-      throw new \Exception('No such mail found.');
+      throw new ExpectationException('No such mail found.', $this->getSession()->getDriver());
     }
     $body = $mail['body'];
 
@@ -502,10 +503,10 @@ class MailContext extends RawMailContext {
         }
       }
 
-      throw new \Exception(sprintf('No URL in mail body contained "%s".', $urlFragment));
+      throw new ExpectationException(sprintf('No URL in mail body contained "%s".', $urlFragment), $this->getSession()->getDriver());
     }
 
-    throw new \Exception('No URL found in mail body.');
+    throw new ExpectationException('No URL found in mail body.', $this->getSession()->getDriver());
   }
 
 }

--- a/src/Drupal/DrupalExtension/Context/MarkupContext.php
+++ b/src/Drupal/DrupalExtension/Context/MarkupContext.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Drupal\DrupalExtension\Context;
 
 use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Mink\Exception\ExpectationException;
 use Behat\Step\Then;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Drupal\DrupalExtension\RegionTrait;
@@ -111,7 +113,12 @@ class MarkupContext extends RawMinkContext {
   #[Then('I should see the :tag element in the :region( region)')]
   public function regionElementAssertExists(string $tag, string $region): void {
     if (!$this->getRegion($region)->findAll('css', $tag)) {
-      throw new \Exception(sprintf('The element "%s" was not found in the "%s" region on the page %s', $tag, $region, $this->getSession()->getCurrentUrl()));
+      throw new ElementNotFoundException(
+        $this->getSession()->getDriver(),
+        sprintf('element in the "%s" region', $region),
+        'css',
+        $tag
+      );
     }
   }
 
@@ -126,7 +133,7 @@ class MarkupContext extends RawMinkContext {
   #[Then('I should not see the :tag element in the :region( region)')]
   public function regionElementAssertNotExists(string $tag, string $region): void {
     if ($this->getRegion($region)->findAll('css', $tag)) {
-      throw new \Exception(sprintf('The element "%s" was found in the "%s" region on the page %s', $tag, $region, $this->getSession()->getCurrentUrl()));
+      throw new ExpectationException(sprintf('The element "%s" was found in the "%s" region on the page %s', $tag, $region, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
     }
   }
 
@@ -148,7 +155,7 @@ class MarkupContext extends RawMinkContext {
       }
     }
 
-    throw new \Exception(sprintf('The text "%s" was not found in the "%s" element in the "%s" region on the page %s', $text, $tag, $region, $this->getSession()->getCurrentUrl()));
+    throw new ExpectationException(sprintf('The text "%s" was not found in the "%s" element in the "%s" region on the page %s', $text, $tag, $region, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
   }
 
   /**
@@ -165,7 +172,7 @@ class MarkupContext extends RawMinkContext {
 
     foreach ($region_obj->findAll('css', $tag) as $result) {
       if ($result->getText() == $text) {
-        throw new \Exception(sprintf('The text "%s" was found in the "%s" element in the "%s" region on the page %s', $text, $tag, $region, $this->getSession()->getCurrentUrl()));
+        throw new ExpectationException(sprintf('The text "%s" was found in the "%s" element in the "%s" region on the page %s', $text, $tag, $region, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
       }
     }
   }
@@ -182,7 +189,12 @@ class MarkupContext extends RawMinkContext {
   public function regionElementAttributeAssertEquals(string $tag, string $attribute, string $value, string $region): void {
     $elements = $this->getRegion($region)->findAll('css', $tag);
     if (empty($elements)) {
-      throw new \Exception(sprintf('The element "%s" was not found in the "%s" region on the page %s', $tag, $region, $this->getSession()->getCurrentUrl()));
+      throw new ElementNotFoundException(
+        $this->getSession()->getDriver(),
+        sprintf('element in the "%s" region', $region),
+        'css',
+        $tag
+      );
     }
 
     if (empty($attribute)) {
@@ -202,10 +214,10 @@ class MarkupContext extends RawMinkContext {
     }
 
     if (!$attr_found) {
-      throw new \Exception(sprintf('The "%s" attribute is not present on the element "%s" in the "%s" region on the page %s', $attribute, $tag, $region, $this->getSession()->getCurrentUrl()));
+      throw new ExpectationException(sprintf('The "%s" attribute is not present on the element "%s" in the "%s" region on the page %s', $attribute, $tag, $region, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
     }
 
-    throw new \Exception(sprintf('The "%s" attribute does not equal "%s" on the element "%s" in the "%s" region on the page %s', $attribute, $value, $tag, $region, $this->getSession()->getCurrentUrl()));
+    throw new ExpectationException(sprintf('The "%s" attribute does not equal "%s" on the element "%s" in the "%s" region on the page %s', $attribute, $value, $tag, $region, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
   }
 
   /**
@@ -223,11 +235,11 @@ class MarkupContext extends RawMinkContext {
     if (!empty($attribute)) {
       $attr = $matched->getAttribute($attribute);
       if (empty($attr)) {
-        throw new \Exception(sprintf('The "%s" attribute is not present on the element "%s" in the "%s" region on the page %s', $attribute, $tag, $region, $this->getSession()->getCurrentUrl()));
+        throw new ExpectationException(sprintf('The "%s" attribute is not present on the element "%s" in the "%s" region on the page %s', $attribute, $tag, $region, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
       }
 
       if (!str_contains($attr, $value)) {
-        throw new \Exception(sprintf('The "%s" attribute does not equal "%s" on the element "%s" in the "%s" region on the page %s', $attribute, $value, $tag, $region, $this->getSession()->getCurrentUrl()));
+        throw new ExpectationException(sprintf('The "%s" attribute does not equal "%s" on the element "%s" in the "%s" region on the page %s', $attribute, $value, $tag, $region, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
       }
     }
   }
@@ -251,13 +263,13 @@ class MarkupContext extends RawMinkContext {
       foreach ($rules as $rule) {
         if (str_contains($rule, $property)) {
           if (!str_contains($rule, $value)) {
-            throw new \Exception(sprintf('The "%s" style property does not equal "%s" on the element "%s" in the "%s" region on the page %s', $property, $value, $tag, $region, $this->getSession()->getCurrentUrl()));
+            throw new ExpectationException(sprintf('The "%s" style property does not equal "%s" on the element "%s" in the "%s" region on the page %s', $property, $value, $tag, $region, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
           }
           return;
         }
       }
 
-      throw new \Exception(sprintf('The "%s" style property was not found in the "%s" element in the "%s" region on the page %s', $property, $tag, $region, $this->getSession()->getCurrentUrl()));
+      throw new ExpectationException(sprintf('The "%s" style property was not found in the "%s" element in the "%s" region on the page %s', $property, $tag, $region, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
     }
   }
 
@@ -274,7 +286,12 @@ class MarkupContext extends RawMinkContext {
    */
   protected function assertRegionContainsButton(string $button, string $region): void {
     if (!$this->getRegion($region)->findButton($button)) {
-      throw new \Exception(sprintf("The button '%s' was not found in the region '%s' on the page %s", $button, $region, $this->getSession()->getCurrentUrl()));
+      throw new ElementNotFoundException(
+        $this->getSession()->getDriver(),
+        sprintf('button in the "%s" region', $region),
+        'id|name|title|alt|value',
+        $button
+      );
     }
   }
 
@@ -291,7 +308,7 @@ class MarkupContext extends RawMinkContext {
    */
   protected function assertRegionDoesNotContainButton(string $button, string $region): void {
     if ($this->getRegion($region)->findButton($button)) {
-      throw new \Exception(sprintf("The button '%s' was found in the region '%s' on the page %s but should not", $button, $region, $this->getSession()->getCurrentUrl()));
+      throw new ExpectationException(sprintf("The button '%s' was found in the region '%s' on the page %s but should not", $button, $region, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
     }
   }
 
@@ -317,7 +334,12 @@ class MarkupContext extends RawMinkContext {
     $elements = $regionObj->findAll('css', $tag);
 
     if (empty($elements)) {
-      throw new \Exception(sprintf('The element "%s" was not found in the "%s" region on the page %s', $tag, $region, $this->getSession()->getCurrentUrl()));
+      throw new ElementNotFoundException(
+        $this->getSession()->getDriver(),
+        sprintf('element in the "%s" region', $region),
+        'css',
+        $tag
+      );
     }
 
     foreach ($elements as $element) {
@@ -326,7 +348,7 @@ class MarkupContext extends RawMinkContext {
       }
     }
 
-    throw new \Exception(sprintf('The text "%s" was not found in the "%s" element in the "%s" region on the page %s', $text, $tag, $region, $this->getSession()->getCurrentUrl()));
+    throw new ExpectationException(sprintf('The text "%s" was not found in the "%s" element in the "%s" region on the page %s', $text, $tag, $region, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
   }
 
 }

--- a/src/Drupal/DrupalExtension/Context/MarkupContext.php
+++ b/src/Drupal/DrupalExtension/Context/MarkupContext.php
@@ -113,12 +113,7 @@ class MarkupContext extends RawMinkContext {
   #[Then('I should see the :tag element in the :region( region)')]
   public function regionElementAssertExists(string $tag, string $region): void {
     if (!$this->getRegion($region)->findAll('css', $tag)) {
-      throw new ElementNotFoundException(
-        $this->getSession()->getDriver(),
-        sprintf('element in the "%s" region', $region),
-        'css',
-        $tag
-      );
+      throw new ElementNotFoundException($this->getSession()->getDriver(), sprintf('element in the "%s" region', $region), 'css', $tag);
     }
   }
 
@@ -189,12 +184,7 @@ class MarkupContext extends RawMinkContext {
   public function regionElementAttributeAssertEquals(string $tag, string $attribute, string $value, string $region): void {
     $elements = $this->getRegion($region)->findAll('css', $tag);
     if (empty($elements)) {
-      throw new ElementNotFoundException(
-        $this->getSession()->getDriver(),
-        sprintf('element in the "%s" region', $region),
-        'css',
-        $tag
-      );
+      throw new ElementNotFoundException($this->getSession()->getDriver(), sprintf('element in the "%s" region', $region), 'css', $tag);
     }
 
     if (empty($attribute)) {
@@ -286,12 +276,7 @@ class MarkupContext extends RawMinkContext {
    */
   protected function assertRegionContainsButton(string $button, string $region): void {
     if (!$this->getRegion($region)->findButton($button)) {
-      throw new ElementNotFoundException(
-        $this->getSession()->getDriver(),
-        sprintf('button in the "%s" region', $region),
-        'id|name|title|alt|value',
-        $button
-      );
+      throw new ElementNotFoundException($this->getSession()->getDriver(), sprintf('button in the "%s" region', $region), 'id|name|title|alt|value', $button);
     }
   }
 
@@ -334,12 +319,7 @@ class MarkupContext extends RawMinkContext {
     $elements = $regionObj->findAll('css', $tag);
 
     if (empty($elements)) {
-      throw new ElementNotFoundException(
-        $this->getSession()->getDriver(),
-        sprintf('element in the "%s" region', $region),
-        'css',
-        $tag
-      );
+      throw new ElementNotFoundException($this->getSession()->getDriver(), sprintf('element in the "%s" region', $region), 'css', $tag);
     }
 
     foreach ($elements as $element) {

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -503,12 +503,7 @@ JS;
     // Find the link within the region.
     $link_obj = $region_obj->findLink($link);
     if (empty($link_obj)) {
-      throw new ElementNotFoundException(
-        $this->getSession()->getDriver(),
-        sprintf('link in the "%s" region', $region),
-        'id|title|alt|text',
-        $link
-      );
+      throw new ElementNotFoundException($this->getSession()->getDriver(), sprintf('link in the "%s" region', $region), 'id|title|alt|text', $link);
     }
     $link_obj->click();
   }
@@ -537,12 +532,7 @@ JS;
 
     $button_obj = $region_obj->findButton($button);
     if (empty($button_obj)) {
-      throw new ElementNotFoundException(
-        $this->getSession()->getDriver(),
-        sprintf('button in the "%s" region', $region),
-        'id|name|title|alt|value',
-        $button
-      );
+      throw new ElementNotFoundException($this->getSession()->getDriver(), sprintf('button in the "%s" region', $region), 'id|name|title|alt|value', $button);
     }
     $button_obj->press();
   }
@@ -675,12 +665,7 @@ JS;
 
     $result = $region_obj->findLink($link);
     if (empty($result)) {
-      throw new ElementNotFoundException(
-        $this->getSession()->getDriver(),
-        sprintf('link in the "%s" region', $region),
-        'id|title|alt|text',
-        $link
-      );
+      throw new ElementNotFoundException($this->getSession()->getDriver(), sprintf('link in the "%s" region', $region), 'id|title|alt|text', $link);
     }
   }
 
@@ -875,12 +860,7 @@ JS;
 
     $element = $page->find('xpath', $xpath);
     if (!$element) {
-      throw new ElementNotFoundException(
-        $this->getSession()->getDriver(),
-        sprintf('details element for "%s" action', $action),
-        'summary text',
-        $summary
-      );
+      throw new ElementNotFoundException($this->getSession()->getDriver(), sprintf('details element for "%s" action', $action), 'summary text', $summary);
     }
 
     $ajax_timeout = $this->getMinkParameter('ajax_timeout') ?? 5;
@@ -946,12 +926,7 @@ JS;
       }
     }
 
-    throw new ElementNotFoundException(
-      $this->getSession()->getDriver(),
-      sprintf('heading in the "%s" region', $region),
-      'text',
-      $heading
-    );
+    throw new ElementNotFoundException($this->getSession()->getDriver(), sprintf('heading in the "%s" region', $region), 'text', $heading);
   }
 
   /**
@@ -998,12 +973,7 @@ JS;
       $label,
     ]);
     if ($radiobutton === NULL) {
-      throw new ElementNotFoundException(
-        $this->getSession()->getDriver(),
-        'radio button',
-        $id !== '' && $id !== '0' ? 'id' : 'label',
-        $id ?: $label
-      );
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'radio button', $id !== '' && $id !== '0' ? 'id' : 'label', $id ?: $label);
     }
     $value = $radiobutton->getAttribute('value');
     $radio_id = $radiobutton->getAttribute('id');

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -13,6 +13,7 @@ use Behat\Behat\Hook\Scope\BeforeStepScope;
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Behat\Context\TranslatableContext;
 use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Mink\Selector\Xpath\Escaper;
 use Behat\MinkExtension\Context\MinkContext as MinkExtension;
@@ -177,7 +178,7 @@ JS;
     $result = $this->getSession()->wait(1000 * $ajax_timeout, $condition);
     if (!$result) {
       if ($ajax_timeout === NULL) {
-        throw new \Exception('No AJAX timeout has been defined. Please verify that "Drupal\MinkExtension" is configured in behat.yml (and not "Behat\MinkExtension").');
+        throw new \RuntimeException('No AJAX timeout has been defined. Please verify that "Drupal\MinkExtension" is configured in behat.yml (and not "Behat\MinkExtension").');
       }
       if ($event) {
         /** @var \Behat\Behat\Hook\Scope\BeforeStepScope $event */
@@ -264,7 +265,7 @@ JS;
 
     if (is_string($char)) {
       if (strlen($char) < 1) {
-        throw new \Exception('FeatureContext->keyPress($char, $field) was invoked but the $char parameter was empty.');
+        throw new \RuntimeException('FeatureContext->keyPress($char, $field) was invoked but the $char parameter was empty.');
       }
       if (strlen($char) > 1) {
         // Support for all variations, e.g. ESC, Esc, page up, pageup.
@@ -274,7 +275,7 @@ JS;
 
     $element = $this->getSession()->getPage()->findField($field);
     if (!$element) {
-      throw new \Exception(sprintf("Field '%s' not found", $field));
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'field', 'id|name|label|value|placeholder', $field);
     }
 
     $driver = $this->getSession()->getDriver();
@@ -322,10 +323,11 @@ JS;
   public function linkAssertIsVisible(string $link): void {
     $element = $this->getSession()->getPage();
     $result = $element->findLink($link);
+    $driver = $this->getSession()->getDriver();
 
     try {
       if ($result && !$result->isVisible()) {
-        throw new \Exception(sprintf("No link to '%s' on the page %s", $link, $this->getSession()->getCurrentUrl()));
+        throw new ElementNotFoundException($driver, 'link', 'id|title|alt|text', $link);
       }
     }
     catch (UnsupportedDriverActionException) {
@@ -335,7 +337,7 @@ JS;
     }
 
     if (empty($result)) {
-      throw new \Exception(sprintf("No link to '%s' on the page %s", $link, $this->getSession()->getCurrentUrl()));
+      throw new ElementNotFoundException($driver, 'link', 'id|title|alt|text', $link);
     }
   }
 
@@ -350,10 +352,11 @@ JS;
   public function linkAssertIsNotVisible(string $link): void {
     $element = $this->getSession()->getPage();
     $result = $element->findLink($link);
+    $driver = $this->getSession()->getDriver();
 
     try {
       if ($result && $result->isVisible()) {
-        throw new \Exception(sprintf("The link '%s' was present on the page %s and was not supposed to be", $link, $this->getSession()->getCurrentUrl()));
+        throw new ExpectationException(sprintf("The link '%s' was present on the page %s and was not supposed to be", $link, $this->getSession()->getCurrentUrl()), $driver);
       }
     }
     catch (UnsupportedDriverActionException) {
@@ -363,7 +366,7 @@ JS;
     }
 
     if ($result) {
-      throw new \Exception(sprintf("The link '%s' was present on the page %s and was not supposed to be", $link, $this->getSession()->getCurrentUrl()));
+      throw new ExpectationException(sprintf("The link '%s' was present on the page %s and was not supposed to be", $link, $this->getSession()->getCurrentUrl()), $driver);
     }
   }
 
@@ -380,10 +383,11 @@ JS;
   public function linkAssertIsNotVisuallyVisible(string $link): void {
     $element = $this->getSession()->getPage();
     $result = $element->findLink($link);
+    $driver = $this->getSession()->getDriver();
 
     try {
       if ($result && $result->isVisible()) {
-        throw new \Exception(sprintf("The link '%s' was visually visible on the page %s and was not supposed to be", $link, $this->getSession()->getCurrentUrl()));
+        throw new ExpectationException(sprintf("The link '%s' was visually visible on the page %s and was not supposed to be", $link, $this->getSession()->getCurrentUrl()), $driver);
       }
     }
     catch (UnsupportedDriverActionException) {
@@ -393,7 +397,7 @@ JS;
     }
 
     if (!$result) {
-      throw new \Exception(sprintf("The link '%s' was not loaded on the page %s at all", $link, $this->getSession()->getCurrentUrl()));
+      throw new ElementNotFoundException($driver, 'link', 'id|title|alt|text', $link);
     }
   }
 
@@ -412,7 +416,7 @@ JS;
         return;
       }
     }
-    throw new \Exception(sprintf("The text '%s' was not found in any heading on the page %s", $heading, $this->getSession()->getCurrentUrl()));
+    throw new ElementNotFoundException($this->getSession()->getDriver(), 'heading', 'text', $heading);
   }
 
   /**
@@ -427,7 +431,7 @@ JS;
     $element = $this->getSession()->getPage();
     foreach ($element->findAll('css', 'h1, h2, h3, h4, h5, h6') as $result) {
       if ($result->getText() == $heading) {
-        throw new \Exception(sprintf("The text '%s' was found in a heading on the page %s", $heading, $this->getSession()->getCurrentUrl()));
+        throw new ExpectationException(sprintf("The text '%s' was found in a heading on the page %s", $heading, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
       }
     }
   }
@@ -499,12 +503,12 @@ JS;
     // Find the link within the region.
     $link_obj = $region_obj->findLink($link);
     if (empty($link_obj)) {
-      throw new \Exception(sprintf(
-        'The link "%s" was not found in the region "%s" on the page %s',
-        $link,
-        $region,
-        $this->getSession()->getCurrentUrl()
-      ));
+      throw new ElementNotFoundException(
+        $this->getSession()->getDriver(),
+        sprintf('link in the "%s" region', $region),
+        'id|title|alt|text',
+        $link
+      );
     }
     $link_obj->click();
   }
@@ -533,7 +537,12 @@ JS;
 
     $button_obj = $region_obj->findButton($button);
     if (empty($button_obj)) {
-      throw new \Exception(sprintf("The button '%s' was not found in the region '%s' on the page %s", $button, $region, $this->getSession()->getCurrentUrl()));
+      throw new ElementNotFoundException(
+        $this->getSession()->getDriver(),
+        sprintf('button in the "%s" region', $region),
+        'id|name|title|alt|value',
+        $button
+      );
     }
     $button_obj->press();
   }
@@ -666,7 +675,12 @@ JS;
 
     $result = $region_obj->findLink($link);
     if (empty($result)) {
-      throw new \Exception(sprintf('No link to "%s" in the "%s" region on the page %s', $link, $region, $this->getSession()->getCurrentUrl()));
+      throw new ElementNotFoundException(
+        $this->getSession()->getDriver(),
+        sprintf('link in the "%s" region', $region),
+        'id|title|alt|text',
+        $link
+      );
     }
   }
 
@@ -687,7 +701,7 @@ JS;
 
     $result = $region_obj->findLink($link);
     if (!empty($result)) {
-      throw new \Exception(sprintf('Link to "%s" in the "%s" region on the page %s', $link, $region, $this->getSession()->getCurrentUrl()));
+      throw new ExpectationException(sprintf('Link to "%s" in the "%s" region on the page %s', $link, $region, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
     }
   }
 
@@ -861,7 +875,12 @@ JS;
 
     $element = $page->find('xpath', $xpath);
     if (!$element) {
-      throw new \Exception(sprintf('Unable to find details%s containing text %s for action %s', $expanded_state, $summary, $action));
+      throw new ElementNotFoundException(
+        $this->getSession()->getDriver(),
+        sprintf('details element for "%s" action', $action),
+        'summary text',
+        $summary
+      );
     }
 
     $ajax_timeout = $this->getMinkParameter('ajax_timeout') ?? 5;
@@ -900,7 +919,7 @@ JS;
     $element = $this->getSession()->getPage();
     $button_obj = $element->findButton($button);
     if (empty($button_obj)) {
-      throw new \Exception(sprintf("The button '%s' was not found on the page %s", $button, $this->getSession()->getCurrentUrl()));
+      throw new ElementNotFoundException($this->getSession()->getDriver(), 'button', 'id|name|title|alt|value', $button);
     }
   }
 
@@ -911,7 +930,7 @@ JS;
     $element = $this->getSession()->getPage();
     $button_obj = $element->findButton($button);
     if (!empty($button_obj)) {
-      throw new \Exception(sprintf("The button '%s' was found on the page %s", $button, $this->getSession()->getCurrentUrl()));
+      throw new ExpectationException(sprintf("The button '%s' was found on the page %s", $button, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
     }
   }
 
@@ -927,7 +946,12 @@ JS;
       }
     }
 
-    throw new \Exception(sprintf('The heading "%s" was not found in the "%s" region on the page %s', $heading, $region, $this->getSession()->getCurrentUrl()));
+    throw new ElementNotFoundException(
+      $this->getSession()->getDriver(),
+      sprintf('heading in the "%s" region', $region),
+      'text',
+      $heading
+    );
   }
 
   /**
@@ -938,7 +962,7 @@ JS;
 
     $region_text = $region_obj->getText();
     if (!str_contains($region_text, $text)) {
-      throw new \Exception(sprintf("The text '%s' was not found in the region '%s' on the page %s", $text, $region, $this->getSession()->getCurrentUrl()));
+      throw new ExpectationException(sprintf("The text '%s' was not found in the region '%s' on the page %s", $text, $region, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
     }
   }
 
@@ -950,7 +974,7 @@ JS;
 
     $region_text = $region_obj->getText();
     if (str_contains($region_text, $text)) {
-      throw new \Exception(sprintf('The text "%s" was found in the region "%s" on the page %s', $text, $region, $this->getSession()->getCurrentUrl()));
+      throw new ExpectationException(sprintf('The text "%s" was found in the region "%s" on the page %s', $text, $region, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
     }
   }
 
@@ -974,7 +998,12 @@ JS;
       $label,
     ]);
     if ($radiobutton === NULL) {
-      throw new \Exception(sprintf('The radio button with "%s" was not found on the page %s', $id ?: $label, $this->getSession()->getCurrentUrl()));
+      throw new ElementNotFoundException(
+        $this->getSession()->getDriver(),
+        'radio button',
+        $id !== '' && $id !== '0' ? 'id' : 'label',
+        $id ?: $label
+      );
     }
     $value = $radiobutton->getAttribute('value');
     $radio_id = $radiobutton->getAttribute('id');
@@ -982,7 +1011,7 @@ JS;
     if ($label_element !== NULL) {
       $labelonpage = $label_element->getText();
       if ($label != $labelonpage) {
-        throw new \Exception(sprintf("Button with id '%s' has label '%s' instead of '%s' on the page %s", $id, $labelonpage, $label, $this->getSession()->getCurrentUrl()));
+        throw new ExpectationException(sprintf("Button with id '%s' has label '%s' instead of '%s' on the page %s", $id, $labelonpage, $label, $this->getSession()->getCurrentUrl()), $this->getSession()->getDriver());
       }
     }
     $radiobutton->selectOption($value, FALSE);

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -804,7 +804,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    * @return \Behat\Behat\Context\Context|false
    *   The requested context, or FALSE if the context is not registered.
    *
-   * @throws \Exception
+   * @throws \RuntimeException
    *   Thrown when the environment is not yet initialized, meaning that contexts
    *   cannot yet be retrieved.
    */

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -816,7 +816,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
     // before a test scenario starts (e.g. in a `@BeforeScenario` hook) then the
     // contexts cannot yet be retrieved.
     if (!$environment instanceof InitializedContextEnvironment) {
-      throw new \Exception('Cannot retrieve contexts when the environment is not yet initialized.');
+      throw new \RuntimeException('Cannot retrieve contexts when the environment is not yet initialized.');
     }
     foreach ($environment->getContexts() as $context) {
       if ($context instanceof $class) {

--- a/src/Drupal/DrupalExtension/Context/RawMailContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawMailContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Context;
 
+use Behat\Mink\Exception\ExpectationException;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Drupal\Driver\Capability\MailCapabilityInterface;
 use Drupal\DrupalMailManager;
@@ -149,7 +150,7 @@ class RawMailContext extends RawDrupalContext {
         $expected_field = [$field_name => $field_value];
         $is_match = $this->matchMessage($actualMessages[$index], $expected_field);
         if (!$is_match) {
-          throw new \Exception(sprintf("The #%s mail did not have '%s' in its %s field. It had:\n'%s'", $index, $field_value, $field_name, mb_strimwidth((string) $actualMessages[$index][$field_name], 0, 30, "...")));
+          throw new ExpectationException(sprintf("The #%s mail did not have '%s' in its %s field. It had:\n'%s'", $index, $field_value, $field_name, mb_strimwidth((string) $actualMessages[$index][$field_name], 0, 30, "...")), $this->getSession()->getDriver());
         }
       }
     }
@@ -168,7 +169,7 @@ class RawMailContext extends RawDrupalContext {
     if (is_null($expectedCount)) {
       // If number to expect is not specified, expect more than zero.
       if ($actual_count === 0) {
-        throw new \Exception("Expected some mail, but none found.");
+        throw new ExpectationException("Expected some mail, but none found.", $this->getSession()->getDriver());
       }
     }
     elseif ($expectedCount !== $actual_count) {
@@ -180,7 +181,7 @@ class RawMailContext extends RawDrupalContext {
           'subject' => $actual_message['subject'],
         ];
       }
-      throw new \Exception(sprintf("Expected %s mail, but %s found:\n\n%s", $expectedCount, $actual_count, print_r($formatted_actual_messages, TRUE)));
+      throw new ExpectationException(sprintf("Expected %s mail, but %s found:\n\n%s", $expectedCount, $actual_count, print_r($formatted_actual_messages, TRUE)), $this->getSession()->getDriver());
     }
   }
 
@@ -213,7 +214,7 @@ class RawMailContext extends RawDrupalContext {
     $mink_context = $this->getContext(RawMinkContext::class);
 
     if (!$mink_context instanceof RawMinkContext) {
-      throw new \Exception('No mink context found.');
+      throw new \RuntimeException('No mink context found.');
     }
 
     return $mink_context;

--- a/src/Drupal/DrupalExtension/DrupalParametersTrait.php
+++ b/src/Drupal/DrupalExtension/DrupalParametersTrait.php
@@ -53,13 +53,13 @@ trait DrupalParametersTrait {
    * @return string
    *   The text value.
    *
-   * @throws \Exception
+   * @throws \RuntimeException
    *   Thrown when the text is not present in the list of parameters.
    */
   public function getDrupalText(string $name) {
     $text = $this->getDrupalParameter('text');
     if (!isset($text[$name])) {
-      throw new \Exception(sprintf('No such Drupal string: %s', $name));
+      throw new \RuntimeException(sprintf('No such Drupal string: %s', $name));
     }
     return $text[$name];
   }
@@ -73,13 +73,13 @@ trait DrupalParametersTrait {
    * @return string
    *   The CSS selector.
    *
-   * @throws \Exception
+   * @throws \RuntimeException
    *   Thrown when the selector is not present in the list of parameters.
    */
   public function getDrupalSelector(string $name) {
     $text = $this->getDrupalParameter('selectors');
     if (!isset($text[$name])) {
-      throw new \Exception(sprintf('No such selector configured: %s', $name));
+      throw new \RuntimeException(sprintf('No such selector configured: %s', $name));
     }
     return $text[$name];
   }

--- a/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
@@ -98,12 +98,8 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
 
     // Verify the login was successful.
     if (!$this->loggedIn()) {
-      throw new ExpectationException(
-        isset($user->role)
-              ? sprintf("Unable to determine if logged in because '%s' ('log_out') link cannot be found for user '%s' with role '%s'", $this->getDrupalText('log_out'), $user->name, $user->role)
-              : sprintf("Unable to determine if logged in because '%s' ('log_out') link cannot be found for user '%s'", $this->getDrupalText('log_out'), $user->name),
-        $session->getDriver()
-      );
+      $message = isset($user->role) ? sprintf("Unable to determine if logged in because '%s' ('log_out') link cannot be found for user '%s' with role '%s'", $this->getDrupalText('log_out'), $user->name, $user->role) : sprintf("Unable to determine if logged in because '%s' ('log_out') link cannot be found for user '%s'", $this->getDrupalText('log_out'), $user->name);
+      throw new ExpectationException($message, $session->getDriver());
     }
 
     // Track the logged-in user.

--- a/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
@@ -7,6 +7,8 @@ namespace Drupal\DrupalExtension\Manager;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Element\DocumentElement;
 use Behat\Mink\Exception\DriverException;
+use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Mink;
 use Drupal\Driver\Capability\AuthenticationCapabilityInterface;
 use Drupal\DrupalDriverManagerInterface;
@@ -68,7 +70,7 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
     // Submit the login form.
     $login_element = $this->getLoginElement($page);
     if (!$login_element instanceof NodeElement) {
-      throw new \Exception(sprintf('No submit button at %s', $session->getCurrentUrl()));
+      throw new ElementNotFoundException($session->getDriver(), 'submit button', 'css', 'login form');
     }
     $login_element->click();
 
@@ -96,9 +98,12 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
 
     // Verify the login was successful.
     if (!$this->loggedIn()) {
-      throw new \Exception(isset($user->role)
-            ? sprintf("Unable to determine if logged in because '%s' ('log_out') link cannot be found for user '%s' with role '%s'", $this->getDrupalText('log_out'), $user->name, $user->role)
-            : sprintf("Unable to determine if logged in because '%s' ('log_out') link cannot be found for user '%s'", $this->getDrupalText('log_out'), $user->name));
+      throw new ExpectationException(
+        isset($user->role)
+              ? sprintf("Unable to determine if logged in because '%s' ('log_out') link cannot be found for user '%s' with role '%s'", $this->getDrupalText('log_out'), $user->name, $user->role)
+              : sprintf("Unable to determine if logged in because '%s' ('log_out') link cannot be found for user '%s'", $this->getDrupalText('log_out'), $user->name),
+        $session->getDriver()
+      );
     }
 
     // Track the logged-in user.
@@ -124,7 +129,7 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
       $logout_element = $this->getLogoutConfirmElement($session->getPage());
 
       if (!$logout_element instanceof NodeElement) {
-        throw new \Exception(sprintf("Unable to determine if logged out because '%s' button cannot be found on the logout confirmation page at %s", $this->getDrupalText('log_out'), $session->getCurrentUrl()));
+        throw new ElementNotFoundException($session->getDriver(), 'logout button', 'css', 'logout confirmation page');
       }
 
       $logout_element->click();

--- a/src/Drupal/DrupalExtension/RegionTrait.php
+++ b/src/Drupal/DrupalExtension/RegionTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension;
 
+use Behat\Mink\Exception\ElementNotFoundException;
+
 /**
  * Provides a method to find a region on the current page.
  */
@@ -18,14 +20,14 @@ trait RegionTrait {
    * @return \Behat\Mink\Element\NodeElement
    *   The region element.
    *
-   * @throws \Exception
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
    *   If region cannot be found.
    */
   public function getRegion(string $region) {
     $session = $this->getSession();
     $region_obj = $session->getPage()->find('region', $region);
     if (!$region_obj) {
-      throw new \Exception(sprintf('No region "%s" found on the page %s.', $region, $session->getCurrentUrl()));
+      throw new ElementNotFoundException($session->getDriver(), 'region', 'name', $region);
     }
 
     return $region_obj;

--- a/tests/behat/features/drupal.feature
+++ b/tests/behat/features/drupal.feature
@@ -24,7 +24,7 @@ Feature: DrupalContext coverage gaps
       Given I am viewing my "article" content with the title "Anon content"
       """
     When I run behat with drupal profile
-    Then it should fail with an error:
+    Then it should fail with an exception:
       """
       There is no current logged in user to create a node for.
       """
@@ -111,7 +111,7 @@ Feature: DrupalContext coverage gaps
     When I run behat with drupal profile
     Then it should fail with an error:
       """
-      Failed to find a row containing "NONEXISTENT_ROW"
+      Row with text "NONEXISTENT_ROW" not found.
       """
 
   @test-drupal @api
@@ -174,7 +174,7 @@ Feature: DrupalContext coverage gaps
     When I run behat with drupal profile
     Then it should fail with an error:
       """
-      no "Nonexistent link" link
+      Link in the "Link row test" row with id|title|alt|text "Nonexistent link" not found.
       """
 
   @test-drupal @api
@@ -219,7 +219,7 @@ Feature: DrupalContext coverage gaps
     When I run behat with drupal profile
     Then it should fail with an error:
       """
-      no "Nonexistent link" link
+      Link in the "Click target" row with id|title|alt|text "Nonexistent link" not found.
       """
 
   @test-drupal @api
@@ -237,7 +237,7 @@ Feature: DrupalContext coverage gaps
     When I run behat with drupal profile
     Then it should fail with an error:
       """
-      no "Nonexistent button" button
+      Button in the "Button target" row with id|name|title|alt|value "Nonexistent button" not found.
       """
 
   @test-drupal @api

--- a/tests/behat/features/drupal_smoke.feature
+++ b/tests/behat/features/drupal_smoke.feature
@@ -25,7 +25,7 @@ Feature: Drupal driver smoke test
     When I run behat with drupal profile
     Then it should fail with an error:
       """
-      No rows found on the page
+      Row matching css "tr" not found.
       """
 
   @test-drupal @api

--- a/tests/behat/features/markup.feature
+++ b/tests/behat/features/markup.feature
@@ -14,7 +14,7 @@ Feature: MarkupContext
     When I run behat
     Then it should fail with an error:
       """
-      The button 'Nonexistent' was not found in the region 'static content'
+      Button in the "static content" region with id|name|title|alt|value "Nonexistent" not found.
       """
 
   @test-blackbox
@@ -42,7 +42,7 @@ Feature: MarkupContext
     When I run behat
     Then it should fail with an error:
       """
-      The element "h99" was not found in the "static content" region
+      Element in the "static content" region matching css "h99" not found.
       """
 
   @test-blackbox

--- a/tests/behat/features/mink.feature
+++ b/tests/behat/features/mink.feature
@@ -19,7 +19,7 @@ Feature: MinkContext coverage gaps
     When I run behat
     Then it should fail with an error:
       """
-      The text 'Does Not Exist' was not found in any heading
+      Heading with text "Does Not Exist" not found.
       """
 
   @test-blackbox
@@ -52,7 +52,7 @@ Feature: MinkContext coverage gaps
     When I run behat
     Then it should fail with an error:
       """
-      The button 'Missing Button' was not found on the page
+      Button with id|name|title|alt|value "Missing Button" not found.
       """
 
   @test-blackbox
@@ -80,7 +80,7 @@ Feature: MinkContext coverage gaps
     When I run behat
     Then it should fail with an error:
       """
-      No link to 'Nonexistent link'
+      Link with id|title|alt|text "Nonexistent link" not found.
       """
 
   @test-blackbox
@@ -113,7 +113,7 @@ Feature: MinkContext coverage gaps
     When I run behat
     Then it should fail with an error:
       """
-      The link 'Totally missing link' was not loaded on the page
+      Link with id|title|alt|text "Totally missing link" not found.
       """
 
   @test-blackbox
@@ -153,7 +153,7 @@ Feature: MinkContext coverage gaps
     When I run behat
     Then it should fail with an error:
       """
-      The radio button with "Nonexistent Option" was not found on the page
+      Radio button with label "Nonexistent Option" not found.
       """
 
   @test-blackbox
@@ -224,7 +224,7 @@ Feature: MinkContext coverage gaps
     When I run behat
     Then it should fail with an error:
       """
-      No link to "Missing" in the "static content" region
+      Link in the "static content" region with id|title|alt|text "Missing" not found.
       """
 
   @test-blackbox
@@ -252,7 +252,7 @@ Feature: MinkContext coverage gaps
     When I run behat
     Then it should fail with an error:
       """
-      The heading "Nonexistent Heading" was not found in the "static content" region
+      Heading in the "static content" region with text "Nonexistent Heading" not found.
       """
 
   @test-blackbox
@@ -266,7 +266,7 @@ Feature: MinkContext coverage gaps
     When I run behat
     Then it should fail with an error:
       """
-      The link "Nonexistent link" was not found in the region "static content"
+      Link in the "static content" region with id|title|alt|text "Nonexistent link" not found.
       """
 
   @test-blackbox
@@ -280,7 +280,7 @@ Feature: MinkContext coverage gaps
     When I run behat
     Then it should fail with an error:
       """
-      The button 'Nonexistent' was not found in the region 'static footer'
+      Button in the "static footer" region with id|name|title|alt|value "Nonexistent" not found.
       """
 
   @test-blackbox
@@ -294,7 +294,7 @@ Feature: MinkContext coverage gaps
     When I run behat
     Then it should fail with an error:
       """
-      Unable to find details
+      Details element for "click" action with summary text "Nonexistent details" not found.
       """
 
   @test-blackbox @javascript

--- a/tests/phpunit/src/DrupalAuthenticationManagerTest.php
+++ b/tests/phpunit/src/DrupalAuthenticationManagerTest.php
@@ -6,6 +6,7 @@ namespace Drupal\DrupalExtension\Tests;
 
 use Drupal\Driver\DriverInterface;
 use PHPUnit\Framework\MockObject\MockObject;
+use Behat\Mink\Driver\DriverInterface as MinkDriverInterface;
 use Behat\Mink\Element\DocumentElement;
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\DriverException;
@@ -97,7 +98,7 @@ class DrupalAuthenticationManagerTest extends TestCase {
     $manager = $this->createManager($session);
 
     $this->expectException(\Exception::class);
-    $this->expectExceptionMessage('No submit button at http://localhost/user/login');
+    $this->expectExceptionMessage('Submit button matching css "login form" not found.');
     $manager->logIn((object) ['name' => 'admin', 'pass' => 'pass']);
   }
 
@@ -218,7 +219,7 @@ class DrupalAuthenticationManagerTest extends TestCase {
     $manager = $this->createManager($session);
 
     $this->expectException(\Exception::class);
-    $this->expectExceptionMessage("Unable to determine if logged out because 'Log out' button cannot be found on the logout confirmation page");
+    $this->expectExceptionMessage('Logout button matching css "logout confirmation page" not found.');
     $manager->logout();
   }
 
@@ -389,6 +390,7 @@ class DrupalAuthenticationManagerTest extends TestCase {
   private function createSessionMock(?DocumentElement $page = NULL): Session {
     $session = $this->createMock(Session::class);
     $session->method('getPage')->willReturn($page ?? $this->createMock(DocumentElement::class));
+    $session->method('getDriver')->willReturn($this->createMock(MinkDriverInterface::class));
     return $session;
   }
 

--- a/tests/phpunit/src/RawMailContextTest.php
+++ b/tests/phpunit/src/RawMailContextTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Tests;
 
+use Behat\Mink\Driver\DriverInterface as MinkDriverInterface;
+use Behat\Mink\Mink;
+use Behat\Mink\Session;
 use Drupal\DrupalExtension\Context\RawMailContext;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -45,6 +48,13 @@ class RawMailContextTest extends TestCase {
    */
   protected function setUp(): void {
     $this->context = new RawMailContext();
+
+    $session = $this->createMock(Session::class);
+    $session->method('getDriver')->willReturn($this->createMock(MinkDriverInterface::class));
+    $mink = new Mink(['default' => $session]);
+    $mink->setDefaultSessionName('default');
+    $this->context->setMink($mink);
+
     $this->matchMessage = new \ReflectionMethod(RawMailContext::class, 'matchMessage');
     $this->sortMessages = new \ReflectionMethod(RawMailContext::class, 'sortMessages');
     $this->compareMessages = new \ReflectionMethod(RawMailContext::class, 'compareMessages');


### PR DESCRIPTION
Closes #752

## Summary

- Replaced ~30 generic `\Exception` throws across bundled contexts with typed Mink and PHP exceptions, following the canonical mapping the issue documents.
- Added an "Exception conventions" reference section to `CONTRIBUTING.md` and a migration note to `MIGRATION.md` so subclassers know what changed in 6.0.
- Updated Behat test fixtures to match the auto-generated `ElementNotFoundException` message format produced by Mink.

## Changes

**Exception mapping applied:**

| Situation | Before | After |
|---|---|---|
| Element / field / link / button / region not found | `\Exception` | `Behat\Mink\Exception\ElementNotFoundException` |
| Assertion fails (value mismatch, state verification) | `\Exception` | `Behat\Mink\Exception\ExpectationException` |
| Configuration / processing error (non-assertion) | `\Exception` | `\RuntimeException` |

**Files with exception changes:**

- `MinkContext.php` - ~15 throws: link/field/heading/button lookups and visibility assertions
- `MarkupContext.php` - ~12 throws: region/element/attribute assertions
- `DrupalContext.php` - ~10 throws: table row lookups and state assertions
- `DrupalAuthenticationManager.php` - login/logout failure assertions
- `RawDrupalContext.php` - environment not initialized
- `RawMailContext.php` - mail content/count assertions and missing context
- `MailContext.php` - mail/URL not found assertions
- `DrushContext.php` - drush output assertions
- `BatchContext.php` - queue item creation failure
- `RegionTrait.php` - region not found
- `DrupalParametersTrait.php` - no such drupal string/selector

**Test fixture updates:**

- `mink.feature`, `markup.feature`, `drupal.feature`, `drupal_smoke.feature` - updated expected message substrings to match Mink's auto-generated `ElementNotFoundException` format

**Documentation:**

- `CONTRIBUTING.md` - new "Exception conventions" section with the full type mapping and example messages
- `MIGRATION.md` - new "Exception classes" section noting the 5.x → 6.0 message format change

## Before / After

```
Before (generic):
-  throw new \Exception(sprintf('No link to "%s" on the page %s', $link, $this->getSession()->getCurrentUrl()));

After (typed Mink exception):
+  throw new ElementNotFoundException($this->getSession()->getDriver(), 'link', 'id|title|alt|text', $link);
```

```
Before (generic assertion):
-  throw new \Exception(sprintf('"%s" link not found in the "%s" region.', $link, $region));

After (typed Mink exception):
+  throw new ExpectationException(sprintf('"%s" link not found in the "%s" region.', $link, $region), $this->getSession()->getDriver());
```

```
Before (generic runtime error):
-  throw new \Exception('Mink is not available.');

After (typed runtime exception):
+  throw new \RuntimeException('Mink is not available.');
```

The Mink exception classes append the current URL and a page snippet via
`__toString()`, so callers and test output get the same contextual information
without the throw site embedding the URL manually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added exception handling standards and migration guidance for improved error reporting.

* **Tests**
  * Updated test assertions to match refined error message formats with structured locator and context information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->