### PR TITLE
[#806] Removed 'store' parameter from 'DrupalMailManager' and 'DrupalMailManagerInterface'.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -84,6 +84,25 @@ Several multi-step methods have also been split, so that each step
 annotation lives on its own method. See [`STEPS.md`](STEPS.md) for the full
 list of methods and their step patterns.
 
+## Service interface changes
+
+`DrupalMailManagerInterface::getMail()` and `::clearMail()` no longer accept
+a `$store` argument. The v3 driver's `MailCapabilityInterface` exposes a
+single implicit collector, so the multi-store concept inherited from
+drupal-driver v2 has been removed.
+
+| 5.x signature                              | 6.0 signature                  |
+|--------------------------------------------|--------------------------------|
+| `getMail(string $store)`                   | `getMail(): array`             |
+| `clearMail(string $store): void`           | `clearMail(): void`            |
+
+If you implement `DrupalMailManagerInterface` directly, drop the `$store`
+parameter from your overrides. If you subclass `RawMailContext`, the
+protected `getMail()` helper has lost its `$store` argument and the
+`getMailMessageCount()` helper has been removed; the
+`$mailMessageCount` property is now an `int` rather than an array keyed by
+store name.
+
 ## Recommended upgrade flow
 
 1. Update your `composer.json` to `drupal/drupal-extension:^6.0`.

--- a/src/Drupal/DrupalExtension/Context/MailContext.php
+++ b/src/Drupal/DrupalExtension/Context/MailContext.php
@@ -31,7 +31,7 @@ class MailContext extends RawMailContext {
     // Always reset mail count, in case the default mail manager is being used
     // which enables mail collecting automatically when mail is disabled, making
     // the use of the @mail tag optional in this case.
-    $this->mailMessageCount = [];
+    $this->mailMessageCount = 0;
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Context/RawMailContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawMailContext.php
@@ -20,11 +20,9 @@ class RawMailContext extends RawDrupalContext {
   protected ?DrupalMailManager $mailManager = NULL;
 
   /**
-   * The number of mails received so far in this scenario, for each mail store.
-   *
-   * @var array<string, int>
+   * The number of mails received so far in this scenario.
    */
-  protected array $mailMessageCount = [];
+  protected int $mailMessageCount = 0;
 
   /**
    * Get the mail manager service that handles stored test mail.
@@ -57,18 +55,16 @@ class RawMailContext extends RawDrupalContext {
    *   Whether to ignore previously seen mail.
    * @param null|int $index
    *   A particular mail to return, e.g. 0 for first or -1 for last.
-   * @param string $store
-   *   The name of the mail store to get mail from.
    *
    * @return array<int, array<string, mixed>>|array<string, mixed>
    *   An array of mail messages keyed by index, or a single mail message
    *   array when '$index' is specified. Each item follows Drupal's
    *   'MailInterface::mail()' shape ('to', 'subject', 'body', etc.).
    */
-  protected function getMail(array $criteria = [], bool $new = FALSE, ?int $index = NULL, string $store = 'default') {
-    $messages = $this->getMailManager()->getMail($store);
-    $previous_count = $this->getMailMessageCount($store);
-    $this->mailMessageCount[$store] = count($messages);
+  protected function getMail(array $criteria = [], bool $new = FALSE, ?int $index = NULL) {
+    $messages = $this->getMailManager()->getMail();
+    $previous_count = $this->mailMessageCount;
+    $this->mailMessageCount = count($messages);
 
     // Ignore previously seen messages.
     if ($new) {
@@ -85,20 +81,6 @@ class RawMailContext extends RawDrupalContext {
     }
 
     return array_slice($messages, $index, 1)[0];
-  }
-
-  /**
-   * Get the number of mails received in a particular mail store.
-   *
-   * @return int
-   *   The number of mails received during this scenario.
-   */
-  protected function getMailMessageCount(string $store): int {
-    if (array_key_exists($store, $this->mailMessageCount)) {
-      return $this->mailMessageCount[$store];
-    }
-
-    return 0;
   }
 
   /**

--- a/src/Drupal/DrupalMailManager.php
+++ b/src/Drupal/DrupalMailManager.php
@@ -55,34 +55,15 @@ class DrupalMailManager implements DrupalMailManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getMail($store = 'default'): array {
-    $this->assertDefaultStore($store);
-
+  public function getMail(): array {
     return $this->driver->mailGet();
   }
 
   /**
    * {@inheritdoc}
    */
-  public function clearMail(string $store = 'default'): void {
-    $this->assertDefaultStore($store);
-
+  public function clearMail(): void {
     $this->driver->mailClear();
-  }
-
-  /**
-   * Rejects non-default mail stores.
-   *
-   * The v3 driver's 'MailCapabilityInterface' exposes a single implicit
-   * collector, so any '$store' other than 'default' is unsupported. Throw
-   * loudly rather than silently misroute reads or clears that consumers
-   * relied on under earlier multi-store implementations. The '$store'
-   * parameter will be removed entirely in a follow-up.
-   */
-  protected function assertDefaultStore(string $store): void {
-    if ($store !== 'default') {
-      throw new \InvalidArgumentException(sprintf('Mail store "%s" is not supported - the active driver only exposes the default store.', $store));
-    }
   }
 
 }

--- a/src/Drupal/DrupalMailManagerInterface.php
+++ b/src/Drupal/DrupalMailManagerInterface.php
@@ -32,22 +32,16 @@ interface DrupalMailManagerInterface {
   /**
    * Get all collected mail.
    *
-   * @param string $store
-   *   The name of the mail store to get mail from.
-   *
    * @return array<int, array<string, mixed>>
    *   An array of collected emails. Each item is a Drupal mail message
    *   array as produced by 'MailInterface::mail()' - the keys include
    *   'to', 'subject', 'body', 'headers', etc.
    */
-  public function getMail(string $store);
+  public function getMail(): array;
 
   /**
    * Empty the store of collected mail.
-   *
-   * @param string $store
-   *   The name of the mail store to clear.
    */
-  public function clearMail(string $store): void;
+  public function clearMail(): void;
 
 }


### PR DESCRIPTION
Closes #806

## Summary

Removes the `$store` parameter from `DrupalMailManagerInterface::getMail()` and `::clearMail()`, and from their implementations in `DrupalMailManager` and `RawMailContext`. The drupal-driver v3 `MailCapabilityInterface` exposes a single implicit collector via `mailGet()` / `mailClear()`, so the multi-store concept inherited from drupal-driver v2 has no backing implementation. The interim `assertDefaultStore()` guard (added in #803) is removed in favour of dropping the parameter entirely. `MIGRATION.md` documents the breaking change for downstream implementors.

## Changes

**`DrupalMailManagerInterface`**
- `getMail()` drops the `$store` parameter and gains an explicit `: array` return type declaration.
- `clearMail()` drops the `$store` parameter.

**`DrupalMailManager`**
- `getMail()` and `clearMail()` drop the `$store` parameter and delegate directly to `mailGet()` / `mailClear()`.
- `assertDefaultStore()` guard method removed entirely.

**`RawMailContext`**
- `$mailMessageCount` collapses from `array<string, int>` (keyed by store name) to a plain `int`, initialised to `0`.
- `getMail()` loses the `$store` parameter; previous-count tracking uses the scalar property directly.
- `getMailMessageCount(string $store): int` helper is inlined and removed.

**`MailContext`**
- `disableMail()` resets `$mailMessageCount` to `0` instead of `[]`.

**`MIGRATION.md`**
- New "Service interface changes" section with a signature comparison table and upgrade guidance for downstream subclassers.

## Before / After

```
Before                                                  After
──────────────────────────────────────────────────────  ────────────────────────────────────────
DrupalMailManagerInterface                              DrupalMailManagerInterface
├── getMail(string $store)                              ├── getMail(): array
└── clearMail(string $store): void                      └── clearMail(): void

DrupalMailManager                                       DrupalMailManager
├── getMail($store = 'default'): array                  ├── getMail(): array
├── clearMail(string $store = 'default'): void          ├── clearMail(): void
└── assertDefaultStore(string $store): void             └── (removed)
    └── throws InvalidArgumentException

RawMailContext                                          RawMailContext
├── $mailMessageCount: array<string, int> = []          ├── $mailMessageCount: int = 0
├── getMail(..., string $store = 'default'): mixed      ├── getMail(...): mixed
└── getMailMessageCount(string $store): int             └── (inlined; helper removed)
```
