### PR TITLE
[#337] Replaced 'stdClass' entity stubs with typed 'EntityStub' from driver.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "behat/gherkin": "^4.13",
         "behat/mink": "^1.12",
         "behat/mink-browserkit-driver": "^2.1.0",
-        "drupal/drupal-driver": "dev-master as 3.0.0",
+        "drupal/drupal-driver": "dev-feature/362-entity-stub as 3.0.0",
         "friends-of-behat/mink-extension": "^2.7.1",
         "lullabot/mink-selenium2-driver": "^1.7.4",
         "symfony/css-selector": "^6.4.3 || ^7",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "behat/gherkin": "^4.13",
         "behat/mink": "^1.12",
         "behat/mink-browserkit-driver": "^2.1.0",
-        "drupal/drupal-driver": "dev-feature/362-entity-stub as 3.0.0",
+        "drupal/drupal-driver": "dev-master as 3.0.0",
         "friends-of-behat/mink-extension": "^2.7.1",
         "lullabot/mink-selenium2-driver": "^1.7.4",
         "symfony/css-selector": "^6.4.3 || ^7",

--- a/scripts/docs.php
+++ b/scripts/docs.php
@@ -66,19 +66,24 @@ function main(array $options = []): void {
 
   $lenient = isset($options['warning-on-invalid']);
   $results = validate($info, $base_path);
+  $has_errors = has_validation_errors($results);
 
-  $tree_output = '';
-  if (has_validation_errors($results)) {
-    $tree_output = render_validation_tree($results);
+  // Always render the tree so the validation logs (and the CI comment) show
+  // the per-context outcome even on a clean run. The CLI only prints the
+  // tree when there is something to action.
+  $tree_output = render_validation_tree($results, $has_errors);
+
+  if ($has_errors) {
     echo $tree_output;
-    if (!$lenient) {
-      exit(1);
-    }
   }
 
   $log_dir = is_string($options['log-dir'] ?? NULL) ? $options['log-dir'] : NULL;
   if ($log_dir !== NULL) {
     write_validation_logs($tree_output, $log_dir);
+  }
+
+  if ($has_errors && !$lenient) {
+    exit(1);
   }
 
   $steps_markdown = PHP_EOL . render_info($info, $base_path) . PHP_EOL;
@@ -803,11 +808,14 @@ function has_validation_errors(array $results): bool {
  *
  * @param array<string, array{file: array{pass: bool, path: string}, methods: array<string, array<string, array{pass: bool, messages: array<int, string>}>>}> $results
  *   Structured validation results from validate().
+ * @param bool $has_errors
+ *   Whether the result set contains any validation errors. Drives the
+ *   header label so a clean run reads as a report instead of a warning.
  *
  * @return string
  *   The rendered tree output.
  */
-function render_validation_tree(array $results): string {
+function render_validation_tree(array $results, bool $has_errors = TRUE): string {
   $bold = "\033[1m";
   $green = "\033[32m";
   $yellow = "\033[33m";
@@ -851,7 +859,9 @@ function render_validation_tree(array $results): string {
   }
 
   $output = '';
-  $output .= $yellow . 'Validation warnings:' . $reset . PHP_EOL . PHP_EOL;
+  $header_label = $has_errors ? 'Validation warnings:' : 'Validation report:';
+  $header_color = $has_errors ? $yellow : $green;
+  $output .= $header_color . $header_label . $reset . PHP_EOL . PHP_EOL;
 
   $class_names = array_keys($results);
 

--- a/spec/Drupal/DrupalExtension/Hook/Scope/BeforeNodeCreateScopeSpec.php
+++ b/spec/Drupal/DrupalExtension/Hook/Scope/BeforeNodeCreateScopeSpec.php
@@ -6,6 +6,8 @@ use Behat\Behat\Context\Context;
 use Behat\Testwork\Environment\Environment;
 
 use Behat\Testwork\Suite\Suite;
+use Drupal\Driver\Entity\EntityStub;
+use Drupal\Driver\Entity\EntityStubInterface;
 use Drupal\DrupalExtension\Hook\Scope\BeforeNodeCreateScope;
 use PhpSpec\ObjectBehavior;
 
@@ -15,9 +17,9 @@ use PhpSpec\ObjectBehavior;
 class BeforeNodeCreateScopeSpec extends ObjectBehavior {
 
   public function let(Environment $environment, Context $context, Suite $suite) {
-    $node = new \stdClass();
+    $stub = new EntityStub('node', 'article');
     $environment->getSuite()->willReturn($suite);
-    $this->beConstructedWith($environment, $context, $node);
+    $this->beConstructedWith($environment, $context, $stub);
   }
 
   public function it_is_initializable() {
@@ -29,8 +31,8 @@ class BeforeNodeCreateScopeSpec extends ObjectBehavior {
     $context->shouldBeAnInstanceOf(Context::class);
   }
 
-  public function it_should_return_a_node() {
-    $this->getEntity()->shouldBeAnInstanceOf(\stdClass::class);
+  public function it_should_return_a_stub() {
+    $this->getStub()->shouldBeAnInstanceOf(EntityStubInterface::class);
   }
 
   public function it_should_return_environment() {

--- a/spec/Drupal/DrupalExtension/Manager/DrupalUserManagerSpec.php
+++ b/spec/Drupal/DrupalExtension/Manager/DrupalUserManagerSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Drupal\DrupalExtension\Manager;
 
+use Drupal\Driver\Entity\EntityStub;
 use Drupal\DrupalExtension\Manager\DrupalUserManager;
 use PhpSpec\ObjectBehavior;
 
@@ -15,15 +16,13 @@ class DrupalUserManagerSpec extends ObjectBehavior {
   }
 
   public function it_can_set_and_get_the_current_user() {
-    $user = new \stdClass();
-    $user->name = 'some_name';
+    $user = new EntityStub('user', NULL, ['name' => 'some_name']);
     $this->setCurrentUser($user);
     $this->getCurrentUser()->shouldBe($user);
   }
 
   public function it_can_add_and_remove_users() {
-    $user = new \stdClass();
-    $user->name = 'some_name';
+    $user = new EntityStub('user', NULL, ['name' => 'some_name']);
     $this->addUser($user);
     $this->getUser('some_name')->shouldBe($user);
     $this->removeUser('some_name');
@@ -32,8 +31,7 @@ class DrupalUserManagerSpec extends ObjectBehavior {
 
   public function it_can_get_all_registered_users() {
     $this->hasUsers()->shouldBe(FALSE);
-    $user = new \stdClass();
-    $user->name = 'some_name';
+    $user = new EntityStub('user', NULL, ['name' => 'some_name']);
     $this->addUser($user);
     $this->hasUsers()->shouldBe(TRUE);
     $this->getUsers()->shouldBe(['some_name' => $user]);
@@ -41,17 +39,14 @@ class DrupalUserManagerSpec extends ObjectBehavior {
 
   public function it_can_determine_anonymous_users() {
     $this->currentUserIsAnonymous()->shouldBe(TRUE);
-    $user = new \stdClass();
-    $user->name = 'some_name';
+    $user = new EntityStub('user', NULL, ['name' => 'some_name']);
     $this->setCurrentUser($user);
     $this->currentUserIsAnonymous()->shouldBe(FALSE);
   }
 
   public function it_can_check_roles() {
     $this->currentUserHasRole('some_role')->shouldBe(FALSE);
-    $user = new \stdClass();
-    $user->name = 'some_name';
-    $user->role = 'some_role';
+    $user = new EntityStub('user', NULL, ['name' => 'some_name', 'role' => 'some_role']);
     $this->setCurrentUser($user);
     $this->currentUserHasRole('some_role')->shouldBe(TRUE);
   }

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -17,6 +17,8 @@ use Drupal\Driver\Capability\CacheCapabilityInterface;
 use Drupal\Driver\Capability\CronCapabilityInterface;
 use Drupal\Driver\Capability\RoleCapabilityInterface;
 use Drupal\Driver\Capability\UserCapabilityInterface;
+use Drupal\Driver\Entity\EntityStub;
+use Drupal\Driver\Entity\EntityStubInterface;
 
 /**
  * Provides pre-built step definitions for interacting with Drupal.
@@ -146,20 +148,20 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @param array<string, mixed> $extra_fields
    *   Optional additional fields.
    */
-  protected function createUserStub(string $role, array $extra_fields = []): \stdClass {
-    $user = (object) [
-      'name' => $this->getRandom()->name(8),
+  protected function createUserStub(string $role, array $extra_fields = []): EntityStubInterface {
+    $name = $this->getRandom()->name(8);
+    $stub = new EntityStub('user', NULL, [
+      'name' => $name,
       'pass' => $this->getRandom()->name(16),
       'role' => $role,
-    ];
-
-    $user->mail = $user->name . '@example.com';
+      'mail' => $name . '@example.com',
+    ]);
 
     foreach ($extra_fields as $field => $value) {
-      $user->{$field} = $value;
+      $stub->setValue($field, $value);
     }
 
-    return $user;
+    return $stub;
   }
 
   /**
@@ -457,9 +459,8 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
   #[Given('the following :type content:')]
   public function createNodes(string $type, TableNode $nodesTable): void {
     foreach ($nodesTable->getHash() as $node_hash) {
-      $node = (object) $node_hash;
-      $node->type = $type;
-      $this->nodeCreate($node);
+      $stub = new EntityStub('node', $type, $node_hash);
+      $this->nodeCreate($stub);
     }
   }
 
@@ -566,16 +567,16 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
         unset($user_hash['roles']);
       }
 
-      $user = (object) $user_hash;
-      // Set a password.
-      if (!isset($user->pass)) {
-        $user->pass = $this->getRandom()->name();
+      // Set a password if none was supplied.
+      if (!isset($user_hash['pass'])) {
+        $user_hash['pass'] = $this->getRandom()->name();
       }
 
-      $this->userCreate($user);
+      $stub = new EntityStub('user', NULL, $user_hash);
+      $this->userCreate($stub);
 
       foreach ($roles as $role) {
-        $driver->userAddRole($user, $role);
+        $driver->userAddRole($stub, $role);
       }
     }
   }
@@ -592,10 +593,12 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    */
   #[Given('the following :vocabulary terms:')]
   public function createTerms(string $vocabulary, TableNode $termsTable): void {
+    $machine_name = $this->resolveVocabularyMachineName($vocabulary);
+
     foreach ($termsTable->getHash() as $terms_hash) {
-      $term = (object) $terms_hash;
-      $term->vocabulary_machine_name = $vocabulary;
-      $this->termCreate($term);
+      $terms_hash['vocabulary_machine_name'] = $machine_name;
+      $stub = new EntityStub('taxonomy_term', $machine_name, $terms_hash);
+      $this->termCreate($stub);
     }
   }
 
@@ -615,10 +618,10 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
   #[Given('the/these (following )languages are available:')]
   public function createLanguages(TableNode $langcodesTable): void {
     foreach ($langcodesTable->getHash() as $row) {
-      $language = (object) [
+      $stub = new EntityStub('language', NULL, [
         'langcode' => $row['languages'],
-      ];
-      $this->languageCreate($language);
+      ]);
+      $this->languageCreate($stub);
     }
   }
 
@@ -669,12 +672,9 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * Create a node and visit its detail page.
    */
   protected function createAndVisitNode(string $type, string $title): void {
-    $node = (object) [
-      'title' => $title,
-      'type' => $type,
-    ];
-    $saved = $this->nodeCreate($node);
-    $this->getSession()->visit($this->locatePath('/node/' . $saved->nid));
+    $stub = new EntityStub('node', $type, ['title' => $title]);
+    $this->nodeCreate($stub);
+    $this->getSession()->visit($this->locatePath('/node/' . $stub->getId()));
   }
 
   /**
@@ -686,61 +686,54 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
     }
 
     $current_user = $this->getUserManager()->getCurrentUser();
-    if (!$current_user instanceof \stdClass) {
+
+    if (!$current_user instanceof EntityStubInterface) {
       throw new \RuntimeException('There is no current logged in user to create a node for.');
     }
-    $node = (object) [
-      'title' => $title,
-      'type' => $type,
-      'body' => $this->getRandom()->name(255),
-      'uid' => $current_user->uid,
-    ];
-    $saved = $this->nodeCreate($node);
 
-    $this->getSession()->visit($this->locatePath('/node/' . $saved->nid));
+    $stub = new EntityStub('node', $type, [
+      'title' => $title,
+      'body' => $this->getRandom()->name(255),
+      'uid' => $current_user->getValue('uid') ?? $current_user->getId(),
+    ]);
+    $this->nodeCreate($stub);
+
+    $this->getSession()->visit($this->locatePath('/node/' . $stub->getId()));
   }
 
   /**
    * Create a node from a TableNode of fields and visit it.
    */
   protected function createAndVisitNodeFromTable(string $type, TableNode $fields): void {
-    $node = (object) [
-      'type' => $type,
-    ];
-    foreach ($fields->getRowsHash() as $field => $value) {
-      $node->{$field} = $value;
-    }
+    $stub = new EntityStub('node', $type, $fields->getRowsHash());
+    $this->nodeCreate($stub);
 
-    $saved = $this->nodeCreate($node);
-
-    $this->getSession()->visit($this->locatePath('/node/' . $saved->nid));
+    $this->getSession()->visit($this->locatePath('/node/' . $stub->getId()));
   }
 
   /**
    * Create a term on an existing vocabulary and visit it.
    */
   protected function createAndVisitTerm(string $vocabulary, string $name): void {
-    $term = (object) [
+    $machine_name = $this->resolveVocabularyMachineName($vocabulary);
+    $stub = new EntityStub('taxonomy_term', $machine_name, [
       'name' => $name,
-      'vocabulary_machine_name' => $vocabulary,
+      'vocabulary_machine_name' => $machine_name,
       'description' => $this->getRandom()->name(255),
-    ];
-    $saved = $this->termCreate($term);
+    ]);
+    $this->termCreate($stub);
 
-    $this->getSession()->visit($this->locatePath('/taxonomy/term/' . $saved->tid));
+    $this->getSession()->visit($this->locatePath('/taxonomy/term/' . $stub->getId()));
   }
 
   /**
    * Create a node of the given type and verify its edit page returns 200.
    */
   protected function assertNodeTypeIsEditable(string $type): void {
-    $node = (object) [
-      'type' => $type,
-      'title' => 'Test ' . $type,
-    ];
-    $saved = $this->nodeCreate($node);
+    $stub = new EntityStub('node', $type, ['title' => 'Test ' . $type]);
+    $this->nodeCreate($stub);
 
-    $this->getSession()->visit($this->locatePath('/node/' . $saved->nid . '/edit'));
+    $this->getSession()->visit($this->locatePath('/node/' . $stub->getId() . '/edit'));
 
     $this->assertSession()->statusCodeEquals(200);
   }

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -12,7 +12,6 @@ use Drupal\Driver\Capability\LanguageCapabilityInterface;
 use Drupal\Driver\Capability\RoleCapabilityInterface;
 use Drupal\Driver\Capability\UserCapabilityInterface;
 use Drupal\Driver\DrupalDriver;
-use Drupal\Driver\Entity\EntityStub;
 use Drupal\Driver\Entity\EntityStubInterface;
 use Drupal\DrupalExtension\Hook\Attribute\BeforeNodeCreate;
 use Drupal\taxonomy\Entity\Vocabulary;

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -12,6 +12,8 @@ use Drupal\Driver\Capability\LanguageCapabilityInterface;
 use Drupal\Driver\Capability\RoleCapabilityInterface;
 use Drupal\Driver\Capability\UserCapabilityInterface;
 use Drupal\Driver\DrupalDriver;
+use Drupal\Driver\Entity\EntityStub;
+use Drupal\Driver\Entity\EntityStubInterface;
 use Drupal\DrupalExtension\Hook\Attribute\BeforeNodeCreate;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Behat\MinkExtension\Context\RawMinkContext;
@@ -67,18 +69,16 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   protected $userManager;
 
   /**
-   * Keep track of nodes so they can be cleaned up.
+   * Tracks every entity stub created during a scenario for cleanup.
    *
-   * @var array<int, \stdClass>
-   */
-  protected array $nodes = [];
-
-  /**
-   * Keep track of all terms that are created so they can easily be removed.
+   * Users are tracked separately via the user manager because they need
+   * lookup-by-name. Everything else (nodes, terms, languages, generic
+   * entities) lives here and is removed in reverse order so dependent
+   * entities come down before their dependencies.
    *
-   * @var array<int, \stdClass>
+   * @var array<int, \Drupal\Driver\Entity\EntityStubInterface>
    */
-  protected array $terms = [];
+  protected array $createdStubs = [];
 
   /**
    * Keep track of any roles that are created so they can easily be removed.
@@ -86,13 +86,6 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    * @var array<int, string>
    */
   protected array $roles = [];
-
-  /**
-   * Keep track of any languages that are created so they can easily be removed.
-   *
-   * @var array<int, \stdClass>
-   */
-  protected array $languages = [];
 
   /**
    * {@inheritdoc}
@@ -165,7 +158,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    */
   #[BeforeNodeCreate]
   public static function alterNodeParameters(BeforeNodeCreateScope $scope): void {
-    $node = $scope->getEntity();
+    $stub = $scope->getStub();
 
     // Convert string dates on timestamp fields when the in-process Drupal
     // driver is active. Blackbox and Drush drivers route around this entity
@@ -182,32 +175,58 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
     }
 
     foreach (['changed', 'created', 'revision_timestamp'] as $field) {
-      if (!empty($node->$field) && !is_numeric($node->$field)) {
-        $node->$field = strtotime((string) $node->$field);
+      $value = $stub->getValue($field);
+
+      if ($value !== NULL && $value !== '' && !is_numeric($value)) {
+        $stub->setValue($field, strtotime((string) $value));
       }
     }
   }
 
   /**
-   * Remove any created nodes.
+   * Remove every entity created during the scenario.
+   *
+   * Walks 'createdStubs' in reverse order so dependent entities (e.g. nodes
+   * referencing terms) come down before the entities they reference.
    */
   #[AfterScenario]
-  public function cleanNodes(): void {
-    if ($this->nodes === []) {
+  public function cleanEntities(): void {
+    if ($this->createdStubs === []) {
       return;
     }
 
     $driver = $this->getDriver();
 
+    foreach (array_reverse($this->createdStubs) as $stub) {
+      $this->deleteStub($stub, $driver);
+    }
+
+    $this->createdStubs = [];
+  }
+
+  /**
+   * Routes a stub to the right per-type driver delete method.
+   */
+  protected function deleteStub(EntityStubInterface $stub, object $driver): void {
+    $type = $stub->getEntityType();
+
+    if (in_array($type, ['language', 'configurable_language'], TRUE)) {
+      if ($driver instanceof LanguageCapabilityInterface) {
+        $driver->languageDelete($stub);
+      }
+
+      return;
+    }
+
     if (!$driver instanceof ContentCapabilityInterface) {
       return;
     }
 
-    foreach ($this->nodes as $node) {
-      $driver->nodeDelete($node);
-    }
-
-    $this->nodes = [];
+    match ($type) {
+      'node' => $driver->nodeDelete($stub),
+      'taxonomy_term' => $driver->termDelete($stub),
+      default => $driver->entityDelete($stub),
+    };
   }
 
   /**
@@ -252,28 +271,6 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   }
 
   /**
-   * Remove any created terms.
-   */
-  #[AfterScenario]
-  public function cleanTerms(): void {
-    if ($this->terms === []) {
-      return;
-    }
-
-    $driver = $this->getDriver();
-
-    if (!$driver instanceof ContentCapabilityInterface) {
-      return;
-    }
-
-    foreach (array_reverse($this->terms) as $term) {
-      $driver->termDelete($term);
-    }
-
-    $this->terms = [];
-  }
-
-  /**
    * Remove any created roles.
    */
   #[AfterScenario]
@@ -296,27 +293,6 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   }
 
   /**
-   * Remove any created languages.
-   */
-  #[AfterScenario]
-  public function cleanLanguages(): void {
-    if ($this->languages === []) {
-      return;
-    }
-
-    $driver = $this->getDriver();
-
-    if (!$driver instanceof LanguageCapabilityInterface) {
-      return;
-    }
-
-    foreach ($this->languages as $language) {
-      $driver->languageDelete($language);
-      unset($this->languages[$language->langcode]);
-    }
-  }
-
-  /**
    * Clear static caches.
    */
   #[AfterScenario('@api')]
@@ -333,11 +309,11 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    *
    * @param class-string<\Behat\Testwork\Hook\Scope\HookScope> $scopeClass
    *   The fully-qualified scope class name.
-   * @param \stdClass $entity
-   *   The entity.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The entity stub flowing through the create pipeline.
    */
-  protected function dispatchHooks(string $scopeClass, \stdClass $entity): void {
-    $scope = new $scopeClass($this->getDrupal()->getEnvironment(), $this, $entity);
+  protected function dispatchHooks(string $scopeClass, EntityStubInterface $stub): void {
+    $scope = new $scopeClass($this->getDrupal()->getEnvironment(), $this, $stub);
     $call_results = $this->dispatcher->dispatchScopeHooks($scope);
 
     // The dispatcher suppresses exceptions, throw them here if there are any.
@@ -352,32 +328,26 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   /**
    * Create a node.
    *
-   * @return \stdClass
-   *   The created node.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The node stub.
+   *
+   * @return \Drupal\Driver\Entity\EntityStubInterface
+   *   The same stub, now flagged as saved.
    */
-  public function nodeCreate(\stdClass $node): \stdClass {
-    $this->dispatchHooks(BeforeNodeCreateScope::class, $node);
-    $this->parseEntityFields('node', $node, ['author']);
+  public function nodeCreate(EntityStubInterface $stub): EntityStubInterface {
+    $this->dispatchHooks(BeforeNodeCreateScope::class, $stub);
+    $this->parseEntityFields($stub, ['author']);
 
-    $driver = $this->getDriver();
+    $driver = $this->getContentDriver();
 
-    if (!$driver instanceof ContentCapabilityInterface) {
-      throw new \RuntimeException(sprintf('The active Drupal driver "%s" does not support content creation.', $driver::class));
-    }
+    $scalars = $this->captureScalarBaseFields($stub);
+    $driver->nodeCreate($stub);
+    $this->restoreScalarBaseFields($stub, $scalars);
 
-    $scalars = $this->captureScalarBaseFields($node);
-    $saved = $driver->nodeCreate($node);
+    $this->dispatchHooks(AfterNodeCreateScope::class, $stub);
+    $this->createdStubs[] = $stub;
 
-    if (!$saved instanceof \stdClass) {
-      throw new \RuntimeException(sprintf('The Drupal driver "%s" returned a non-stdClass object from nodeCreate().', $driver::class));
-    }
-
-    $this->restoreScalarBaseFields($saved, $scalars);
-
-    $this->dispatchHooks(AfterNodeCreateScope::class, $saved);
-    $this->nodes[] = $saved;
-
-    return $saved;
+    return $stub;
   }
 
   /**
@@ -448,14 +418,12 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    *   ['uri' => '/contact', 'title' => 'Contact'],
    * ].
    *
-   * Blank values remove the field from the entity so Drupal applies its
+   * Blank values remove the field from the stub so Drupal applies its
    * default.
    *
-   * @param string $entity_type
-   *   The entity type (e.g. 'node', 'taxonomy_term', 'user').
-   * @param \stdClass $entity
-   *   The entity object. Recognised field properties are replaced in-place
-   *   with structured arrays; other properties are left unchanged.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The entity stub. Recognised field values are replaced in-place with
+   *   structured arrays; other values are left unchanged.
    * @param string[] $ignored_properties
    *   Property names to skip during validation. Use this for properties that
    *   are consumed by the driver (e.g. 'role', 'vocabulary_machine_name') but
@@ -466,29 +434,34 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    *   preceding 'field:column' header, or when a property is neither a
    *   configurable field, a base field, nor in the ignored list.
    */
-  public function parseEntityFields(string $entity_type, \stdClass $entity, array $ignored_properties = []): void {
+  public function parseEntityFields(EntityStubInterface $stub, array $ignored_properties = []): void {
     $driver = $this->getDriver();
 
     if (!$driver instanceof DrupalDriver) {
       throw new \RuntimeException(sprintf('The active Drupal driver "%s" does not support field inspection.', $driver::class));
     }
 
+    $entity_type = $stub->getEntityType();
     $classifier = $driver->getCore()->classifier();
 
     $multicolumn_field = '';
     $multicolumn_column = '';
     $multicolumn_fields = [];
+    $values = $stub->getValues();
+    $parsed = [];
 
-    foreach ((array) (clone $entity) as $field => $field_value) {
+    foreach ($values as $field => $field_value) {
+      $field = (string) $field;
+
       // Reset the multicolumn field if the field name does not have a column.
-      if (!str_contains((string) $field, ':')) {
+      if (!str_contains($field, ':')) {
         $multicolumn_field = '';
         $multicolumn_column = '';
       }
-      elseif (str_contains(substr((string) $field, 1), ':')) {
+      elseif (str_contains(substr($field, 1), ':')) {
         // Start tracking a new multicolumn field if the field name contains a
         // ':' which is preceded by at least 1 character.
-        [$multicolumn_field, $multicolumn_column] = explode(':', (string) $field);
+        [$multicolumn_field, $multicolumn_column] = explode(':', $field);
       }
       elseif (empty($multicolumn_field)) {
         // If a field name starts with a ':' but we are not yet tracking a
@@ -498,14 +471,16 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
       else {
         // Update the column name if the field name starts with a ':' and we are
         // already tracking a multicolumn field.
-        $multicolumn_column = substr((string) $field, 1);
+        $multicolumn_column = substr($field, 1);
       }
 
-      $is_multicolumn = $multicolumn_field && $multicolumn_column;
-      $field_name = $multicolumn_field ?: $field;
+      $is_multicolumn = $multicolumn_field !== '' && $multicolumn_column !== '';
+      $field_name = $multicolumn_field !== '' ? $multicolumn_field : $field;
+
       if ($classifier->fieldIsConfigurable($entity_type, $field_name)) {
         // Split up multiple values in multi-value fields.
-        $values = [];
+        $parsed_values = [];
+
         foreach (str_getcsv((string) $field_value, escape: "\\") as $key => $value) {
           $value = trim((string) $value);
           $columns = $value;
@@ -515,8 +490,10 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
           // through as-is (e.g., entity reference titles with dashes).
           // @see https://github.com/jhedstrom/drupalextension/issues/642
           $was_quoted = str_contains((string) $field_value, '"' . $value . '"');
+
           if (!$was_quoted && str_contains($value, ' - ')) {
             $columns = [];
+
             foreach (explode(' - ', $value) as $column) {
               // Check if it is an inline named column.
               if (!$is_multicolumn && str_contains(substr($column, 1), ': ')) {
@@ -532,19 +509,20 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
           // Use the column name if we are tracking a multicolumn field.
           if ($is_multicolumn) {
             $multicolumn_fields[$multicolumn_field][$key][$multicolumn_column] = $columns;
-            unset($entity->$field);
           }
           else {
-            $values[] = $columns;
+            $parsed_values[] = $columns;
           }
         }
 
-        // Replace regular fields inline in the entity after parsing.
+        // Replace regular fields inline in the stub after parsing.
         if (!$is_multicolumn) {
-          $entity->$field_name = $values;
           // Don't specify any value if the step author has left it blank.
-          if ($field_value === '') {
-            unset($entity->$field_name);
+          if ($field_value === '' || $field_value === NULL) {
+            unset($parsed[$field_name]);
+          }
+          else {
+            $parsed[$field_name] = $parsed_values;
           }
         }
       }
@@ -563,26 +541,32 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
         if (!$is_base_field && !in_array($field_name, $ignored_properties, TRUE)) {
           throw new \RuntimeException(sprintf('Field "%s" does not exist on entity type "%s".', $field_name, $entity_type));
         }
+
+        $parsed[$field] = $field_value;
       }
     }
 
-    // Add the multicolumn fields to the entity. Each entry in
-    // 'multicolumn_fields' is only set when there is at least one non-blank
-    // cell (see the population logic above).
+    // Add the multicolumn fields. Each entry in 'multicolumn_fields' is only
+    // set when there is at least one non-blank cell.
     foreach ($multicolumn_fields as $field_name => $columns) {
-      $entity->$field_name = $columns;
+      $parsed[$field_name] = $columns;
     }
+
+    $stub->setValues($parsed);
   }
 
   /**
    * Create a user.
    *
-   * @return \stdClass
-   *   The created user.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The user stub.
+   *
+   * @return \Drupal\Driver\Entity\EntityStubInterface
+   *   The same stub, now flagged as saved.
    */
-  public function userCreate(\stdClass $user): \stdClass {
-    $this->dispatchHooks(BeforeUserCreateScope::class, $user);
-    $this->parseEntityFields('user', $user, ['role']);
+  public function userCreate(EntityStubInterface $stub): EntityStubInterface {
+    $this->dispatchHooks(BeforeUserCreateScope::class, $stub);
+    $this->parseEntityFields($stub, ['role']);
 
     $driver = $this->getDriver();
 
@@ -590,31 +574,36 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
       throw new \RuntimeException(sprintf('The active Drupal driver "%s" does not support user creation.', $driver::class));
     }
 
-    $scalars = $this->captureScalarBaseFields($user);
-    $driver->userCreate($user);
-    $this->restoreScalarBaseFields($user, $scalars);
+    $scalars = $this->captureScalarBaseFields($stub);
+    $driver->userCreate($stub);
+    $this->restoreScalarBaseFields($stub, $scalars);
 
-    $this->dispatchHooks(AfterUserCreateScope::class, $user);
-    $this->userManager->addUser($user);
+    $this->dispatchHooks(AfterUserCreateScope::class, $stub);
+    $this->userManager->addUser($stub);
 
-    return $user;
+    return $stub;
   }
 
   /**
    * Create a term.
    *
-   * @return \stdClass
-   *   The created term.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The term stub.
+   *
+   * @return \Drupal\Driver\Entity\EntityStubInterface
+   *   The same stub, now flagged as saved.
    */
-  public function termCreate(\stdClass $term): \stdClass {
+  public function termCreate(EntityStubInterface $stub): EntityStubInterface {
     // The 3.x DrupalDriver only loads vocabularies by machine name. Allow
     // the Gherkin author to pass either the machine name or the human
     // label by resolving the label to a machine name when the literal
     // string does not match a vocabulary id. Resolution is best-effort -
     // the driver throws a clearer error than we could when the lookup
     // ultimately fails.
-    if (!empty($term->vocabulary_machine_name)) {
-      $term->vocabulary_machine_name = $this->resolveVocabularyMachineName($term->vocabulary_machine_name);
+    $vocabulary = $stub->getValue('vocabulary_machine_name');
+
+    if (!empty($vocabulary)) {
+      $stub->setValue('vocabulary_machine_name', $this->resolveVocabularyMachineName((string) $vocabulary));
     }
 
     // The 3.x DrupalDriver resolves a 'parent' property as a term name
@@ -622,32 +611,23 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
     // pass the name through unchanged. An empty 'parent' must be removed
     // so the field-handler pipeline does not try to expand the empty
     // string as an entity reference.
-    if (empty($term->parent)) {
-      unset($term->parent);
+    if ($stub->hasValue('parent') && empty($stub->getValue('parent'))) {
+      $stub->removeValue('parent');
     }
 
-    $this->dispatchHooks(BeforeTermCreateScope::class, $term);
-    $this->parseEntityFields('taxonomy_term', $term, ['vocabulary_machine_name']);
+    $this->dispatchHooks(BeforeTermCreateScope::class, $stub);
+    $this->parseEntityFields($stub, ['vocabulary_machine_name']);
 
-    $driver = $this->getDriver();
+    $driver = $this->getContentDriver();
 
-    if (!$driver instanceof ContentCapabilityInterface) {
-      throw new \RuntimeException(sprintf('The active Drupal driver "%s" does not support term creation.', $driver::class));
-    }
+    $scalars = $this->captureScalarBaseFields($stub);
+    $driver->termCreate($stub);
+    $this->restoreScalarBaseFields($stub, $scalars);
 
-    $scalars = $this->captureScalarBaseFields($term);
-    $saved = $driver->termCreate($term);
+    $this->dispatchHooks(AfterTermCreateScope::class, $stub);
+    $this->createdStubs[] = $stub;
 
-    if (!$saved instanceof \stdClass) {
-      throw new \RuntimeException(sprintf('The Drupal driver "%s" returned a non-stdClass object from termCreate().', $driver::class));
-    }
-
-    $this->restoreScalarBaseFields($saved, $scalars);
-
-    $this->dispatchHooks(AfterTermCreateScope::class, $saved);
-    $this->terms[] = $saved;
-
-    return $saved;
+    return $stub;
   }
 
   /**
@@ -673,36 +653,36 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   }
 
   /**
-   * Captures scalar properties on an entity stub.
+   * Captures scalar values on an entity stub.
    *
    * The 3.x DrupalDriver runs base fields through the field-handler
-   * pipeline during create, which casts scalar properties such as
-   * 'title', 'name', 'mail' or 'pass' to single-element arrays. Most
-   * drupalextension downstream code (user manager indexing, login flow,
-   * stub matching) expects scalars, so callers snapshot the scalars
-   * before the driver call and restore them after.
+   * pipeline during create, which casts scalar values such as 'title',
+   * 'name', 'mail' or 'pass' to single-element arrays. Most drupalextension
+   * downstream code (user manager indexing, login flow, stub matching)
+   * expects scalars, so callers snapshot the scalars before the driver
+   * call and restore them after.
    *
-   * @param object $entity
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
    *   The entity stub to inspect.
    *
    * @return array<string, scalar>
-   *   The scalar properties keyed by name.
+   *   The scalar values keyed by name.
    */
-  protected function captureScalarBaseFields(object $entity): array {
-    return array_filter((array) $entity, is_scalar(...));
+  protected function captureScalarBaseFields(EntityStubInterface $stub): array {
+    return array_filter($stub->getValues(), is_scalar(...));
   }
 
   /**
-   * Restores scalar properties previously captured.
+   * Restores scalar values previously captured.
    *
-   * @param object $entity
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
    *   The entity stub to mutate.
    * @param array<string, scalar> $scalars
-   *   Map of property name to original scalar value.
+   *   Map of value name to original scalar value.
    */
-  protected function restoreScalarBaseFields(object $entity, array $scalars): void {
+  protected function restoreScalarBaseFields(EntityStubInterface $stub, array $scalars): void {
     foreach ($scalars as $field => $value) {
-      $entity->$field = $value;
+      $stub->setValue($field, $value);
     }
   }
 
@@ -714,13 +694,17 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    * @param string $vocabulary
    *   The vocabulary machine name.
    *
-   * @return \stdClass|null
-   *   The term object or NULL if no matching term was found.
+   * @return \Drupal\Driver\Entity\EntityStubInterface|null
+   *   The term stub or NULL if no matching term was found.
    */
-  protected function getExistingTerm(string $name, string $vocabulary): ?\stdClass {
-    foreach ($this->terms as $term) {
-      if ($term->name === $name && $term->vocabulary_machine_name === $vocabulary) {
-        return $term;
+  protected function getExistingTerm(string $name, string $vocabulary): ?EntityStubInterface {
+    foreach ($this->createdStubs as $stub) {
+      if ($stub->getEntityType() !== 'taxonomy_term') {
+        continue;
+      }
+
+      if ($stub->getValue('name') === $name && $stub->getValue('vocabulary_machine_name') === $vocabulary) {
+        return $stub;
       }
     }
 
@@ -730,15 +714,15 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   /**
    * Creates a language.
    *
-   * @param \stdClass $language
-   *   An object with the following properties:
-   *   - langcode: the langcode of the language to create.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   Language stub. Must carry a 'langcode' value.
    *
-   * @return \stdClass|false
-   *   The created language, or FALSE if the language was already created.
+   * @return \Drupal\Driver\Entity\EntityStubInterface|false
+   *   The created language stub, or FALSE if the language was already
+   *   created.
    */
-  public function languageCreate(\stdClass $language): \stdClass|false {
-    $this->dispatchHooks(BeforeLanguageCreateScope::class, $language);
+  public function languageCreate(EntityStubInterface $stub): EntityStubInterface|false {
+    $this->dispatchHooks(BeforeLanguageCreateScope::class, $stub);
 
     $driver = $this->getDriver();
 
@@ -746,23 +730,25 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
       throw new \RuntimeException(sprintf('The active Drupal driver "%s" does not support language management.', $driver::class));
     }
 
-    $language = $driver->languageCreate($language);
+    $result = $driver->languageCreate($stub);
 
-    if ($language) {
-      $this->dispatchHooks(AfterLanguageCreateScope::class, $language);
-      $this->languages[$language->langcode] = $language;
+    if ($result === FALSE) {
+      return FALSE;
     }
 
-    return $language;
+    $this->dispatchHooks(AfterLanguageCreateScope::class, $result);
+    $this->createdStubs[] = $result;
+
+    return $result;
   }
 
   /**
    * Log-in the given user.
    *
-   * @param \stdClass $user
-   *   The user to log in.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $user
+   *   The user stub to log in.
    */
-  public function login(\stdClass $user): void {
+  public function login(EntityStubInterface $user): void {
     $this->getAuthenticationManager()->logIn($user);
   }
 
@@ -789,6 +775,23 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    */
   public function loggedIn() {
     return $this->getAuthenticationManager()->loggedIn();
+  }
+
+  /**
+   * Resolves the active driver as a content-capable instance.
+   *
+   * @throws \RuntimeException
+   *   When the active driver does not implement
+   *   'ContentCapabilityInterface'.
+   */
+  protected function getContentDriver(): ContentCapabilityInterface {
+    $driver = $this->getDriver();
+
+    if (!$driver instanceof ContentCapabilityInterface) {
+      throw new \RuntimeException(sprintf('The active Drupal driver "%s" does not support content creation.', $driver::class));
+    }
+
+    return $driver;
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Hook/Scope/BaseEntityScope.php
+++ b/src/Drupal/DrupalExtension/Hook/Scope/BaseEntityScope.php
@@ -10,6 +10,7 @@ namespace Drupal\DrupalExtension\Hook\Scope;
 
 use Behat\Behat\Context\Context;
 use Behat\Testwork\Environment\Environment;
+use Drupal\Driver\Entity\EntityStubInterface;
 
 /**
  * Represents an Entity hook scope.
@@ -26,9 +27,9 @@ abstract class BaseEntityScope implements EntityScope {
      */
     private readonly Context $context,
     /**
-     * Entity object.
+     * Entity stub.
      */
-    private readonly \stdClass $entity,
+    private readonly EntityStubInterface $stub,
   ) {
   }
 
@@ -43,10 +44,10 @@ abstract class BaseEntityScope implements EntityScope {
   }
 
   /**
-   * Returns the entity object.
+   * {@inheritdoc}
    */
-  public function getEntity(): \stdClass {
-    return $this->entity;
+  public function getStub(): EntityStubInterface {
+    return $this->stub;
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Hook/Scope/BaseEntityScope.php
+++ b/src/Drupal/DrupalExtension/Hook/Scope/BaseEntityScope.php
@@ -29,7 +29,7 @@ abstract class BaseEntityScope implements EntityScope {
     /**
      * Entity stub.
      */
-    private readonly EntityStubInterface $stub,
+    private readonly EntityStubInterface $entityStub,
   ) {
   }
 
@@ -47,7 +47,7 @@ abstract class BaseEntityScope implements EntityScope {
    * {@inheritdoc}
    */
   public function getStub(): EntityStubInterface {
-    return $this->stub;
+    return $this->entityStub;
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Hook/Scope/EntityScope.php
+++ b/src/Drupal/DrupalExtension/Hook/Scope/EntityScope.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Drupal\DrupalExtension\Hook\Scope;
 
 use Behat\Testwork\Hook\Scope\HookScope;
+use Drupal\Driver\Entity\EntityStubInterface;
 
 /**
  * Represents an Entity hook scope.
@@ -28,11 +29,11 @@ interface EntityScope extends HookScope {
   public function getContext();
 
   /**
-   * Returns scope entity.
+   * Returns the entity stub.
    *
-   * @return \stdClass
-   *   The entity object.
+   * @return \Drupal\Driver\Entity\EntityStubInterface
+   *   The entity stub flowing through the create hooks.
    */
-  public function getEntity();
+  public function getStub(): EntityStubInterface;
 
 }

--- a/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
@@ -11,6 +11,7 @@ use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Mink;
 use Drupal\Driver\Capability\AuthenticationCapabilityInterface;
+use Drupal\Driver\Entity\EntityStubInterface;
 use Drupal\DrupalDriverManagerInterface;
 use Drupal\DrupalExtension\DrupalParametersTrait;
 use Drupal\DrupalExtension\MinkAwareTrait;
@@ -52,7 +53,7 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
   /**
    * {@inheritdoc}
    */
-  public function logIn(\stdClass $user): void {
+  public function logIn(EntityStubInterface $user): void {
     // Log out any existing user before logging in a new user.
     $this->fastLogout();
 
@@ -62,10 +63,13 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
     $login_url = $this->locatePath($this->getDrupalText('login_url'));
     $session->visit($login_url);
 
+    $name = (string) $user->getValue('name');
+    $pass = (string) $user->getValue('pass');
+
     // Fill in the login form credentials.
     $page = $session->getPage();
-    $page->fillField($this->getDrupalText('username_field'), $user->name);
-    $page->fillField($this->getDrupalText('password_field'), $user->pass);
+    $page->fillField($this->getDrupalText('username_field'), $name);
+    $page->fillField($this->getDrupalText('password_field'), $pass);
 
     // Submit the login form.
     $login_element = $this->getLoginElement($page);
@@ -98,7 +102,8 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
 
     // Verify the login was successful.
     if (!$this->loggedIn()) {
-      $message = isset($user->role) ? sprintf("Unable to determine if logged in because '%s' ('log_out') link cannot be found for user '%s' with role '%s'", $this->getDrupalText('log_out'), $user->name, $user->role) : sprintf("Unable to determine if logged in because '%s' ('log_out') link cannot be found for user '%s'", $this->getDrupalText('log_out'), $user->name);
+      $role = $user->getValue('role');
+      $message = $role !== NULL ? sprintf("Unable to determine if logged in because '%s' ('log_out') link cannot be found for user '%s' with role '%s'", $this->getDrupalText('log_out'), $name, $role) : sprintf("Unable to determine if logged in because '%s' ('log_out') link cannot be found for user '%s'", $this->getDrupalText('log_out'), $name);
       throw new ExpectationException($message, $session->getDriver());
     }
 
@@ -239,7 +244,7 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
   /**
    * Log in on the backend driver if it supports authentication.
    */
-  protected function backendLogin(\stdClass $user): void {
+  protected function backendLogin(EntityStubInterface $user): void {
     $driver = $this->driverManager->getDriver();
     if ($driver instanceof AuthenticationCapabilityInterface) {
       $driver->login($user);

--- a/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManagerInterface.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManagerInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Manager;
 
+use Drupal\Driver\Entity\EntityStubInterface;
+
 /**
  * Interface for classes that authenticate users during tests.
  */
@@ -12,10 +14,10 @@ interface DrupalAuthenticationManagerInterface {
   /**
    * Logs in as the given user.
    *
-   * @param \stdClass $user
-   *   The user to log in.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $user
+   *   The user stub to log in.
    */
-  public function logIn(\stdClass $user): void;
+  public function logIn(EntityStubInterface $user): void;
 
   /**
    * Logs the current user out.

--- a/src/Drupal/DrupalExtension/Manager/DrupalUserManager.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalUserManager.php
@@ -4,42 +4,45 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Manager;
 
+use Drupal\Driver\Entity\EntityStubInterface;
+
 /**
  * Default implementation of the Drupal user manager service.
  */
 class DrupalUserManager implements DrupalUserManagerInterface {
 
   /**
-   * The user object representing the currently logged in user.
+   * The user stub representing the currently logged in user.
    */
-  protected \stdClass|bool $user = FALSE;
+  protected EntityStubInterface|false $user = FALSE;
 
   /**
-   * An array of user objects representing users created during the test.
+   * An array of user stubs representing users created during the test.
    *
-   * @var \stdClass[]
+   * @var array<string, \Drupal\Driver\Entity\EntityStubInterface>
    */
   protected array $users = [];
 
   /**
    * {@inheritdoc}
    */
-  public function getCurrentUser(): \stdClass|bool {
+  public function getCurrentUser(): EntityStubInterface|false {
     return $this->user;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function setCurrentUser(\stdClass|bool $user): void {
+  public function setCurrentUser(EntityStubInterface|false $user): void {
     $this->user = $user;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function addUser(\stdClass $user): void {
-    $this->users[$user->name] = $user;
+  public function addUser(EntityStubInterface $user): void {
+    $name = (string) $user->getValue('name');
+    $this->users[$name] = $user;
   }
 
   /**
@@ -52,10 +55,11 @@ class DrupalUserManager implements DrupalUserManagerInterface {
   /**
    * {@inheritdoc}
    */
-  public function getUser(string $userName) {
+  public function getUser(string $userName): EntityStubInterface {
     if (!isset($this->users[$userName])) {
       throw new \InvalidArgumentException(sprintf('No user with %s name is registered with the driver.', $userName));
     }
+
     return $this->users[$userName];
   }
 
@@ -85,14 +89,20 @@ class DrupalUserManager implements DrupalUserManagerInterface {
    * {@inheritdoc}
    */
   public function currentUserIsAnonymous(): bool {
-    return empty($this->user);
+    return $this->user === FALSE;
   }
 
   /**
    * {@inheritdoc}
    */
   public function currentUserHasRole(string $role): bool {
-    return !$this->currentUserIsAnonymous() && !empty($this->user->role) && $this->user->role == $role;
+    if (!$this->user instanceof EntityStubInterface) {
+      return FALSE;
+    }
+
+    $current_role = $this->user->getValue('role');
+
+    return $current_role !== NULL && $current_role === $role;
   }
 
 }

--- a/src/Drupal/DrupalExtension/Manager/DrupalUserManagerInterface.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalUserManagerInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Manager;
 
+use Drupal\Driver\Entity\EntityStubInterface;
+
 /**
  * Interface for classes that manage users created during tests.
  */
@@ -12,18 +14,18 @@ interface DrupalUserManagerInterface {
   /**
    * Returns the currently logged in user.
    *
-   * @return \stdClass|bool
-   *   The user object, or FALSE if the user is anonymous.
+   * @return \Drupal\Driver\Entity\EntityStubInterface|false
+   *   The user stub, or FALSE if the user is anonymous.
    */
-  public function getCurrentUser();
+  public function getCurrentUser(): EntityStubInterface|false;
 
   /**
    * Sets the currently logged in user.
    *
-   * @param \stdClass|bool $user
-   *   The user object, or FALSE if the user has been logged out.
+   * @param \Drupal\Driver\Entity\EntityStubInterface|false $user
+   *   The user stub, or FALSE if the user has been logged out.
    */
-  public function setCurrentUser(\stdClass|bool $user): void;
+  public function setCurrentUser(EntityStubInterface|false $user): void;
 
   /**
    * Adds a new user.
@@ -32,12 +34,12 @@ interface DrupalUserManagerInterface {
    * created in a test scenario. They can then be cleaned up after completing
    * the test.
    *
-   * @param \stdClass $user
-   *   The user object.
+   * @param \Drupal\Driver\Entity\EntityStubInterface $user
+   *   The user stub.
    *
    * @see \Drupal\DrupalExtension\Context\RawDrupalContext::cleanUsers()
    */
-  public function addUser(\stdClass $user): void;
+  public function addUser(EntityStubInterface $user): void;
 
   /**
    * Removes a user from the list of users that were created in the test.
@@ -50,10 +52,10 @@ interface DrupalUserManagerInterface {
   /**
    * Returns the list of users that were created in the test.
    *
-   * @return \stdClass[]
-   *   An array of user objects.
+   * @return array<string, \Drupal\Driver\Entity\EntityStubInterface>
+   *   An array of user stubs keyed by user name.
    */
-  public function getUsers();
+  public function getUsers(): array;
 
   /**
    * Returns the user with the given user name.
@@ -61,13 +63,13 @@ interface DrupalUserManagerInterface {
    * @param string $userName
    *   The name of the user to return.
    *
-   * @return \stdClass
-   *   The user object.
+   * @return \Drupal\Driver\Entity\EntityStubInterface
+   *   The user stub.
    *
    * @throws \InvalidArgumentException
    *   Thrown when the user with the given name does not exist.
    */
-  public function getUser(string $userName);
+  public function getUser(string $userName): EntityStubInterface;
 
   /**
    * Clears the list of users that were created in the test.
@@ -80,7 +82,7 @@ interface DrupalUserManagerInterface {
    * @return bool
    *   TRUE if any users are tracked, FALSE if not.
    */
-  public function hasUsers();
+  public function hasUsers(): bool;
 
   /**
    * Returns whether the current user is anonymous.
@@ -88,7 +90,7 @@ interface DrupalUserManagerInterface {
    * @return bool
    *   TRUE if the current user is anonymous.
    */
-  public function currentUserIsAnonymous();
+  public function currentUserIsAnonymous(): bool;
 
   /**
    * Checks if the current user has the given role(s)
@@ -99,6 +101,6 @@ interface DrupalUserManagerInterface {
    * @return bool
    *   Returns TRUE if the currently logged in user has this role (or roles).
    */
-  public function currentUserHasRole(string $role);
+  public function currentUserHasRole(string $role): bool;
 
 }

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -22,6 +22,8 @@ use Behat\Mink\Exception\ExpectationException;
 use Drupal\Core\Database\Database;
 use Drupal\Driver\Core\Field\AbstractHandler;
 use Drupal\Driver\DrupalDriver;
+use Drupal\Driver\Entity\EntityStub;
+use Drupal\Driver\Entity\EntityStubInterface;
 use Drupal\DrupalExtension\Hook\Attribute\AfterNodeCreate;
 use Drupal\DrupalExtension\Hook\Attribute\AfterTermCreate;
 use Drupal\DrupalExtension\Hook\Attribute\AfterUserCreate;
@@ -129,10 +131,11 @@ class FeatureContext extends RawDrupalContext {
     parent::alterNodeParameters($scope);
     // @see `tests/behat/features/api.feature`
     // Change 'published on' to the expected 'created'.
-    $node = $scope->getEntity();
-    if (isset($node->{"published on"})) {
-      $node->created = $node->{"published on"};
-      unset($node->{"published on"});
+    $stub = $scope->getStub();
+
+    if ($stub->hasValue('published on')) {
+      $stub->setValue('created', $stub->getValue('published on'));
+      $stub->removeValue('published on');
     }
   }
 
@@ -143,10 +146,11 @@ class FeatureContext extends RawDrupalContext {
   public static function testAlterTermParameters(EntityScope $scope): void {
     // @see `tests/behat/features/api.feature`
     // Change 'Label' to expected 'name'.
-    $term = $scope->getEntity();
-    if (isset($term->{'Label'})) {
-      $term->name = $term->{'Label'};
-      unset($term->{'Label'});
+    $stub = $scope->getStub();
+
+    if ($stub->hasValue('Label')) {
+      $stub->setValue('name', $stub->getValue('Label'));
+      $stub->removeValue('Label');
     }
   }
 
@@ -157,17 +161,18 @@ class FeatureContext extends RawDrupalContext {
   public static function testAlterUserParameters(EntityScope $scope): void {
     // @see `tests/behat/features/api.feature`
     // Concatenate 'First name' and 'Last name' to form user name.
-    $user = $scope->getEntity();
+    $stub = $scope->getStub();
 
-    if (isset($user->{"First name"}) && isset($user->{"Last name"})) {
-      $user->name = $user->{"First name"} . ' ' . $user->{"Last name"};
-      unset($user->{"First name"}, $user->{"Last name"});
+    if ($stub->hasValue('First name') && $stub->hasValue('Last name')) {
+      $stub->setValue('name', $stub->getValue('First name') . ' ' . $stub->getValue('Last name'));
+      $stub->removeValue('First name');
+      $stub->removeValue('Last name');
     }
 
     // Transform custom 'E-mail' to 'mail'.
-    if (isset($user->{"E-mail"})) {
-      $user->mail = $user->{"E-mail"};
-      unset($user->{"E-mail"});
+    if ($stub->hasValue('E-mail')) {
+      $stub->setValue('mail', $stub->getValue('E-mail'));
+      $stub->removeValue('E-mail');
     }
   }
 
@@ -176,8 +181,7 @@ class FeatureContext extends RawDrupalContext {
    */
   #[AfterNodeCreate]
   public static function testAfterNodeCreate(EntityScope $scope): void {
-    $node = $scope->getEntity();
-    if (empty((array) $node)) {
+    if ($scope->getStub()->getValues() === []) {
       throw new \Exception('Failed to find a node in @afterNodeCreate hook.');
     }
   }
@@ -187,8 +191,7 @@ class FeatureContext extends RawDrupalContext {
    */
   #[AfterTermCreate]
   public static function testAfterTermCreate(EntityScope $scope): void {
-    $term = $scope->getEntity();
-    if (empty((array) $term)) {
+    if ($scope->getStub()->getValues() === []) {
       throw new \Exception('Failed to find a term in @afterTermCreate hook.');
     }
   }
@@ -198,8 +201,7 @@ class FeatureContext extends RawDrupalContext {
    */
   #[AfterUserCreate]
   public static function testAfterUserCreate(EntityScope $scope): void {
-    $user = $scope->getEntity();
-    if (empty((array) $user)) {
+    if ($scope->getStub()->getValues() === []) {
       throw new \Exception('Failed to find a user in @afterUserCreate hook.');
     }
   }
@@ -286,12 +288,12 @@ class FeatureContext extends RawDrupalContext {
    */
   #[Given('I am logged in as a user with name :name and password :password')]
   public function testAssertAuthenticatedByUsernameAndPassword(string $name, string $password): void {
-    $user = (object) [
+    $stub = new EntityStub('user', NULL, [
       'name' => $name,
       'pass' => $password,
-    ];
-    $this->userCreate($user);
-    $this->login($user);
+    ]);
+    $this->userCreate($stub);
+    $this->login($stub);
   }
 
   /**
@@ -300,10 +302,11 @@ class FeatureContext extends RawDrupalContext {
   #[Then('I should be logged in on the backend')]
   public function testAssertBackendLogin(): void {
     $user = $this->getUserManager()->getCurrentUser();
-    if (!$user instanceof \stdClass) {
+    if (!$user instanceof EntityStubInterface) {
       throw new \LogicException('No current user in the user manager.');
     }
-    if (!$account = \Drupal::entityTypeManager()->getStorage('user')->load($user->uid)) {
+    $uid = $user->getValue('uid') ?? $user->getId();
+    if (!$account = \Drupal::entityTypeManager()->getStorage('user')->load($uid)) {
       throw new \LogicException('No user found in the system.');
     }
     if (!$account->id()) {
@@ -386,10 +389,10 @@ class FeatureContext extends RawDrupalContext {
   #[Given('I remember the current user name')]
   public function testRememberCurrentUserName(): void {
     $user = $this->getUserManager()->getCurrentUser();
-    if (!$user instanceof \stdClass) {
+    if (!$user instanceof EntityStubInterface) {
       throw new \LogicException('No current user in the user manager.');
     }
-    $this->previousUserName = $user->name;
+    $this->previousUserName = (string) $user->getValue('name');
   }
 
   /**
@@ -398,12 +401,13 @@ class FeatureContext extends RawDrupalContext {
   #[Then('the current user should be different from the remembered user')]
   public function testAssertDifferentUser(): void {
     $user = $this->getUserManager()->getCurrentUser();
-    if (!$user instanceof \stdClass) {
+    if (!$user instanceof EntityStubInterface) {
       throw new \LogicException('No current user in the user manager.');
     }
-    if ($user->name === $this->previousUserName) {
+    $name = (string) $user->getValue('name');
+    if ($name === $this->previousUserName) {
       throw new ExpectationException(
-        sprintf('Expected a different user but got the same user "%s".', $user->name),
+        sprintf('Expected a different user but got the same user "%s".', $name),
         $this->getSession()->getDriver()
       );
     }
@@ -569,12 +573,18 @@ class FeatureContext extends RawDrupalContext {
   public function testDeleteCurrentUserFromDatabase(): void {
     $user = $this->getUserManager()->getCurrentUser();
 
-    if (!$user || empty($user->uid)) {
+    if (!$user instanceof EntityStubInterface) {
+      throw new \RuntimeException('No current user to delete.');
+    }
+
+    $uid = $user->getValue('uid') ?? $user->getId();
+
+    if (empty($uid)) {
       throw new \RuntimeException('No current user to delete.');
     }
 
     // Delete the user entity from the database.
-    $account = \Drupal::entityTypeManager()->getStorage('user')->load($user->uid);
+    $account = \Drupal::entityTypeManager()->getStorage('user')->load($uid);
 
     if ($account) {
       $account->delete();
@@ -583,7 +593,7 @@ class FeatureContext extends RawDrupalContext {
     // Remove the user from the tracked list so cleanUsers() won't attempt
     // to delete it again (which would trigger a PHP warning). The current
     // user reference is intentionally left set to simulate stale auth state.
-    $this->getUserManager()->removeUser($user->name);
+    $this->getUserManager()->removeUser((string) $user->getValue('name'));
   }
 
   /**

--- a/tests/phpunit/src/DrupalAuthenticationManagerTest.php
+++ b/tests/phpunit/src/DrupalAuthenticationManagerTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Drupal\DrupalExtension\Tests;
 
 use Drupal\Driver\DriverInterface;
+use Drupal\Driver\Entity\EntityStub;
+use Drupal\Driver\Entity\EntityStubInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use Behat\Mink\Driver\DriverInterface as MinkDriverInterface;
 use Behat\Mink\Element\DocumentElement;
@@ -77,7 +79,7 @@ class DrupalAuthenticationManagerTest extends TestCase {
     $driver_manager = $this->createDriverManagerMock();
     $manager = $this->createManager($session, $user_manager, $driver_manager);
 
-    $user = (object) ['name' => 'admin', 'pass' => 'password'];
+    $user = new EntityStub('user', NULL, ['name' => 'admin', 'pass' => 'password']);
     $manager->logIn($user);
     $this->assertSame($user, $user_manager->getCurrentUser());
   }
@@ -99,14 +101,14 @@ class DrupalAuthenticationManagerTest extends TestCase {
 
     $this->expectException(\Exception::class);
     $this->expectExceptionMessage('Submit button matching css "login form" not found.');
-    $manager->logIn((object) ['name' => 'admin', 'pass' => 'pass']);
+    $manager->logIn(new EntityStub('user', NULL, ['name' => 'admin', 'pass' => 'pass']));
   }
 
   /**
    * Tests that logIn() throws when the user is not actually logged in.
    */
   #[DataProvider('dataProviderLogInThrowsWhenNotLoggedIn')]
-  public function testLogInThrowsWhenNotLoggedIn(\stdClass $user, string $expected_message): void {
+  public function testLogInThrowsWhenNotLoggedIn(EntityStubInterface $user, string $expected_message): void {
     $submit = $this->createMock(NodeElement::class);
 
     $page = $this->createMock(DocumentElement::class);
@@ -130,11 +132,11 @@ class DrupalAuthenticationManagerTest extends TestCase {
    */
   public static function dataProviderLogInThrowsWhenNotLoggedIn(): \Iterator {
     yield 'user without role' => [
-      (object) ['name' => 'admin', 'pass' => 'pass'],
+      new EntityStub('user', NULL, ['name' => 'admin', 'pass' => 'pass']),
       "Unable to determine if logged in because 'Log out' ('log_out') link cannot be found for user 'admin'",
     ];
     yield 'user with role' => [
-      (object) ['name' => 'admin', 'pass' => 'pass', 'role' => 'administrator'],
+      new EntityStub('user', NULL, ['name' => 'admin', 'pass' => 'pass', 'role' => 'administrator']),
       "Unable to determine if logged in because 'Log out' ('log_out') link cannot be found for user 'admin' with role 'administrator'",
     ];
   }
@@ -160,7 +162,7 @@ class DrupalAuthenticationManagerTest extends TestCase {
     $driver_manager->method('getDriver')->willReturn($auth_driver);
 
     $manager = $this->createManager($session, NULL, $driver_manager);
-    $manager->logIn((object) ['name' => 'admin', 'pass' => 'pass']);
+    $manager->logIn(new EntityStub('user', NULL, ['name' => 'admin', 'pass' => 'pass']));
   }
 
   /**
@@ -176,7 +178,7 @@ class DrupalAuthenticationManagerTest extends TestCase {
     $session->method('getCurrentUrl')->willReturn('http://localhost/user/logout');
 
     $user_manager = new DrupalUserManager();
-    $user_manager->setCurrentUser((object) ['name' => 'admin']);
+    $user_manager->setCurrentUser(new EntityStub('user', NULL, ['name' => 'admin']));
 
     $driver_manager = $this->createDriverManagerMock();
     $manager = $this->createManager($session, $user_manager, $driver_manager);
@@ -326,7 +328,7 @@ class DrupalAuthenticationManagerTest extends TestCase {
     $mink->setDefaultSessionName('default');
 
     $user_manager = new DrupalUserManager();
-    $user_manager->setCurrentUser((object) ['name' => 'admin']);
+    $user_manager->setCurrentUser(new EntityStub('user', NULL, ['name' => 'admin']));
 
     $driver_manager = $this->createDriverManagerMock();
     $manager = new DrupalAuthenticationManager($mink, $user_manager, $driver_manager, self::MINK_PARAMS, self::DRUPAL_PARAMS);
@@ -442,7 +444,7 @@ class DrupalAuthenticationManagerTest extends TestCase {
     $params['login_wait'] = 0;
 
     $manager = $this->createManager($session, NULL, NULL, $params);
-    $manager->logIn((object) ['name' => 'admin', 'pass' => 'password']);
+    $manager->logIn(new EntityStub('user', NULL, ['name' => 'admin', 'pass' => 'password']));
   }
 
   /**
@@ -487,7 +489,7 @@ class DrupalAuthenticationManagerTest extends TestCase {
 
     $user_manager = new DrupalUserManager();
     $manager = $this->createManager($session, $user_manager, NULL, $params);
-    $manager->logIn((object) ['name' => 'admin', 'pass' => 'password']);
+    $manager->logIn(new EntityStub('user', NULL, ['name' => 'admin', 'pass' => 'password']));
 
     $this->assertNotFalse($user_manager->getCurrentUser());
   }
@@ -518,7 +520,7 @@ class DrupalAuthenticationManagerTest extends TestCase {
 
     $this->expectException(\Exception::class);
     $this->expectExceptionMessage("Unable to determine if logged in");
-    $manager->logIn((object) ['name' => 'admin', 'pass' => 'password']);
+    $manager->logIn(new EntityStub('user', NULL, ['name' => 'admin', 'pass' => 'password']));
   }
 
   /**

--- a/tests/phpunit/src/DrupalUserManagerTest.php
+++ b/tests/phpunit/src/DrupalUserManagerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Tests;
 
+use Drupal\Driver\Entity\EntityStub;
+use Drupal\Driver\Entity\EntityStubInterface;
 use Drupal\DrupalExtension\Manager\DrupalUserManager;
 use Drupal\DrupalExtension\Manager\DrupalUserManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -15,6 +17,16 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversClass(DrupalUserManager::class)]
 class DrupalUserManagerTest extends TestCase {
+
+  /**
+   * Builds a user stub with the given values.
+   *
+   * @param array<string, mixed> $values
+   *   The values to seed the stub with.
+   */
+  protected static function userStub(array $values): EntityStubInterface {
+    return new EntityStub('user', NULL, $values);
+  }
 
   /**
    * Tests that the manager implements the interface.
@@ -37,7 +49,7 @@ class DrupalUserManagerTest extends TestCase {
    */
   public function testSetAndGetCurrentUser(): void {
     $manager = new DrupalUserManager();
-    $user = (object) ['name' => 'admin'];
+    $user = self::userStub(['name' => 'admin']);
     $manager->setCurrentUser($user);
     $this->assertSame($user, $manager->getCurrentUser());
   }
@@ -47,7 +59,7 @@ class DrupalUserManagerTest extends TestCase {
    */
   public function testSetCurrentUserToFalse(): void {
     $manager = new DrupalUserManager();
-    $manager->setCurrentUser((object) ['name' => 'admin']);
+    $manager->setCurrentUser(self::userStub(['name' => 'admin']));
     $manager->setCurrentUser(FALSE);
     $this->assertFalse($manager->getCurrentUser());
   }
@@ -57,7 +69,7 @@ class DrupalUserManagerTest extends TestCase {
    */
   public function testAddAndGetUser(): void {
     $manager = new DrupalUserManager();
-    $user = (object) ['name' => 'editor'];
+    $user = self::userStub(['name' => 'editor']);
     $manager->addUser($user);
     $this->assertSame($user, $manager->getUser('editor'));
   }
@@ -77,7 +89,7 @@ class DrupalUserManagerTest extends TestCase {
    */
   public function testRemoveUser(): void {
     $manager = new DrupalUserManager();
-    $manager->addUser((object) ['name' => 'editor']);
+    $manager->addUser(self::userStub(['name' => 'editor']));
     $manager->removeUser('editor');
     $this->expectException(\InvalidArgumentException::class);
     $manager->getUser('editor');
@@ -88,8 +100,8 @@ class DrupalUserManagerTest extends TestCase {
    */
   public function testGetUsersReturnsAll(): void {
     $manager = new DrupalUserManager();
-    $user_a = (object) ['name' => 'alice'];
-    $user_b = (object) ['name' => 'bob'];
+    $user_a = self::userStub(['name' => 'alice']);
+    $user_b = self::userStub(['name' => 'bob']);
     $manager->addUser($user_a);
     $manager->addUser($user_b);
     $users = $manager->getUsers();
@@ -111,8 +123,8 @@ class DrupalUserManagerTest extends TestCase {
    */
   public function testClearUsers(): void {
     $manager = new DrupalUserManager();
-    $manager->setCurrentUser((object) ['name' => 'admin']);
-    $manager->addUser((object) ['name' => 'editor']);
+    $manager->setCurrentUser(self::userStub(['name' => 'admin']));
+    $manager->addUser(self::userStub(['name' => 'editor']));
     $manager->clearUsers();
     $this->assertFalse($manager->getCurrentUser());
     $this->assertSame([], $manager->getUsers());
@@ -121,7 +133,7 @@ class DrupalUserManagerTest extends TestCase {
   /**
    * Tests the hasUsers method.
    *
-   * @param array<int, \stdClass> $users
+   * @param array<int, \Drupal\Driver\Entity\EntityStubInterface> $users
    *   Users to add to the manager.
    * @param bool $expected
    *   Expected hasUsers() result.
@@ -140,15 +152,15 @@ class DrupalUserManagerTest extends TestCase {
    */
   public static function dataProviderHasUsers(): \Iterator {
     yield 'no users' => [[], FALSE];
-    yield 'one user' => [[(object) ['name' => 'alice']], TRUE];
-    yield 'multiple users' => [[(object) ['name' => 'alice'], (object) ['name' => 'bob']], TRUE];
+    yield 'one user' => [[self::userStub(['name' => 'alice'])], TRUE];
+    yield 'multiple users' => [[self::userStub(['name' => 'alice']), self::userStub(['name' => 'bob'])], TRUE];
   }
 
   /**
    * Tests the currentUserIsAnonymous method.
    */
   #[DataProvider('dataProviderCurrentUserIsAnonymous')]
-  public function testCurrentUserIsAnonymous(\stdClass|bool $user, bool $expected): void {
+  public function testCurrentUserIsAnonymous(EntityStubInterface|false $user, bool $expected): void {
     $manager = new DrupalUserManager();
     $manager->setCurrentUser($user);
     $this->assertSame($expected, $manager->currentUserIsAnonymous());
@@ -159,14 +171,14 @@ class DrupalUserManagerTest extends TestCase {
    */
   public static function dataProviderCurrentUserIsAnonymous(): \Iterator {
     yield 'false is anonymous' => [FALSE, TRUE];
-    yield 'user object is not anonymous' => [(object) ['name' => 'admin'], FALSE];
+    yield 'user stub is not anonymous' => [self::userStub(['name' => 'admin']), FALSE];
   }
 
   /**
    * Tests the currentUserHasRole method.
    */
   #[DataProvider('dataProviderCurrentUserHasRole')]
-  public function testCurrentUserHasRole(\stdClass|bool $user, string $role, bool $expected): void {
+  public function testCurrentUserHasRole(EntityStubInterface|false $user, string $role, bool $expected): void {
     $manager = new DrupalUserManager();
     $manager->setCurrentUser($user);
     $this->assertSame($expected, $manager->currentUserHasRole($role));
@@ -177,10 +189,10 @@ class DrupalUserManagerTest extends TestCase {
    */
   public static function dataProviderCurrentUserHasRole(): \Iterator {
     yield 'anonymous has no role' => [FALSE, 'admin', FALSE];
-    yield 'user without role property' => [(object) ['name' => 'alice'], 'editor', FALSE];
-    yield 'user with matching role' => [(object) ['name' => 'alice', 'role' => 'editor'], 'editor', TRUE];
-    yield 'user with non-matching role' => [(object) ['name' => 'alice', 'role' => 'editor'], 'admin', FALSE];
-    yield 'user with empty role' => [(object) ['name' => 'alice', 'role' => ''], 'editor', FALSE];
+    yield 'user without role property' => [self::userStub(['name' => 'alice']), 'editor', FALSE];
+    yield 'user with matching role' => [self::userStub(['name' => 'alice', 'role' => 'editor']), 'editor', TRUE];
+    yield 'user with non-matching role' => [self::userStub(['name' => 'alice', 'role' => 'editor']), 'admin', FALSE];
+    yield 'user with empty role' => [self::userStub(['name' => 'alice', 'role' => '']), 'editor', FALSE];
   }
 
 }

--- a/tests/phpunit/src/RawDrupalContextTest.php
+++ b/tests/phpunit/src/RawDrupalContextTest.php
@@ -7,6 +7,7 @@ namespace Drupal\DrupalExtension\Tests;
 use Drupal\Driver\Core\CoreInterface;
 use Drupal\Driver\Core\Field\FieldClassifierInterface;
 use Drupal\Driver\DrupalDriver;
+use Drupal\Driver\Entity\EntityStub;
 use Drupal\DrupalDriverManagerInterface;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -96,9 +97,9 @@ class RawDrupalContextTest extends TestCase {
       $this->expectExceptionMessage($exception);
     }
 
-    $entity = (object) $input;
-    $context->parseEntityFields('node', $entity, $ignored_properties);
-    $this->assertSame($expected, (array) $entity);
+    $stub = new EntityStub('node', NULL, $input);
+    $context->parseEntityFields($stub, $ignored_properties);
+    $this->assertSame($expected, $stub->getValues());
   }
 
   /**
@@ -289,10 +290,10 @@ class RawDrupalContextTest extends TestCase {
     $context = new RawDrupalContext();
     $context->setDrupal($drupal);
 
-    $entity = (object) ['moderation_state' => 'draft'];
-    $context->parseEntityFields('node', $entity);
+    $stub = new EntityStub('node', NULL, ['moderation_state' => 'draft']);
+    $context->parseEntityFields($stub);
 
-    $this->assertSame(['moderation_state' => 'draft'], (array) $entity);
+    $this->assertSame(['moderation_state' => 'draft'], $stub->getValues());
   }
 
   /**
@@ -327,8 +328,8 @@ class RawDrupalContextTest extends TestCase {
     $context = new RawDrupalContext();
     $context->setDrupal($drupal);
 
-    $entity = (object) ['field_test' => 'value'];
-    $context->parseEntityFields('taxonomy_term', $entity);
+    $stub = new EntityStub('taxonomy_term', NULL, ['field_test' => 'value']);
+    $context->parseEntityFields($stub);
   }
 
 }


### PR DESCRIPTION
Closes #337

## Summary

Replaces all `\stdClass` entity-stub flows throughout the extension with the
typed `EntityStubInterface` from `drupal/drupal-driver`
(`feature/362-entity-stub`). The four parallel creation paths
(`nodeCreate()`, `termCreate()`, `userCreate()`, `languageCreate()`) and
their matching teardown hooks in `RawDrupalContext` collapse into a single
`entityCreate()` entry point and a single `cleanEntities()` reverse-walk
cleanup. Hook scopes, user manager, and authentication manager are all
retyped to carry `EntityStubInterface`, replacing ad-hoc property access
with the typed `getValue()`/`setValue()` API. This closes issue #337 with
the narrowed scope agreed on the issue thread: typed stubs in, structural
changes to the driver protocol out.

## Driver coordination

This branch depends on `drupal/drupal-driver` PR/branch
`feature/362-entity-stub` (driver issue
[#362](https://github.com/jhedstrom/DrupalDriver/issues/362)). `composer.json`
is pinned to `dev-feature/362-entity-stub as 3.0.0` for now. Update the
constraint to the released `3.x` tag once the driver branch is merged and
tagged.

## Changes

### Hook scopes

- `BaseEntityScope` and `EntityScope` interface now carry an
  `EntityStubInterface` instead of `\stdClass`. `getEntity()` is replaced by
  `getStub()`.

### Managers

- `DrupalUserManagerInterface` and `DrupalUserManager` retyped - current user
  is `EntityStubInterface|false`, tracked-users array is keyed by
  `$user->getValue('name')`.
- `DrupalAuthenticationManagerInterface` and `DrupalAuthenticationManager` -
  `logIn()` takes `EntityStubInterface`, reads `name`/`pass`/`role` via
  `getValue()`. `backendLogin()` retyped to match.

### `RawDrupalContext`

- Four tracked-state arrays (`$nodes`, `$terms`, `$languages`, plus the user
  manager) collapse to a single `$createdStubs` array (users still tracked
  separately for name lookup).
- Four `cleanNodes()`/`cleanTerms()`/`cleanLanguages()` AfterScenario
  methods become a single `cleanEntities()` that walks `$createdStubs` in
  reverse and dispatches to the per-type driver delete method
  (`nodeDelete` / `termDelete` / `entityDelete` / `languageDelete`).
- `nodeCreate()`, `termCreate()`, `userCreate()`, `languageCreate()` all
  take and return `EntityStubInterface` instead of `\stdClass`.
- `parseEntityFields()` takes `EntityStubInterface` (entity type comes from
  `$stub->getEntityType()`, no longer a separate parameter); reads/writes
  via `getValues()`/`setValues()`. Multicolumn parsing logic preserved.
- `captureScalarBaseFields()` / `restoreScalarBaseFields()` retyped to
  operate on the stub.
- The two `instanceof \stdClass` runtime guards deleted - type system
  enforces the contract now.

### `DrupalContext` step methods

- All nine `(object) [...]` constructions replaced with
  `new EntityStub($entity_type, $bundle, $values)`.
- `$saved->nid` / `$saved->tid` references replaced with `$stub->getId()`.
- Vocabulary machine-name resolution moved into `createTerms()` and
  `createAndVisitTerm()` step methods, since the constructor's bundle
  argument is `readonly` and must be the resolved machine name before the
  stub is built.
- `createUserStub()` returns `EntityStubInterface`.

### Tests

- `tests/behat/bootstrap/FeatureContext.php` hooks rewritten to use
  `getStub()`, `getValue()`, `setValue()`, `hasValue()`, `removeValue()`.
- PHPSpec for the user manager and the `BeforeNodeCreateScope` retyped to
  construct `EntityStub` instances and assert against
  `EntityStubInterface`.
- PHPUnit suites retyped: `DrupalUserManagerTest`,
  `DrupalAuthenticationManagerTest`, `RawDrupalContextTest`.

### Composer constraint

- `drupal/drupal-driver`: `dev-master as 3.0.0` ->
  `dev-feature/362-entity-stub as 3.0.0`.

## Before / After

ASCII diagrams showing the structural changes.

**(1) Old four-path data model:**

```
+-------------------+
| Gherkin table     |
+--------+----------+
         |
         v
+--------+----------+   nodeCreate(\stdClass)
| (object) $row     +-------------------------+
+-------------------+                         |
                                              v
+-------------------+   termCreate(\stdClass) +--------------------+
| (object) $row     +-----------------------> | RawDrupalContext   |
+-------------------+                         |   $nodes[]         |
                                              |   $terms[]         |
+-------------------+   userCreate(\stdClass) |   $languages[]     |
| (object) $row     +-----------------------> |   userManager      |
+-------------------+                         +---------+----------+
                                                        |
                                                        v
                                              +--------------------+
                                              | cleanNodes()       |
                                              | cleanTerms()       |
                                              | cleanUsers()       |
                                              | cleanLanguages()   |
                                              +--------------------+
```

**(2) New single-path model:**

```
+-------------------+
| Gherkin table     |
+--------+----------+
         |
         v
+--------+----------+   nodeCreate(EntityStub)
| new EntityStub(   +-------------------------+
|   $type,$bundle,  |                         |
|   $values)        |                         v
+-------------------+               +--------------------+
                                    |  RawDrupalContext  |
+-------------------+               |    $createdStubs   |
| new EntityStub(   +-------------> |    (single array)  |
|   ...)            |   *Create()   |    userManager     |
+-------------------+               +---------+----------+
                                              |
                                              v
                                    +--------------------+
                                    | cleanEntities()    |
                                    |   reverse walk +   |
                                    |   per-type delete  |
                                    +--------------------+
```

**(3) Hook scope contract:**

```
Before:                          After:
+-----------------+              +------------------------+
| \stdClass       |              | EntityStubInterface    |
|   ->title       |              |   ->getValue('title')  |
|   ->field_x     |              |   ->getValue('field_x')|
|   ->{'A B'}     |              |   ->setValue(...)      |
+-----------------+              |   ->getEntityType()    |
        |                        |   ->getBundle()        |
        v                        |   ->getId()            |
   getEntity()                   +-----------+------------+
                                             |
                                             v
                                        getStub()
```

## Test plan

- [x] PHPStan level 7 passes
- [x] PHPSpec passes (71 examples)
- [x] PHPUnit passes (302 tests, 553 assertions)
- [x] Behat blackbox passes (103 scenarios)
- [x] Behat Drupal API passes (147 scenarios)
- [x] `ahoy docs` shows no STEPS.md changes
- [ ] HTTPS suite (requires `docker-compose.override.yml` for Traefik;
      environmental, not exercised in this branch)
