### PR TITLE
Renamed 'classifier()' calls to 'getFieldClassifier()' to match drupal-driver API.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -441,7 +441,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
     }
 
     $entity_type = $stub->getEntityType();
-    $classifier = $driver->getCore()->classifier();
+    $classifier = $driver->getCore()->getFieldClassifier();
 
     $multicolumn_field = '';
     $multicolumn_column = '';

--- a/tests/phpunit/src/RawDrupalContextTest.php
+++ b/tests/phpunit/src/RawDrupalContextTest.php
@@ -35,7 +35,7 @@ class RawDrupalContextTest extends TestCase {
     $classifier->method('fieldIsConfigurable')->willReturn(TRUE);
 
     $core = $this->createMock(CoreInterface::class);
-    $core->method('classifier')->willReturn($classifier);
+    $core->method('getFieldClassifier')->willReturn($classifier);
 
     $driver = $this->createMock(DrupalDriver::class);
     $driver->method('getCore')->willReturn($core);
@@ -77,7 +77,7 @@ class RawDrupalContextTest extends TestCase {
       $classifier->method('fieldIsBaseCustomStorage')->willReturnCallback($is_base_field);
 
       $core = $this->createMock(CoreInterface::class);
-      $core->method('classifier')->willReturn($classifier);
+      $core->method('getFieldClassifier')->willReturn($classifier);
 
       $driver = $this->createMock(DrupalDriver::class);
       $driver->method('getCore')->willReturn($core);
@@ -279,7 +279,7 @@ class RawDrupalContextTest extends TestCase {
     }
 
     $core = $this->createMock(CoreInterface::class);
-    $core->method('classifier')->willReturn($classifier);
+    $core->method('getFieldClassifier')->willReturn($classifier);
 
     $driver = $this->createMock(DrupalDriver::class);
     $driver->method('getCore')->willReturn($core);
@@ -317,7 +317,7 @@ class RawDrupalContextTest extends TestCase {
       ->willReturn(TRUE);
 
     $core = $this->createMock(CoreInterface::class);
-    $core->method('classifier')->willReturn($classifier);
+    $core->method('getFieldClassifier')->willReturn($classifier);
 
     $driver = $this->createMock(DrupalDriver::class);
     $driver->method('getCore')->willReturn($core);


### PR DESCRIPTION
## Summary

The drupal-driver package renamed the `classifier()` accessor to `getFieldClassifier()` on `CoreInterface` (jhedstrom/DrupalDriver#364). This PR updates drupalextension to use the new method name so it stays in sync with the upstream API. No backwards-compatibility shim is provided - any code that calls `getCore()->classifier()` directly must migrate to `getCore()->getFieldClassifier()`.

## Changes

**`src/Drupal/DrupalExtension/Context/RawDrupalContext.php`**
- Updated the call site in `parseEntityFields()` to use `getFieldClassifier()` instead of `classifier()`.

**`tests/phpunit/src/RawDrupalContextTest.php`**
- Updated 4 mock setups (lines 38, 80, 282, 320) to mock `getFieldClassifier` instead of `classifier`.

## Before / After

```
  CoreInterface
    Before:                                    After:
    ───────                                    ──────
    classifier(): FieldClassifier        -->   getFieldClassifier(): FieldClassifier

  Call site in RawDrupalContext::parseEntityFields():
    Before:                                    After:
    ───────                                    ──────
    $driver->getCore()->classifier()     -->   $driver->getCore()->getFieldClassifier()
```
