### PR TITLE
[#766] Added modern entity-field parser with 'field_parser' configuration flag.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -196,6 +196,9 @@ commands:
       ahoy title "Running Behat: drupal"
       ahoy cli "vendor/bin/behat --profile=drupal $STRICT --no-coverage --allow-no-tests $@"
 
+      ahoy title "Running Behat: drupal_legacy_parser"
+      ahoy cli "vendor/bin/behat --profile=drupal_legacy_parser $STRICT --no-coverage --allow-no-tests $@"
+
   test-bdd-blackbox:
     usage: Run blackbox Behat tests.
     cmd: ahoy cli "vendor/bin/behat --strict --no-coverage $@"
@@ -203,6 +206,10 @@ commands:
   test-bdd-drupal:
     usage: Run Drupal API Behat tests.
     cmd: ahoy cli "vendor/bin/behat --profile=drupal --strict --no-coverage $@"
+
+  test-bdd-drupal-legacy-parser:
+    usage: Run Drupal API Behat tests under the deprecated legacy field parser.
+    cmd: ahoy cli "vendor/bin/behat --profile=drupal_legacy_parser --strict --no-coverage $@"
 
   test-bdd-drupal-https:
     usage: Run HTTPS Behat tests.

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -196,9 +196,6 @@ commands:
       ahoy title "Running Behat: drupal"
       ahoy cli "vendor/bin/behat --profile=drupal $STRICT --no-coverage --allow-no-tests $@"
 
-      ahoy title "Running Behat: drupal_legacy_parser"
-      ahoy cli "vendor/bin/behat --profile=drupal_legacy_parser $STRICT --no-coverage --allow-no-tests $@"
-
   test-bdd-blackbox:
     usage: Run blackbox Behat tests.
     cmd: ahoy cli "vendor/bin/behat --strict --no-coverage $@"
@@ -206,10 +203,6 @@ commands:
   test-bdd-drupal:
     usage: Run Drupal API Behat tests.
     cmd: ahoy cli "vendor/bin/behat --profile=drupal --strict --no-coverage $@"
-
-  test-bdd-drupal-legacy-parser:
-    usage: Run Drupal API Behat tests under the deprecated legacy field parser.
-    cmd: ahoy cli "vendor/bin/behat --profile=drupal_legacy_parser --strict --no-coverage $@"
 
   test-bdd-drupal-https:
     usage: Run HTTPS Behat tests.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -99,7 +99,7 @@ to be named. Common field types and their column names:
 Whitespace around `,`, `;` and `:` is ignored outside quoted strings, so
 both forms are accepted:
 
-```
+```text
 country:"BE",locality:"Brussel"
 country : "BE" , locality : "Brussel"
 ```
@@ -123,7 +123,7 @@ Any other backslash sequence is a parse error.
 The modern parser reports parse errors with character-level position
 information. A typical failure looks like:
 
-```
+```text
 Parse error in field_post_address:
 country:"BE", locality:Brussel, postal_code:"1000"
               ^

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -35,6 +35,105 @@ Update each occurrence in your `.feature` files.
 | `Then break` / `Then I break`                                              | `When break` / `When I break` (re-categorised from `Then`)                               |
 | `Then I log out`                                                           | `When I log out` (re-categorised from `Then`)                                            |
 
+## Field syntax
+
+The inline syntax accepted by `parseEntityFields()` (the body of every
+`Given the following :type content:` and `Given the following users:`
+table) has been replaced. The new syntax has a single uniform escape
+mechanism (double quotes) and detects compound mode by value form rather
+than by the spacing of separators, removing the silent failures that
+plagued the legacy syntax.
+
+### Configuration
+
+A new `field_parser` extension parameter selects the active parser:
+
+```yaml
+default:
+  extensions:
+    Drupal\DrupalExtension:
+      field_parser: default   # one of: default | legacy
+```
+
+`default` is the default and uses the new parser. To opt back into the
+legacy parser during migration:
+
+```yaml
+field_parser: legacy
+```
+
+Setting `legacy` emits a deprecation notice once per process. The legacy
+parser is removed in 6.1; setting `field_parser: legacy` then will produce
+a hard configuration error.
+
+### Side-by-side syntax
+
+| Pattern                           | Legacy syntax                                                       | Modern syntax                                                                            |
+| --------------------------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| Compound named single             | `country: BE - locality: Brussel`                                   | `country:"BE", locality:"Brussel"`                                                       |
+| Compound named multi              | `country: BE - locality: Brussel, country: FR - locality: Paris`    | `country:"BE", locality:"Brussel"; country:"FR", locality:"Paris"`                       |
+| Compound positional single (link) | `Link 1 - http://example.com`                                       | `title:"Link 1", uri:"http://example.com"` (positional gone, use named keys)             |
+| Compound positional multi (link)  | `L1 - http://a, L2 - http://b`                                      | `title:"L1", uri:"http://a"; title:"L2", uri:"http://b"`                                 |
+| Token at compound value position  | not expressible                                                     | `value:[relative:-1 week], end_value:[relative:+1 week]`                                 |
+| Scalar containing `,`             | `"Tag, one"`                                                        | `"Tag, one"` (unchanged)                                                                 |
+| Scalar containing ` - `           | `"Alpha - Bravo"` (workaround required)                             | `Alpha - Bravo` (no escape needed)                                                       |
+| Scalar containing `;`             | `Hello; world`                                                      | `"Hello; world"` (new escape required)                                                   |
+| Scalar containing literal `"`     | not expressible                                                     | `note:"He said \"hi\""`                                                                  |
+| Scalar that looks like `key:value`| `port:8080` (silent compound risk if value present)                 | `port:8080` (unambiguous scalar)                                                         |
+
+### Positional compound columns are no longer supported
+
+The legacy syntax allowed compound values without column names, e.g.
+`Link 1 - http://example.com`. The modern syntax requires every column
+to be named. Common field types and their column names:
+
+| Field type           | Column 1   | Column 2   | Column 3 |
+| -------------------- | ---------- | ---------- | -------- |
+| `link`               | `title`    | `uri`      | -        |
+| `text_with_summary`  | `value`    | `summary`  | `format` |
+| `daterange`          | `value`    | `end_value`| -        |
+| `image` / `file`     | `target_id`| `alt`      | `title`  |
+
+### Whitespace tolerance
+
+Whitespace around `,`, `;` and `:` is ignored outside quoted strings, so
+both forms are accepted:
+
+```
+country:"BE",locality:"Brussel"
+country : "BE" , locality : "Brussel"
+```
+
+Whitespace inside `"..."` is preserved literally.
+
+### Escape sequences inside quoted strings
+
+| Sequence | Decoded |
+| -------- | ------- |
+| `\"`     | `"`     |
+| `\\`     | `\`     |
+| `\n`     | LF      |
+| `\t`     | TAB     |
+| `\r`     | CR      |
+
+Any other backslash sequence is a parse error.
+
+### New parse-error format
+
+The modern parser reports parse errors with character-level position
+information. A typical failure looks like:
+
+```
+Parse error in field_post_address:
+country:"BE", locality:Brussel, postal_code:"1000"
+              ^
+unquoted_compound_value at offset 14: Compound column "locality" must use a quoted string or token.
+Hint: Wrap the value in double quotes or use a [token:value] form.
+```
+
+All errors detected in a single cell are reported together, so authors
+fix every problem in one edit instead of one error per run.
+
 ## Behaviour changes
 
 | Step                | 5.x behaviour                                          | 6.0 behaviour                                                          |

--- a/behat.dist.yml
+++ b/behat.dist.yml
@@ -54,6 +54,9 @@ default:
       api_driver: drush
       # Drush driver variant (legacy setting).
       drush_driver: drush
+      # Field-value parser used by parseEntityFields(): "default" or
+      # "legacy" (deprecated, removed in 6.1).
+      field_parser: default
       # Enable the blackbox driver.
       blackbox: ~
       # Map of named regions to CSS selectors.
@@ -105,6 +108,9 @@ drupal:
 
     Drupal\DrupalExtension:
       api_driver: drupal
+      # Field-value parser used by parseEntityFields(): "default" or
+      # "legacy" (deprecated, removed in 6.1).
+      field_parser: default
       # Drupal API driver settings.
       drupal:
         drupal_root: /var/www/html/web

--- a/behat.dist.yml
+++ b/behat.dist.yml
@@ -108,9 +108,6 @@ drupal:
 
     Drupal\DrupalExtension:
       api_driver: drupal
-      # Field-value parser used by parseEntityFields(): "default" or
-      # "legacy" (deprecated, removed in 6.1).
-      field_parser: default
       # Drupal API driver settings.
       drupal:
         drupal_root: /var/www/html/web

--- a/behat.yml
+++ b/behat.yml
@@ -139,7 +139,7 @@ drupal:
         - BehatCliContext
         - DrevOps\BehatScreenshotExtension\Context\ScreenshotContext
       filters:
-        tags: "@test-drupal&&~@skipped&&~@test-legacy-parser"
+        tags: "@test-drupal&&~@skipped"
 
   extensions:
     Drupal\MinkExtension:
@@ -149,49 +149,6 @@ drupal:
     Drupal\DrupalExtension:
       api_driver: "drupal"
       login_wait: 0
-      drupal:
-        drupal_root: "/var/www/html/build/web"
-      drush:
-        root: "/var/www/html/build/web"
-      region_map:
-        main content: "#main"
-      selectors:
-        message_selector: '.messages'
-        error_message_selector: '.messages--error'
-        success_message_selector: '.messages--status'
-        warning_message_selector: '.messages--warning'
-
-# Legacy field-parser profile: runs the legacy-syntax field-handler tests
-# under the deprecated parser. The parser is removed in 6.1; this profile
-# exists to keep the legacy syntax exercised until then.
-drupal_legacy_parser:
-  suites:
-    default:
-      contexts:
-        - Drupal\DrupalExtension\Context\ConfigContext
-        - Drupal\DrupalExtension\Context\BatchContext
-        - Drupal\DrupalExtension\Context\DrupalContext
-        - Drupal\DrupalExtension\Context\DrushContext
-        - Drupal\DrupalExtension\Context\MinkContext
-        - Drupal\DrupalExtension\Context\MarkupContext
-        - Drupal\DrupalExtension\Context\MessageContext
-        - Drupal\DrupalExtension\Context\MailContext
-        - Drupal\DrupalExtension\Context\RandomContext
-        - FeatureContext
-        - BehatCliContext
-        - DrevOps\BehatScreenshotExtension\Context\ScreenshotContext
-      filters:
-        tags: "@test-legacy-parser&&~@skipped"
-
-  extensions:
-    Drupal\MinkExtension:
-      base_url: http://drupal
-      files_path: /var/www/html/tests/behat/fixtures/files
-
-    Drupal\DrupalExtension:
-      api_driver: "drupal"
-      login_wait: 0
-      field_parser: legacy
       drupal:
         drupal_root: "/var/www/html/build/web"
       drush:

--- a/behat.yml
+++ b/behat.yml
@@ -139,7 +139,7 @@ drupal:
         - BehatCliContext
         - DrevOps\BehatScreenshotExtension\Context\ScreenshotContext
       filters:
-        tags: "@test-drupal&&~@skipped"
+        tags: "@test-drupal&&~@skipped&&~@test-legacy-parser"
 
   extensions:
     Drupal\MinkExtension:
@@ -149,6 +149,49 @@ drupal:
     Drupal\DrupalExtension:
       api_driver: "drupal"
       login_wait: 0
+      drupal:
+        drupal_root: "/var/www/html/build/web"
+      drush:
+        root: "/var/www/html/build/web"
+      region_map:
+        main content: "#main"
+      selectors:
+        message_selector: '.messages'
+        error_message_selector: '.messages--error'
+        success_message_selector: '.messages--status'
+        warning_message_selector: '.messages--warning'
+
+# Legacy field-parser profile: runs the legacy-syntax field-handler tests
+# under the deprecated parser. The parser is removed in 6.1; this profile
+# exists to keep the legacy syntax exercised until then.
+drupal_legacy_parser:
+  suites:
+    default:
+      contexts:
+        - Drupal\DrupalExtension\Context\ConfigContext
+        - Drupal\DrupalExtension\Context\BatchContext
+        - Drupal\DrupalExtension\Context\DrupalContext
+        - Drupal\DrupalExtension\Context\DrushContext
+        - Drupal\DrupalExtension\Context\MinkContext
+        - Drupal\DrupalExtension\Context\MarkupContext
+        - Drupal\DrupalExtension\Context\MessageContext
+        - Drupal\DrupalExtension\Context\MailContext
+        - Drupal\DrupalExtension\Context\RandomContext
+        - FeatureContext
+        - BehatCliContext
+        - DrevOps\BehatScreenshotExtension\Context\ScreenshotContext
+      filters:
+        tags: "@test-legacy-parser&&~@skipped"
+
+  extensions:
+    Drupal\MinkExtension:
+      base_url: http://drupal
+      files_path: /var/www/html/tests/behat/fixtures/files
+
+    Drupal\DrupalExtension:
+      api_driver: "drupal"
+      login_wait: 0
+      field_parser: legacy
       drupal:
         drupal_root: "/var/www/html/build/web"
       drush:

--- a/src/Drupal/DrupalExtension/Compiler/DriverPass.php
+++ b/src/Drupal/DrupalExtension/Compiler/DriverPass.php
@@ -30,8 +30,8 @@ class DriverPass implements CompilerPassInterface {
         }
       }
 
-      // The DrupalDriver in 3.x takes a single Core via setCore(). Resolve
-      // the first service tagged 'drupal.core' and inject it.
+      // The DrupalDriver takes a single Core via setCore(). Resolve the
+      // first service tagged 'drupal.core' and inject it.
       if ('drupal.driver.drupal' !== $id) {
         continue;
       }

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -24,6 +24,7 @@ use Drupal\DrupalDriverManagerInterface;
 use Drupal\DrupalExtension\DrupalParametersTrait;
 use Drupal\DrupalExtension\Manager\DrupalAuthenticationManagerInterface;
 use Drupal\DrupalExtension\Manager\DrupalUserManagerInterface;
+use Drupal\DrupalExtension\Parser\EntityFieldParser;
 use Drupal\DrupalExtension\Parser\EntityFieldParserInterface;
 use Drupal\DrupalExtension\Parser\LegacyEntityFieldParser;
 
@@ -395,11 +396,27 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   /**
    * Builds the active entity-field parser for one parsing call.
    *
-   * Override in a subclass to swap in a different parser implementation
-   * (e.g. the v6 modern parser, when it lands in 6.0).
+   * The 'field_parser' extension parameter controls which implementation is
+   * used: 'default' (the current parser) or 'legacy' (the deprecated parser
+   * that will be removed in 6.1). Override in a subclass to swap in a
+   * custom implementation.
    */
   protected function getFieldParser(string $entity_type, FieldClassifierInterface $classifier): EntityFieldParserInterface {
-    return new LegacyEntityFieldParser($entity_type, $classifier);
+    $mode = $this->getDrupalParameter('field_parser') ?? 'default';
+
+    if ($mode === 'legacy') {
+      static $deprecation_emitted = FALSE;
+
+      if (!$deprecation_emitted) {
+        // phpcs:ignore Drupal.Semantics.FunctionTriggerError
+        @trigger_error('The legacy field parser is deprecated and will be removed in 6.1. Remove "field_parser: legacy" from your behat.yml to migrate. See MIGRATION.md.', E_USER_DEPRECATED);
+        $deprecation_emitted = TRUE;
+      }
+
+      return new LegacyEntityFieldParser($entity_type, $classifier);
+    }
+
+    return new EntityFieldParser($entity_type, $classifier);
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -408,8 +408,12 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
       static $deprecation_emitted = FALSE;
 
       if (!$deprecation_emitted) {
-        // phpcs:ignore Drupal.Semantics.FunctionTriggerError
-        @trigger_error('The legacy field parser is deprecated and will be removed in 6.1. Remove "field_parser: legacy" from your behat.yml to migrate. See MIGRATION.md.', E_USER_DEPRECATED);
+        // The deprecation is intentionally not silenced with '@': Behat does
+        // not run with a Symfony-style deprecation collector that observes
+        // suppressed notices, so the notice is only visible to test authors
+        // when emitted unsuppressed.
+        // phpcs:ignore Drupal.Semantics.FunctionTriggerError,Drupal.Semantics.UnsilencedDeprecation
+        trigger_error('The legacy field parser is deprecated and will be removed in 6.1. Remove "field_parser: legacy" from your behat.yml to migrate. See MIGRATION.md.', E_USER_DEPRECATED);
         $deprecation_emitted = TRUE;
       }
 

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -408,12 +408,12 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
       static $deprecation_emitted = FALSE;
 
       if (!$deprecation_emitted) {
-        // The deprecation is intentionally not silenced with '@': Behat does
-        // not run with a Symfony-style deprecation collector that observes
-        // suppressed notices, so the notice is only visible to test authors
-        // when emitted unsuppressed.
-        // phpcs:ignore Drupal.Semantics.FunctionTriggerError,Drupal.Semantics.UnsilencedDeprecation
-        trigger_error('The legacy field parser is deprecated and will be removed in 6.1. Remove "field_parser: legacy" from your behat.yml to migrate. See MIGRATION.md.', E_USER_DEPRECATED);
+        // Behat installs an error handler that escalates 'E_USER_DEPRECATED'
+        // to a step failure, so 'trigger_error()' is the wrong vehicle here:
+        // it would break legacy-parser tests instead of merely warning. Write
+        // the notice to STDERR directly so test authors still see it during
+        // a Behat run.
+        fwrite(STDERR, '[Deprecation] The legacy field parser is deprecated and will be removed in 6.1. Remove "field_parser: legacy" from your behat.yml to migrate. See MIGRATION.md.' . PHP_EOL);
         $deprecation_emitted = TRUE;
       }
 

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -441,23 +441,23 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
    *   The same stub, now flagged as saved.
    */
   public function termCreate(EntityStubInterface $stub): EntityStubInterface {
-    // The 3.x DrupalDriver only loads vocabularies by machine name. Allow
-    // the Gherkin author to pass either the machine name or the human
-    // label by resolving the label to a machine name when the literal
-    // string does not match a vocabulary id. Resolution is best-effort -
-    // the driver throws a clearer error than we could when the lookup
-    // ultimately fails.
+    // The DrupalDriver only loads vocabularies by machine name. Allow the
+    // Gherkin author to pass either the machine name or the human label by
+    // resolving the label to a machine name when the literal string does
+    // not match a vocabulary id. Resolution is best-effort - the driver
+    // throws a clearer error than we could when the lookup ultimately
+    // fails.
     $vocabulary = $stub->getValue('vocabulary_machine_name');
 
     if (!empty($vocabulary)) {
       $stub->setValue('vocabulary_machine_name', $this->resolveVocabularyMachineName((string) $vocabulary));
     }
 
-    // The 3.x DrupalDriver resolves a 'parent' property as a term name
-    // against the configured vocabulary and throws if it does not exist;
-    // pass the name through unchanged. An empty 'parent' must be removed
-    // so the field-handler pipeline does not try to expand the empty
-    // string as an entity reference.
+    // The DrupalDriver resolves a 'parent' property as a term name against
+    // the configured vocabulary and throws if it does not exist; pass the
+    // name through unchanged. An empty 'parent' must be removed so the
+    // field-handler pipeline does not try to expand the empty string as
+    // an entity reference.
     if ($stub->hasValue('parent') && empty($stub->getValue('parent'))) {
       $stub->removeValue('parent');
     }
@@ -502,9 +502,9 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface {
   /**
    * Captures scalar values on an entity stub.
    *
-   * The 3.x DrupalDriver runs base fields through the field-handler
-   * pipeline during create, which casts scalar values such as 'title',
-   * 'name', 'mail' or 'pass' to single-element arrays. Most drupalextension
+   * The DrupalDriver runs base fields through the field-handler pipeline
+   * during create, which casts scalar values such as 'title', 'name',
+   * 'mail' or 'pass' to single-element arrays. Most drupalextension
    * downstream code (user manager indexing, login flow, stub matching)
    * expects scalars, so callers snapshot the scalars before the driver
    * call and restore them after.

--- a/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
+++ b/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
@@ -236,11 +236,6 @@ final class EntityFieldParser implements EntityFieldParserInterface {
         $i++;
       }
 
-      if ($i >= $length) {
-        $items[] = '';
-        break;
-      }
-
       if ($cell[$i] === '"') {
         $start = $i;
 
@@ -573,16 +568,6 @@ final class EntityFieldParser implements EntityFieldParserInterface {
   private function readQuotedString(string $cell, int &$offset): string {
     $length = strlen($cell);
     $start = $offset;
-
-    if ($offset >= $length || $cell[$offset] !== '"') {
-      throw new ParseException(
-        'expected_quoted_string',
-        $offset,
-        $cell,
-        'Expected a quoted string.',
-      );
-    }
-
     $offset++;
     $out = '';
 
@@ -651,18 +636,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    * '[...]' substring (downstream field handlers expand the token).
    */
   private function readToken(string $cell, int &$offset): string {
-    $length = strlen($cell);
     $start = $offset;
-
-    if ($offset >= $length || $cell[$offset] !== '[') {
-      throw new ParseException(
-        'expected_token',
-        $offset,
-        $cell,
-        'Expected a [name:value] token.',
-      );
-    }
-
     $close = strpos($cell, ']', $offset + 1);
 
     if ($close === FALSE) {

--- a/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
+++ b/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
@@ -41,14 +41,14 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    *
    * @var string[]
    */
-  private array $ignoredProperties = [];
+  protected array $ignoredProperties = [];
 
   /**
    * Constructs the parser for one entity-type / classifier pairing.
    */
   public function __construct(
-    private readonly string $entityType,
-    private readonly FieldClassifierInterface $fieldClassifier,
+    protected readonly string $entityType,
+    protected readonly FieldClassifierInterface $fieldClassifier,
   ) {
   }
 
@@ -150,7 +150,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    * @throws \Drupal\DrupalExtension\Parser\Exception\ParseException
    *   On any cell-level parse error.
    */
-  private function parseCell(string $cell, bool $is_multicolumn): array {
+  protected function parseCell(string $cell, bool $is_multicolumn): array {
     $trimmed = trim($cell);
 
     if ($trimmed === '') {
@@ -173,7 +173,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    * scan respecting quoted strings and bracketed tokens so an embedded
    * pattern inside a quoted scalar does not trigger compound mode.
    */
-  private function detectCompoundMode(string $cell): bool {
+  protected function detectCompoundMode(string $cell): bool {
     $length = strlen($cell);
     $i = 0;
 
@@ -225,7 +225,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    * @return array<int, string>
    *   The parsed list of scalar items.
    */
-  private function parseScalarList(string $cell): array {
+  protected function parseScalarList(string $cell): array {
     $items = [];
     $length = strlen($cell);
     $i = 0;
@@ -328,7 +328,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    * @return array<int, array<string, string>>
    *   The parsed list of compound records.
    */
-  private function parseCompound(string $cell): array {
+  protected function parseCompound(string $cell): array {
     $records = [];
     $errors = [];
     $record_strings = $this->splitTopLevel($cell, ';');
@@ -337,12 +337,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
       $record = trim($record);
 
       if ($record === '') {
-        $errors[] = new ParseException(
-          'empty_record',
-          0,
-          $cell,
-          'Empty compound record (consecutive ";" or trailing ";").',
-        );
+        $errors[] = new ParseException('empty_record', 0, $cell, 'Empty compound record (consecutive ";" or trailing ";").');
 
         continue;
       }
@@ -369,7 +364,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    * @return array<string, string>
    *   The parsed columns keyed by column name.
    */
-  private function parseRecord(string $record, string $cell): array {
+  protected function parseRecord(string $record, string $cell): array {
     $columns = [];
     $errors = [];
     $column_strings = $this->splitTopLevel($record, ',');
@@ -378,12 +373,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
       $column = trim($column);
 
       if ($column === '') {
-        $errors[] = new ParseException(
-          'empty_column',
-          0,
-          $cell,
-          'Empty compound column (consecutive "," or trailing ",").',
-        );
+        $errors[] = new ParseException('empty_column', 0, $cell, 'Empty compound column (consecutive "," or trailing ",").');
 
         continue;
       }
@@ -410,7 +400,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    * @return array{0: string, 1: string}
    *   [$key, $value]
    */
-  private function parseColumn(string $column, string $cell): array {
+  protected function parseColumn(string $column, string $cell): array {
     if (preg_match('/^([a-z_][a-z0-9_]*)\s*:\s*(.*)$/s', $column, $match) !== 1) {
       throw new ParseException(
         'invalid_column',
@@ -439,12 +429,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
       $value = $this->readQuotedString($value_raw, $offset);
 
       if ($offset !== strlen($value_raw)) {
-        throw new ParseException(
-          'trailing_characters',
-          0,
-          $cell,
-          sprintf('Trailing characters after closing quote in column "%s".', $key),
-        );
+        throw new ParseException('trailing_characters', 0, $cell, sprintf('Trailing characters after closing quote in column "%s".', $key));
       }
 
       return [$key, $value];
@@ -455,12 +440,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
       $value = $this->readToken($value_raw, $offset);
 
       if ($offset !== strlen($value_raw)) {
-        throw new ParseException(
-          'trailing_characters',
-          0,
-          $cell,
-          sprintf('Trailing characters after closing token in column "%s".', $key),
-        );
+        throw new ParseException('trailing_characters', 0, $cell, sprintf('Trailing characters after closing token in column "%s".', $key));
       }
 
       return [$key, $value];
@@ -483,7 +463,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    * @return string[]
    *   The string segments separated by the top-level separator.
    */
-  private function splitTopLevel(string $cell, string $separator): array {
+  protected function splitTopLevel(string $cell, string $separator): array {
     $segments = [];
     $length = strlen($cell);
     $i = 0;
@@ -523,7 +503,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    * Matches the same escape grammar as 'readQuotedString()'. If the string
    * is unterminated returns the cell length.
    */
-  private function skipQuotedString(string $cell, int $i): int {
+  protected function skipQuotedString(string $cell, int $i): int {
     $length = strlen($cell);
     $i++;
 
@@ -548,7 +528,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    *
    * If the token is unterminated returns the cell length.
    */
-  private function skipToken(string $cell, int $i): int {
+  protected function skipToken(string $cell, int $i): int {
     $length = strlen($cell);
     $close = strpos($cell, ']', $i + 1);
 
@@ -565,7 +545,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    * Advances $offset past the closing quote. Decodes the escapes \\, \",
    * \n, \t, \r. Any other backslash sequence is a parse error.
    */
-  private function readQuotedString(string $cell, int &$offset): string {
+  protected function readQuotedString(string $cell, int &$offset): string {
     $length = strlen($cell);
     $start = $offset;
     $offset++;
@@ -576,12 +556,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
 
       if ($char === '\\') {
         if ($offset + 1 >= $length) {
-          throw new ParseException(
-            'unclosed_quote',
-            $start,
-            $cell,
-            'Quoted string ends with a dangling backslash.',
-          );
+          throw new ParseException('unclosed_quote', $start, $cell, 'Quoted string ends with a dangling backslash.');
         }
 
         $next = $cell[$offset + 1];
@@ -635,17 +610,12 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    * Advances $offset past the closing bracket and returns the verbatim
    * '[...]' substring (downstream field handlers expand the token).
    */
-  private function readToken(string $cell, int &$offset): string {
+  protected function readToken(string $cell, int &$offset): string {
     $start = $offset;
     $close = strpos($cell, ']', $offset + 1);
 
     if ($close === FALSE) {
-      throw new ParseException(
-        'unclosed_token',
-        $start,
-        $cell,
-        'Token is missing a closing "]".',
-      );
+      throw new ParseException('unclosed_token', $start, $cell, 'Token is missing a closing "]".');
     }
 
     $offset = $close + 1;

--- a/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
+++ b/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
@@ -331,20 +331,20 @@ final class EntityFieldParser implements EntityFieldParserInterface {
   protected function parseCompound(string $cell): array {
     $records = [];
     $errors = [];
-    $record_strings = $this->splitTopLevel($cell, ';');
 
-    foreach ($record_strings as $record) {
-      $record = trim($record);
+    foreach ($this->splitTopLevel($cell, ';') as $segment) {
+      $trimmed = trim($segment['text']);
 
-      if ($record === '') {
-        $errors[] = new ParseException('empty_record', 0, $cell, 'Empty compound record (consecutive ";" or trailing ";").');
+      if ($trimmed === '') {
+        $errors[] = new ParseException('empty_record', $segment['offset'], $cell, 'Empty compound record (consecutive ";" or trailing ";").');
 
         continue;
       }
 
+      $base_offset = $segment['offset'] + (strlen($segment['text']) - strlen(ltrim($segment['text'])));
+
       try {
-        $columns = $this->parseRecord($record, $cell);
-        $records[] = $columns;
+        $records[] = $this->parseRecord($trimmed, $cell, $base_offset);
       }
       catch (ParseException $e) {
         $errors[] = $e;
@@ -364,22 +364,24 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    * @return array<string, string>
    *   The parsed columns keyed by column name.
    */
-  protected function parseRecord(string $record, string $cell): array {
+  protected function parseRecord(string $record, string $cell, int $base_offset): array {
     $columns = [];
     $errors = [];
-    $column_strings = $this->splitTopLevel($record, ',');
 
-    foreach ($column_strings as $column) {
-      $column = trim($column);
+    foreach ($this->splitTopLevel($record, ',') as $segment) {
+      $absolute_offset = $base_offset + $segment['offset'];
+      $trimmed = trim($segment['text']);
 
-      if ($column === '') {
-        $errors[] = new ParseException('empty_column', 0, $cell, 'Empty compound column (consecutive "," or trailing ",").');
+      if ($trimmed === '') {
+        $errors[] = new ParseException('empty_column', $absolute_offset, $cell, 'Empty compound column (consecutive "," or trailing ",").');
 
         continue;
       }
 
+      $column_offset = $absolute_offset + (strlen($segment['text']) - strlen(ltrim($segment['text'])));
+
       try {
-        [$key, $value] = $this->parseColumn($column, $cell);
+        [$key, $value] = $this->parseColumn($trimmed, $cell, $column_offset);
         $columns[$key] = $value;
       }
       catch (ParseException $e) {
@@ -400,11 +402,11 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    * @return array{0: string, 1: string}
    *   [$key, $value]
    */
-  protected function parseColumn(string $column, string $cell): array {
+  protected function parseColumn(string $column, string $cell, int $base_offset): array {
     if (preg_match('/^([a-z_][a-z0-9_]*)\s*:\s*(.*)$/s', $column, $match) !== 1) {
       throw new ParseException(
         'invalid_column',
-        0,
+        $base_offset,
         $cell,
         sprintf('Compound column "%s" is not in "key: value" form.', $column),
         'Each compound column must look like "key: \"value\"" or "key: [token:value]".',
@@ -412,12 +414,16 @@ final class EntityFieldParser implements EntityFieldParserInterface {
     }
 
     $key = $match[1];
-    $value_raw = trim($match[2]);
+    $value_raw_with_ws = $match[2];
+    $value_raw = trim($value_raw_with_ws);
+    // The value position inside $cell: column start + length consumed up to
+    // the trimmed value's first character.
+    $value_offset = $base_offset + (strlen($column) - strlen($value_raw_with_ws)) + (strlen($value_raw_with_ws) - strlen(ltrim($value_raw_with_ws)));
 
     if ($value_raw === '') {
       throw new ParseException(
         'unquoted_compound_value',
-        0,
+        $value_offset,
         $cell,
         sprintf('Compound column "%s" has no value.', $key),
         'Add a quoted string ("...") or a token ([name:value]).',
@@ -426,10 +432,10 @@ final class EntityFieldParser implements EntityFieldParserInterface {
 
     if ($value_raw[0] === '"') {
       $offset = 0;
-      $value = $this->readQuotedString($value_raw, $offset);
+      $value = $this->readQuotedString($value_raw, $offset, $cell, $value_offset);
 
       if ($offset !== strlen($value_raw)) {
-        throw new ParseException('trailing_characters', 0, $cell, sprintf('Trailing characters after closing quote in column "%s".', $key));
+        throw new ParseException('trailing_characters', $value_offset + $offset, $cell, sprintf('Trailing characters after closing quote in column "%s".', $key));
       }
 
       return [$key, $value];
@@ -437,10 +443,10 @@ final class EntityFieldParser implements EntityFieldParserInterface {
 
     if ($value_raw[0] === '[') {
       $offset = 0;
-      $value = $this->readToken($value_raw, $offset);
+      $value = $this->readToken($value_raw, $offset, $cell, $value_offset);
 
       if ($offset !== strlen($value_raw)) {
-        throw new ParseException('trailing_characters', 0, $cell, sprintf('Trailing characters after closing token in column "%s".', $key));
+        throw new ParseException('trailing_characters', $value_offset + $offset, $cell, sprintf('Trailing characters after closing token in column "%s".', $key));
       }
 
       return [$key, $value];
@@ -448,7 +454,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
 
     throw new ParseException(
       'unquoted_compound_value',
-      0,
+      $value_offset,
       $cell,
       sprintf('Compound column "%s" must use a quoted string or token.', $key),
       'Wrap the value in double quotes or use a [token:value] form.',
@@ -460,8 +466,8 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    *
    * Skips matches inside '"..."' or '[...]'.
    *
-   * @return string[]
-   *   The string segments separated by the top-level separator.
+   * @return array<int, array{text: string, offset: int}>
+   *   Each entry is the segment text and its zero-based offset within $cell.
    */
   protected function splitTopLevel(string $cell, string $separator): array {
     $segments = [];
@@ -483,7 +489,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
       }
 
       if ($char === $separator) {
-        $segments[] = substr($cell, $start, $i - $start);
+        $segments[] = ['text' => substr($cell, $start, $i - $start), 'offset' => $start];
         $i++;
         $start = $i;
         continue;
@@ -492,7 +498,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
       $i++;
     }
 
-    $segments[] = substr($cell, $start);
+    $segments[] = ['text' => substr($cell, $start), 'offset' => $start];
 
     return $segments;
   }
@@ -543,23 +549,26 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    * Reads a '"..."' quoted string starting at the current offset.
    *
    * Advances $offset past the closing quote. Decodes the escapes \\, \",
-   * \n, \t, \r. Any other backslash sequence is a parse error.
+   * \n, \t, \r. Any other backslash sequence is a parse error. When called
+   * for cell-level diagnostics, $error_cell and $error_base_offset are used
+   * to report errors against the original cell rather than the fragment.
    */
-  protected function readQuotedString(string $cell, int &$offset): string {
-    $length = strlen($cell);
+  protected function readQuotedString(string $fragment, int &$offset, ?string $error_cell = NULL, int $error_base_offset = 0): string {
+    $error_cell ??= $fragment;
+    $length = strlen($fragment);
     $start = $offset;
     $offset++;
     $out = '';
 
     while ($offset < $length) {
-      $char = $cell[$offset];
+      $char = $fragment[$offset];
 
       if ($char === '\\') {
         if ($offset + 1 >= $length) {
-          throw new ParseException('unclosed_quote', $start, $cell, 'Quoted string ends with a dangling backslash.');
+          throw new ParseException('unclosed_quote', $error_base_offset + $start, $error_cell, 'Quoted string ends with a dangling backslash.');
         }
 
-        $next = $cell[$offset + 1];
+        $next = $fragment[$offset + 1];
         $decoded = match ($next) {
           '"' => '"',
           '\\' => '\\',
@@ -572,8 +581,8 @@ final class EntityFieldParser implements EntityFieldParserInterface {
         if ($decoded === NULL) {
           throw new ParseException(
             'unknown_escape',
-            $offset,
-            $cell,
+            $error_base_offset + $offset,
+            $error_cell,
             sprintf('Unknown escape sequence "\\%s".', $next),
             'Supported escapes are \\", \\\\, \\n, \\t, \\r.',
           );
@@ -597,8 +606,8 @@ final class EntityFieldParser implements EntityFieldParserInterface {
 
     throw new ParseException(
       'unclosed_quote',
-      $start,
-      $cell,
+      $error_base_offset + $start,
+      $error_cell,
       'Quoted string is missing a closing double quote.',
       'Add a closing double quote, or escape any inner quotes with \\".',
     );
@@ -608,19 +617,22 @@ final class EntityFieldParser implements EntityFieldParserInterface {
    * Reads a '[name:value]' token starting at the current offset.
    *
    * Advances $offset past the closing bracket and returns the verbatim
-   * '[...]' substring (downstream field handlers expand the token).
+   * '[...]' substring (downstream field handlers expand the token). When
+   * called for cell-level diagnostics, $error_cell and $error_base_offset
+   * are used to report errors against the original cell.
    */
-  protected function readToken(string $cell, int &$offset): string {
+  protected function readToken(string $fragment, int &$offset, ?string $error_cell = NULL, int $error_base_offset = 0): string {
+    $error_cell ??= $fragment;
     $start = $offset;
-    $close = strpos($cell, ']', $offset + 1);
+    $close = strpos($fragment, ']', $offset + 1);
 
     if ($close === FALSE) {
-      throw new ParseException('unclosed_token', $start, $cell, 'Token is missing a closing "]".');
+      throw new ParseException('unclosed_token', $error_base_offset + $start, $error_cell, 'Token is missing a closing "]".');
     }
 
     $offset = $close + 1;
 
-    return substr($cell, $start, $offset - $start);
+    return substr($fragment, $start, $offset - $start);
   }
 
 }

--- a/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
+++ b/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
@@ -70,7 +70,6 @@ final class EntityFieldParser implements EntityFieldParserInterface {
     $multicolumn_fields = [];
     $parsed = [];
     $errors = [];
-    $error_cell = '';
 
     foreach ($values as $field => $field_value) {
       $field = (string) $field;
@@ -98,7 +97,6 @@ final class EntityFieldParser implements EntityFieldParserInterface {
         }
         catch (ParseException $e) {
           $errors[] = $e;
-          $error_cell = (string) $field_value;
           continue;
         }
 
@@ -137,7 +135,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
     }
 
     if (count($errors) > 1) {
-      throw new MultipleParseException($errors, $error_cell);
+      throw new MultipleParseException($errors, $errors[0]->cell);
     }
 
     return $parsed;

--- a/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
+++ b/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
@@ -1,0 +1,684 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Parser;
+
+use Drupal\Driver\Core\Field\FieldClassifierInterface;
+use Drupal\DrupalExtension\Parser\Exception\MultipleParseException;
+use Drupal\DrupalExtension\Parser\Exception\ParseException;
+
+/**
+ * Modern entity-field parser.
+ *
+ * Implements a syntax with a single uniform escape mechanism (double
+ * quotes) for compound values. Cells fall into two modes detected by the
+ * value form, not by the spacing of separators:
+ *
+ *   Scalar mode (no top-level 'key:"...' or 'key:[...]' pattern):
+ *     - Plain text or comma-separated list of items.
+ *     - Items containing ',' or ';' or '"' must be wrapped in '"..."'.
+ *
+ *   Compound mode (top-level 'key:"...' or 'key:[...]' pattern present):
+ *     - One or more 'key: value' columns separated by ','.
+ *     - Multi-value compound: records separated by ';'.
+ *     - Each column value MUST be a quoted string ('"..."') or token
+ *       ('[name:value]'). Bare values are a parse error.
+ *     - Inside '"..."': '\"' '\\' '\n' '\t' '\r' are recognised escape
+ *       sequences; any other backslash sequence is an error.
+ *
+ * Whitespace around ',', ';' and ':' is ignored outside quoted strings
+ * and tokens. Whitespace inside '"..."' is preserved literally.
+ *
+ * Errors detected while parsing a single cell are collected and thrown
+ * together via 'MultipleParseException' so authors see every problem at
+ * once instead of fixing them one at a time.
+ */
+final class EntityFieldParser implements EntityFieldParserInterface {
+
+  /**
+   * Property names accepted without field-type validation.
+   *
+   * @var string[]
+   */
+  private array $ignoredProperties = [];
+
+  /**
+   * Constructs the parser for one entity-type / classifier pairing.
+   */
+  public function __construct(
+    private readonly string $entityType,
+    private readonly FieldClassifierInterface $fieldClassifier,
+  ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function ignoring(array $properties): static {
+    $this->ignoredProperties = $properties;
+
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function parse(array $values): array {
+    $multicolumn_field = '';
+    $multicolumn_column = '';
+    $multicolumn_fields = [];
+    $parsed = [];
+    $errors = [];
+    $error_cell = '';
+
+    foreach ($values as $field => $field_value) {
+      $field = (string) $field;
+
+      if (!str_contains($field, ':')) {
+        $multicolumn_field = '';
+        $multicolumn_column = '';
+      }
+      elseif (str_contains(substr($field, 1), ':')) {
+        [$multicolumn_field, $multicolumn_column] = explode(':', $field);
+      }
+      elseif (empty($multicolumn_field)) {
+        throw new \RuntimeException('Field name missing for ' . $field);
+      }
+      else {
+        $multicolumn_column = substr($field, 1);
+      }
+
+      $is_multicolumn = $multicolumn_field !== '' && $multicolumn_column !== '';
+      $field_name = $multicolumn_field !== '' ? $multicolumn_field : $field;
+
+      if ($this->fieldClassifier->fieldIsConfigurable($this->entityType, $field_name)) {
+        try {
+          $records = $this->parseCell((string) $field_value, $is_multicolumn);
+        }
+        catch (ParseException $e) {
+          $errors[] = $e;
+          $error_cell = (string) $field_value;
+          continue;
+        }
+
+        if ($is_multicolumn) {
+          foreach ($records as $key => $columns) {
+            $multicolumn_fields[$multicolumn_field][$key][$multicolumn_column] = $columns;
+          }
+        }
+        elseif ($field_value === '' || $field_value === NULL) {
+          unset($parsed[$field_name]);
+        }
+        else {
+          $parsed[$field_name] = $records;
+        }
+      }
+      else {
+        $is_base_field = $this->fieldClassifier->fieldIsBaseStandard($this->entityType, $field_name)
+          || $this->fieldClassifier->fieldIsBaseComputedReadOnly($this->entityType, $field_name)
+          || $this->fieldClassifier->fieldIsBaseComputedWritable($this->entityType, $field_name)
+          || $this->fieldClassifier->fieldIsBaseCustomStorage($this->entityType, $field_name);
+
+        if (!$is_base_field && !in_array($field_name, $this->ignoredProperties, TRUE)) {
+          throw new \RuntimeException(sprintf('Field "%s" does not exist on entity type "%s".', $field_name, $this->entityType));
+        }
+
+        $parsed[$field] = $field_value;
+      }
+    }
+
+    foreach ($multicolumn_fields as $field_name => $columns) {
+      $parsed[$field_name] = $columns;
+    }
+
+    if (count($errors) === 1) {
+      throw $errors[0];
+    }
+
+    if (count($errors) > 1) {
+      throw new MultipleParseException($errors, $error_cell);
+    }
+
+    return $parsed;
+  }
+
+  /**
+   * Parses a single cell value into a list of records.
+   *
+   * @return array<int, mixed>
+   *   The parsed records.
+   *
+   * @throws \Drupal\DrupalExtension\Parser\Exception\ParseException
+   *   On any cell-level parse error.
+   */
+  private function parseCell(string $cell, bool $is_multicolumn): array {
+    $trimmed = trim($cell);
+
+    if ($trimmed === '') {
+      return [''];
+    }
+
+    if (!$is_multicolumn && $this->detectCompoundMode($trimmed)) {
+      return $this->parseCompound($trimmed);
+    }
+
+    return $this->parseScalarList($trimmed);
+  }
+
+  /**
+   * Returns TRUE when the cell is in compound mode.
+   *
+   * Compound mode is detected by the presence of a top-level
+   * 'key:"...' or 'key:[...]' pattern - i.e. an identifier, optional
+   * whitespace, ':', optional whitespace, then '"' or '[' - with the
+   * scan respecting quoted strings and bracketed tokens so an embedded
+   * pattern inside a quoted scalar does not trigger compound mode.
+   */
+  private function detectCompoundMode(string $cell): bool {
+    $length = strlen($cell);
+    $i = 0;
+
+    while ($i < $length) {
+      $char = $cell[$i];
+
+      if ($char === '"') {
+        $i = $this->skipQuotedString($cell, $i);
+        continue;
+      }
+
+      if ($char === '[') {
+        $i = $this->skipToken($cell, $i);
+        continue;
+      }
+
+      if (preg_match('/[a-z_][a-z0-9_]*/A', $cell, $match, 0, $i) === 1) {
+        $j = $i + strlen($match[0]);
+
+        while ($j < $length && ($cell[$j] === ' ' || $cell[$j] === "\t")) {
+          $j++;
+        }
+
+        if ($j < $length && $cell[$j] === ':') {
+          $j++;
+
+          while ($j < $length && ($cell[$j] === ' ' || $cell[$j] === "\t")) {
+            $j++;
+          }
+
+          if ($j < $length && ($cell[$j] === '"' || $cell[$j] === '[')) {
+            return TRUE;
+          }
+        }
+
+        $i += strlen($match[0]);
+        continue;
+      }
+
+      $i++;
+    }
+
+    return FALSE;
+  }
+
+  /**
+   * Parses a scalar list (comma-separated, optional double-quote escape).
+   *
+   * @return array<int, string>
+   *   The parsed list of scalar items.
+   */
+  private function parseScalarList(string $cell): array {
+    $items = [];
+    $length = strlen($cell);
+    $i = 0;
+    $errors = [];
+
+    while ($i <= $length) {
+      while ($i < $length && ($cell[$i] === ' ' || $cell[$i] === "\t")) {
+        $i++;
+      }
+
+      if ($i >= $length) {
+        $items[] = '';
+        break;
+      }
+
+      if ($cell[$i] === '"') {
+        $start = $i;
+
+        try {
+          $value = $this->readQuotedString($cell, $i);
+          $items[] = $value;
+        }
+        catch (ParseException $e) {
+          $errors[] = $e;
+          $i = $length;
+          break;
+        }
+
+        while ($i < $length && ($cell[$i] === ' ' || $cell[$i] === "\t")) {
+          $i++;
+        }
+
+        if ($i < $length && $cell[$i] !== ',') {
+          $errors[] = new ParseException(
+            'unexpected_character',
+            $i,
+            $cell,
+            sprintf('Expected "," or end of value after closing quote, found "%s".', $cell[$i]),
+            'Quote the entire scalar item or remove the stray character.',
+          );
+          $i = $length;
+          break;
+        }
+      }
+      else {
+        $start = $i;
+
+        while ($i < $length && $cell[$i] !== ',' && $cell[$i] !== ';' && $cell[$i] !== '"') {
+          $i++;
+        }
+
+        $raw = substr($cell, $start, $i - $start);
+        $value = rtrim($raw, " \t");
+
+        if ($i < $length && $cell[$i] === ';') {
+          $errors[] = new ParseException(
+            'unquoted_semicolon',
+            $i,
+            $cell,
+            'Semicolons are not allowed in unquoted scalar values.',
+            sprintf('Wrap the value in double quotes: "%s".', $raw),
+          );
+          $i = $length;
+          break;
+        }
+
+        if ($i < $length && $cell[$i] === '"') {
+          $errors[] = new ParseException(
+            'unexpected_quote',
+            $i,
+            $cell,
+            'Unexpected double quote inside an unquoted scalar value.',
+            'Wrap the entire item in double quotes if it contains a literal quote, then escape inner quotes as \\".',
+          );
+          $i = $length;
+          break;
+        }
+
+        $items[] = $value;
+      }
+
+      if ($i >= $length) {
+        break;
+      }
+
+      // $cell[$i] is now ','
+      $i++;
+
+      if ($i >= $length) {
+        $items[] = '';
+        break;
+      }
+    }
+
+    if ($errors !== []) {
+      throw $errors[0];
+    }
+
+    return $items;
+  }
+
+  /**
+   * Parses a compound value: records separated by ';', columns by ','.
+   *
+   * @return array<int, array<string, string>>
+   *   The parsed list of compound records.
+   */
+  private function parseCompound(string $cell): array {
+    $records = [];
+    $errors = [];
+    $record_strings = $this->splitTopLevel($cell, ';');
+
+    foreach ($record_strings as $record) {
+      $record = trim($record);
+
+      if ($record === '') {
+        $errors[] = new ParseException(
+          'empty_record',
+          0,
+          $cell,
+          'Empty compound record (consecutive ";" or trailing ";").',
+        );
+
+        continue;
+      }
+
+      try {
+        $columns = $this->parseRecord($record, $cell);
+        $records[] = $columns;
+      }
+      catch (ParseException $e) {
+        $errors[] = $e;
+      }
+    }
+
+    if ($errors !== []) {
+      throw count($errors) === 1 ? $errors[0] : new MultipleParseException($errors, $cell);
+    }
+
+    return $records;
+  }
+
+  /**
+   * Parses one compound record (','-separated columns) into a key/value map.
+   *
+   * @return array<string, string>
+   *   The parsed columns keyed by column name.
+   */
+  private function parseRecord(string $record, string $cell): array {
+    $columns = [];
+    $errors = [];
+    $column_strings = $this->splitTopLevel($record, ',');
+
+    foreach ($column_strings as $column) {
+      $column = trim($column);
+
+      if ($column === '') {
+        $errors[] = new ParseException(
+          'empty_column',
+          0,
+          $cell,
+          'Empty compound column (consecutive "," or trailing ",").',
+        );
+
+        continue;
+      }
+
+      try {
+        [$key, $value] = $this->parseColumn($column, $cell);
+        $columns[$key] = $value;
+      }
+      catch (ParseException $e) {
+        $errors[] = $e;
+      }
+    }
+
+    if ($errors !== []) {
+      throw count($errors) === 1 ? $errors[0] : new MultipleParseException($errors, $cell);
+    }
+
+    return $columns;
+  }
+
+  /**
+   * Parses one 'key: value' column.
+   *
+   * @return array{0: string, 1: string}
+   *   [$key, $value]
+   */
+  private function parseColumn(string $column, string $cell): array {
+    if (preg_match('/^([a-z_][a-z0-9_]*)\s*:\s*(.*)$/s', $column, $match) !== 1) {
+      throw new ParseException(
+        'invalid_column',
+        0,
+        $cell,
+        sprintf('Compound column "%s" is not in "key: value" form.', $column),
+        'Each compound column must look like "key: \"value\"" or "key: [token:value]".',
+      );
+    }
+
+    $key = $match[1];
+    $value_raw = trim($match[2]);
+
+    if ($value_raw === '') {
+      throw new ParseException(
+        'unquoted_compound_value',
+        0,
+        $cell,
+        sprintf('Compound column "%s" has no value.', $key),
+        'Add a quoted string ("...") or a token ([name:value]).',
+      );
+    }
+
+    if ($value_raw[0] === '"') {
+      $offset = 0;
+      $value = $this->readQuotedString($value_raw, $offset);
+
+      if ($offset !== strlen($value_raw)) {
+        throw new ParseException(
+          'trailing_characters',
+          0,
+          $cell,
+          sprintf('Trailing characters after closing quote in column "%s".', $key),
+        );
+      }
+
+      return [$key, $value];
+    }
+
+    if ($value_raw[0] === '[') {
+      $offset = 0;
+      $value = $this->readToken($value_raw, $offset);
+
+      if ($offset !== strlen($value_raw)) {
+        throw new ParseException(
+          'trailing_characters',
+          0,
+          $cell,
+          sprintf('Trailing characters after closing token in column "%s".', $key),
+        );
+      }
+
+      return [$key, $value];
+    }
+
+    throw new ParseException(
+      'unquoted_compound_value',
+      0,
+      $cell,
+      sprintf('Compound column "%s" must use a quoted string or token.', $key),
+      'Wrap the value in double quotes or use a [token:value] form.',
+    );
+  }
+
+  /**
+   * Splits a string on a top-level separator character.
+   *
+   * Skips matches inside '"..."' or '[...]'.
+   *
+   * @return string[]
+   *   The string segments separated by the top-level separator.
+   */
+  private function splitTopLevel(string $cell, string $separator): array {
+    $segments = [];
+    $length = strlen($cell);
+    $i = 0;
+    $start = 0;
+
+    while ($i < $length) {
+      $char = $cell[$i];
+
+      if ($char === '"') {
+        $i = $this->skipQuotedString($cell, $i);
+        continue;
+      }
+
+      if ($char === '[') {
+        $i = $this->skipToken($cell, $i);
+        continue;
+      }
+
+      if ($char === $separator) {
+        $segments[] = substr($cell, $start, $i - $start);
+        $i++;
+        $start = $i;
+        continue;
+      }
+
+      $i++;
+    }
+
+    $segments[] = substr($cell, $start);
+
+    return $segments;
+  }
+
+  /**
+   * Advances past a '"..."' quoted string, returning the index after the close.
+   *
+   * Matches the same escape grammar as 'readQuotedString()'. If the string
+   * is unterminated returns the cell length.
+   */
+  private function skipQuotedString(string $cell, int $i): int {
+    $length = strlen($cell);
+    $i++;
+
+    while ($i < $length) {
+      if ($cell[$i] === '\\' && $i + 1 < $length) {
+        $i += 2;
+        continue;
+      }
+
+      if ($cell[$i] === '"') {
+        return $i + 1;
+      }
+
+      $i++;
+    }
+
+    return $length;
+  }
+
+  /**
+   * Advances past a '[...]' token, returning the index after the close.
+   *
+   * If the token is unterminated returns the cell length.
+   */
+  private function skipToken(string $cell, int $i): int {
+    $length = strlen($cell);
+    $close = strpos($cell, ']', $i + 1);
+
+    if ($close === FALSE) {
+      return $length;
+    }
+
+    return $close + 1;
+  }
+
+  /**
+   * Reads a '"..."' quoted string starting at the current offset.
+   *
+   * Advances $offset past the closing quote. Decodes the escapes \\, \",
+   * \n, \t, \r. Any other backslash sequence is a parse error.
+   */
+  private function readQuotedString(string $cell, int &$offset): string {
+    $length = strlen($cell);
+    $start = $offset;
+
+    if ($offset >= $length || $cell[$offset] !== '"') {
+      throw new ParseException(
+        'expected_quoted_string',
+        $offset,
+        $cell,
+        'Expected a quoted string.',
+      );
+    }
+
+    $offset++;
+    $out = '';
+
+    while ($offset < $length) {
+      $char = $cell[$offset];
+
+      if ($char === '\\') {
+        if ($offset + 1 >= $length) {
+          throw new ParseException(
+            'unclosed_quote',
+            $start,
+            $cell,
+            'Quoted string ends with a dangling backslash.',
+          );
+        }
+
+        $next = $cell[$offset + 1];
+        $decoded = match ($next) {
+          '"' => '"',
+          '\\' => '\\',
+          'n' => "\n",
+          't' => "\t",
+          'r' => "\r",
+          default => NULL,
+        };
+
+        if ($decoded === NULL) {
+          throw new ParseException(
+            'unknown_escape',
+            $offset,
+            $cell,
+            sprintf('Unknown escape sequence "\\%s".', $next),
+            'Supported escapes are \\", \\\\, \\n, \\t, \\r.',
+          );
+        }
+
+        $out .= $decoded;
+        $offset += 2;
+
+        continue;
+      }
+
+      if ($char === '"') {
+        $offset++;
+
+        return $out;
+      }
+
+      $out .= $char;
+      $offset++;
+    }
+
+    throw new ParseException(
+      'unclosed_quote',
+      $start,
+      $cell,
+      'Quoted string is missing a closing double quote.',
+      'Add a closing double quote, or escape any inner quotes with \\".',
+    );
+  }
+
+  /**
+   * Reads a '[name:value]' token starting at the current offset.
+   *
+   * Advances $offset past the closing bracket and returns the verbatim
+   * '[...]' substring (downstream field handlers expand the token).
+   */
+  private function readToken(string $cell, int &$offset): string {
+    $length = strlen($cell);
+    $start = $offset;
+
+    if ($offset >= $length || $cell[$offset] !== '[') {
+      throw new ParseException(
+        'expected_token',
+        $offset,
+        $cell,
+        'Expected a [name:value] token.',
+      );
+    }
+
+    $close = strpos($cell, ']', $offset + 1);
+
+    if ($close === FALSE) {
+      throw new ParseException(
+        'unclosed_token',
+        $start,
+        $cell,
+        'Token is missing a closing "]".',
+      );
+    }
+
+    $offset = $close + 1;
+
+    return substr($cell, $start, $offset - $start);
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Parser/Exception/MultipleParseException.php
+++ b/src/Drupal/DrupalExtension/Parser/Exception/MultipleParseException.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Parser\Exception;
+
+/**
+ * Container for multiple parse errors detected in a single cell.
+ *
+ * Parsers collect all errors detected in one cell before throwing, so the
+ * test author sees every problem at once instead of fixing one, re-running,
+ * and discovering the next.
+ */
+class MultipleParseException extends ParseException {
+
+  /**
+   * Wraps multiple parse errors detected in a single cell.
+   *
+   * @param ParseException[] $errors
+   *   The individual parse errors. Must contain at least one entry.
+   * @param string $cell
+   *   The cell value being parsed when the errors were collected.
+   * @param \Throwable|null $previous
+   *   Optional previous throwable for chaining.
+   */
+  public function __construct(
+    public readonly array $errors,
+    string $cell,
+    ?\Throwable $previous = NULL,
+  ) {
+    if ($errors === []) {
+      throw new \InvalidArgumentException('MultipleParseException requires at least one error.');
+    }
+
+    $first = $errors[0];
+
+    parent::__construct(
+      $first->errorCode,
+      $first->offset,
+      $cell,
+      $this->buildDescription($errors),
+      NULL,
+      $previous,
+    );
+  }
+
+  /**
+   * Builds a single-line description summarising the wrapped errors.
+   *
+   * @param ParseException[] $errors
+   *   The wrapped errors.
+   */
+  protected function buildDescription(array $errors): string {
+    $count = count($errors);
+
+    if ($count === 1) {
+      return $errors[0]->description;
+    }
+
+    $codes = array_map(fn(ParseException $error): string => $error->errorCode, $errors);
+
+    return sprintf('%d parse errors: %s', $count, implode(', ', $codes));
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Parser/Exception/MultipleParseException.php
+++ b/src/Drupal/DrupalExtension/Parser/Exception/MultipleParseException.php
@@ -23,25 +23,14 @@ class MultipleParseException extends ParseException {
    * @param \Throwable|null $previous
    *   Optional previous throwable for chaining.
    */
-  public function __construct(
-    public readonly array $errors,
-    string $cell,
-    ?\Throwable $previous = NULL,
-  ) {
+  public function __construct(public readonly array $errors, string $cell, ?\Throwable $previous = NULL) {
     if ($errors === []) {
       throw new \InvalidArgumentException('MultipleParseException requires at least one error.');
     }
 
     $first = $errors[0];
 
-    parent::__construct(
-      $first->errorCode,
-      $first->offset,
-      $cell,
-      $this->buildDescription($errors),
-      NULL,
-      $previous,
-    );
+    parent::__construct($first->errorCode, $first->offset, $cell, $this->buildDescription($errors), NULL, $previous);
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Parser/Exception/ParseException.php
+++ b/src/Drupal/DrupalExtension/Parser/Exception/ParseException.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Parser\Exception;
+
+/**
+ * Single parse error with position-aware information.
+ *
+ * Carries:
+ *   - A machine-readable error code (e.g. 'unclosed_quote').
+ *   - The zero-based character offset within the parsed cell.
+ *   - The cell text being parsed and a caret pointer underneath.
+ *   - A human-readable message and an optional suggested fix.
+ *
+ * The exception message returned by 'getMessage()' is a multi-line string
+ * containing the cell, a caret line, and a description; suitable for
+ * surfacing directly in a Behat run.
+ */
+class ParseException extends \RuntimeException {
+
+  public function __construct(
+    public readonly string $errorCode,
+    public readonly int $offset,
+    public readonly string $cell,
+    public readonly string $description,
+    public readonly ?string $hint = NULL,
+    ?\Throwable $previous = NULL,
+  ) {
+    parent::__construct($this->buildMessage(), 0, $previous);
+  }
+
+  /**
+   * Builds the multi-line, human-readable exception message.
+   */
+  protected function buildMessage(): string {
+    $caret = str_repeat(' ', max(0, $this->offset)) . '^';
+    $lines = [
+      $this->cell,
+      $caret,
+      sprintf('%s at offset %d: %s', $this->errorCode, $this->offset, $this->description),
+    ];
+
+    if ($this->hint !== NULL && $this->hint !== '') {
+      $lines[] = 'Hint: ' . $this->hint;
+    }
+
+    return implode("\n", $lines);
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Parser/Exception/ParseException.php
+++ b/src/Drupal/DrupalExtension/Parser/Exception/ParseException.php
@@ -35,11 +35,7 @@ class ParseException extends \RuntimeException {
    */
   protected function buildMessage(): string {
     $caret = str_repeat(' ', max(0, $this->offset)) . '^';
-    $lines = [
-      $this->cell,
-      $caret,
-      sprintf('%s at offset %d: %s', $this->errorCode, $this->offset, $this->description),
-    ];
+    $lines = [$this->cell, $caret, sprintf('%s at offset %d: %s', $this->errorCode, $this->offset, $this->description)];
 
     if ($this->hint !== NULL && $this->hint !== '') {
       $lines[] = 'Hint: ' . $this->hint;

--- a/src/Drupal/DrupalExtension/Parser/LegacyEntityFieldParser.php
+++ b/src/Drupal/DrupalExtension/Parser/LegacyEntityFieldParser.php
@@ -83,14 +83,14 @@ final class LegacyEntityFieldParser implements EntityFieldParserInterface {
    *
    * @var string[]
    */
-  private array $ignoredProperties = [];
+  protected array $ignoredProperties = [];
 
   /**
    * Constructs the parser for one entity-type / classifier pairing.
    */
   public function __construct(
-    private readonly string $entityType,
-    private readonly FieldClassifierInterface $fieldClassifier,
+    protected readonly string $entityType,
+    protected readonly FieldClassifierInterface $fieldClassifier,
   ) {
   }
 

--- a/src/Drupal/DrupalExtension/Parser/README.md
+++ b/src/Drupal/DrupalExtension/Parser/README.md
@@ -1,0 +1,87 @@
+# Entity-field parsers
+
+This namespace contains the parsers used by `RawDrupalContext::parseEntityFields()` to convert raw stub field values into Drupal-ready structured arrays.
+
+Two implementations live here:
+
+- `EntityFieldParser` - the current parser. Default at runtime.
+- `LegacyEntityFieldParser` - the previous parser, kept available behind the `field_parser: legacy` extension parameter for migration. Frozen and scheduled for removal in 6.1.
+
+Both implement `EntityFieldParserInterface` and own everything between the raw stub map and the final stub map: textual parsing, `field:column` / `:column` multicolumn-header merging, configurable / base / ignored field validation, and the unknown-field guard. The context layer just chooses an instance and delegates.
+
+## Modern syntax
+
+A single uniform escape mechanism (double quotes) for compound values. Cells fall into two modes detected by the value form, not by the spacing of separators:
+
+- **Scalar mode** (no top-level `key:"...` or `key:[...]` pattern):
+  - Plain text or comma-separated list of items.
+  - Items containing `,` or `;` or `"` must be wrapped in `"..."`.
+- **Compound mode** (top-level `key:"...` or `key:[...]` pattern present):
+  - One or more `key: value` columns separated by `,`.
+  - Multi-value compound: records separated by `;`.
+  - Each column value MUST be a quoted string (`"..."`) or token (`[name:value]`). Bare values are a parse error.
+  - Inside `"..."`: `\"`, `\\`, `\n`, `\t`, `\r` are recognised escape sequences; any other backslash sequence is an error.
+
+Whitespace around `,`, `;` and `:` is ignored outside quoted strings and tokens. Whitespace inside `"..."` is preserved literally.
+
+Errors detected while parsing a single cell are collected and thrown together via `MultipleParseException` so authors see every problem at once instead of fixing them one at a time.
+
+## Validity table
+
+| #  | Value type                               | Field type example       | Modern syntax                                                          |
+|----|------------------------------------------|--------------------------|------------------------------------------------------------------------|
+| 1  | scalar, single                           | string / integer / email | `Hello`                                                                |
+| 2  | scalar, single, contains `:`             | text_long                | `Note: this is important`                                              |
+| 3  | scalar, single, contains `,`             | text_long                | `"Hello, world"`                                                       |
+| 4  | scalar, single, contains ` - `           | entity_reference title   | `Alpha - Bravo`                                                        |
+| 5  | scalar, single, contains `;`             | text_long                | `"Hello; world"`                                                       |
+| 6  | scalar, looks like `key:value`           | string                   | `port:8080`                                                            |
+| 7  | scalar, multi-value                      | string / list            | `Tag one, Tag two`                                                     |
+| 8  | scalar, multi-value, item contains `,`   | string                   | `Tag one, "Tag, two"`                                                  |
+| 9  | token, single                            | datetime relative        | `[relative:-1 week]`                                                   |
+| 10 | token, multi                             | datetime relative        | `[relative:-1 week], [relative:-2 weeks]`                              |
+| 11 | token in scalar prose                    | text_long                | `Posted [relative:-1 week] ago`                                        |
+| 12 | token at compound value position         | daterange                | `value:[relative:-1 week], end_value:[relative:+1 week]`               |
+| 13 | compound named, single                   | text_with_summary        | `value:"Body", summary:"Summary", format:"basic_html"`                 |
+| 14 | compound named, single                   | address                  | `country:"BE", locality:"Brussel", postal_code:"1000"`                 |
+| 15 | compound named, single                   | daterange                | `value:"2026-01-01", end_value:"2026-12-31"`                           |
+| 16 | compound named, single                   | file / image             | `target_id:"foo.jpg", alt:"A", title:"B"`                              |
+| 17 | compound named, value contains `,`       | address                  | `country:"BE", locality:"Brussel, X", postal_code:"1000"`              |
+| 18 | compound named, value contains `:`       | address                  | `street:"Main: 1", country:"BE"`                                       |
+| 19 | compound named, value contains `;`       | address                  | `street:"A;B", country:"BE"`                                           |
+| 20 | compound named, value contains escaped `"` | text                   | `note:"He said \"hi\""`                                                |
+| 21 | compound named, multi                    | address                  | `country:"BE", locality:"Brussel"; country:"FR", locality:"Paris"`     |
+| 22 | compound named, multi                    | link                     | `title:"Link 1", uri:"http://a"; title:"Link 2", uri:"http://b"`       |
+| 23 | compound positional, single              | link                     | not supported - use named keys                                         |
+| 24 | compound positional, multi               | link                     | not supported - use named keys                                         |
+| 25 | nested compound                          | paragraphs               | not supported inline - use multicolumn header rows                     |
+| 26 | external multicolumn header              | any                      | `field:col` row + `:col` rows merged into one canonical field          |
+| 27 | whitespace tolerance                     | any                      | compact and spaced forms both accepted                                 |
+
+## Configuration
+
+Selected via the `field_parser` extension parameter in `behat.yml`:
+
+```yaml
+default:
+  extensions:
+    Drupal\DrupalExtension:
+      field_parser: default   # one of: default | legacy
+```
+
+`legacy` is opt-in and emits a deprecation notice once per process. It is removed in 6.1.
+
+## Errors
+
+Parse errors thrown by the modern parser carry:
+
+- `errorCode` - machine-readable identifier (`unclosed_quote`, `unknown_escape`, `unquoted_compound_value`, `empty_record`, `empty_column`, `unclosed_token`, `unquoted_semicolon`, `unexpected_quote`, `unexpected_character`, `expected_quoted_string`, `expected_token`, `trailing_characters`, `invalid_column`).
+- `offset` - zero-based character offset within the cell.
+- `cell` - the cell text being parsed.
+- `description` and optional `hint` - human-readable explanation.
+
+`getMessage()` returns a multi-line string with the cell, a caret line at the offset, and the description, suitable for surfacing directly in a Behat run. `MultipleParseException` collects multiple per-cell errors so authors can fix them all in one edit.
+
+## Migration
+
+See [`MIGRATION.md`](../../../../../MIGRATION.md) for the side-by-side syntax mapping, positional-to-named conversion table, escape sequences, and parse-error format.

--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -97,6 +97,11 @@ class DrupalExtension implements ExtensionInterface {
         ->scalarNode('drush_driver')
           ->defaultValue('drush')
         ->end()
+        ->enumNode('field_parser')
+          ->values(['default', 'legacy'])
+          ->defaultValue('default')
+          ->info('Selects the field-value parser used by parseEntityFields(). "default" uses the current syntax; "legacy" opts in to the older syntax (deprecated, removed in 6.1).')
+        ->end()
         ->arrayNode('region_map')
           ->info("Targeting content in specific regions can be accomplished once those regions have been defined." . PHP_EOL
             . '  My region: "#css-selector"' . PHP_EOL

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -142,16 +142,15 @@ EOL;
     unset($yaml['default']['suites']['default']['paths']);
 
     // Find the BehatCliContext and remove it from the contexts list.
-    foreach (['default', 'drupal', 'drupal_legacy_parser'] as $profile) {
-      if (!isset($yaml[$profile]['suites']['default']['contexts'])) {
-        continue;
-      }
+    $index = array_search('BehatCliContext', $yaml['default']['suites']['default']['contexts'], TRUE);
+    if ($index !== FALSE) {
+      unset($yaml['default']['suites']['default']['contexts'][$index]);
+    }
 
-      $index = array_search('BehatCliContext', $yaml[$profile]['suites']['default']['contexts'], TRUE);
-
-      if ($index !== FALSE) {
-        unset($yaml[$profile]['suites']['default']['contexts'][$index]);
-      }
+    // Find the BehatCliContext and remove it from the contexts list.
+    $index = array_search('BehatCliContext', $yaml['drupal']['suites']['default']['contexts'], TRUE);
+    if ($index !== FALSE) {
+      unset($yaml['drupal']['suites']['default']['contexts'][$index]);
     }
 
     if (static::behatCliIsCoverageEnabled()) {
@@ -190,7 +189,7 @@ EOL;
     $project_root = dirname($source);
     $drush_binary = $project_root . '/vendor/bin/drush';
     if (file_exists($drush_binary)) {
-      foreach (['default', 'drupal', 'drupal_https', 'drupal_legacy_parser'] as $profile) {
+      foreach (['default', 'drupal', 'drupal_https'] as $profile) {
         if (isset($yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush'])) {
           $yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush']['binary'] = $drush_binary;
         }
@@ -205,6 +204,20 @@ EOL;
     if (static::behatCliIsDebug()) {
       static::behatCliPrintFileContents($this->workingDir . DIRECTORY_SEPARATOR . $filename, 'Behat Config (copied)');
     }
+  }
+
+  /**
+   * Sets 'field_parser: legacy' on the drupal profile in the subprocess config.
+   *
+   * Use after 'Given some behat configuration' to exercise the legacy
+   * field-value parser inside a Behat subprocess invocation.
+   */
+  #[Given('the behat configuration uses the legacy field parser')]
+  public function behatCliUseLegacyFieldParser(): void {
+    $config_file = $this->workingDir . DIRECTORY_SEPARATOR . 'behat.yml';
+    $yaml = Yaml::parse((string) file_get_contents($config_file));
+    $yaml['drupal']['extensions']['Drupal\DrupalExtension']['field_parser'] = 'legacy';
+    file_put_contents($config_file, Yaml::dump($yaml, 4, 2));
   }
 
   /**

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -142,15 +142,16 @@ EOL;
     unset($yaml['default']['suites']['default']['paths']);
 
     // Find the BehatCliContext and remove it from the contexts list.
-    $index = array_search('BehatCliContext', $yaml['default']['suites']['default']['contexts'], TRUE);
-    if ($index !== FALSE) {
-      unset($yaml['default']['suites']['default']['contexts'][$index]);
-    }
+    foreach (['default', 'drupal', 'drupal_legacy_parser'] as $profile) {
+      if (!isset($yaml[$profile]['suites']['default']['contexts'])) {
+        continue;
+      }
 
-    // Find the BehatCliContext and remove it from the contexts list.
-    $index = array_search('BehatCliContext', $yaml['drupal']['suites']['default']['contexts'], TRUE);
-    if ($index !== FALSE) {
-      unset($yaml['drupal']['suites']['default']['contexts'][$index]);
+      $index = array_search('BehatCliContext', $yaml[$profile]['suites']['default']['contexts'], TRUE);
+
+      if ($index !== FALSE) {
+        unset($yaml[$profile]['suites']['default']['contexts'][$index]);
+      }
     }
 
     if (static::behatCliIsCoverageEnabled()) {
@@ -189,7 +190,7 @@ EOL;
     $project_root = dirname($source);
     $drush_binary = $project_root . '/vendor/bin/drush';
     if (file_exists($drush_binary)) {
-      foreach (['default', 'drupal', 'drupal_https'] as $profile) {
+      foreach (['default', 'drupal', 'drupal_https', 'drupal_legacy_parser'] as $profile) {
         if (isset($yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush'])) {
           $yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush']['binary'] = $drush_binary;
         }

--- a/tests/behat/features/field_handlers_legacy.feature
+++ b/tests/behat/features/field_handlers_legacy.feature
@@ -5,7 +5,7 @@ Feature: FieldHandlers
 
   # Drupal scenarios assume a "standard" install of Drupal and require the
   # feature "fixtures/drupalN/modules/behat_test" to enabled on the site.
-  @test-drupal @api
+  @test-drupal @api @test-legacy-parser
   Scenario: Test various node field handlers
     Given the following "page" content:
       | title      |
@@ -13,13 +13,13 @@ Feature: FieldHandlers
       | Page two   |
       | Page three |
     When I am viewing a "post" content with the following fields:
-      | title                | Post title                                                                            |
-      | body                 | PLACEHOLDER BODY                                                                      |
-      | field_post_reference | Page one, Page two                                                                    |
-      | field_post_date      | 2015-02-08 17:45:00                                                                   |
-      | field_post_links     | title:"Link 1", uri:"http://example.com"; title:"Link 2", uri:"http://example.com"    |
-      | field_post_select    | Select value one, Select value two                                                    |
-      | field_post_address   | country:"BE", locality:"Brussel", thoroughfare:"Louisalaan 1", postal_code:"1000"     |
+      | title                | Post title                                                                       |
+      | body                 | PLACEHOLDER BODY                                                                 |
+      | field_post_reference | Page one, Page two                                                               |
+      | field_post_date      | 2015-02-08 17:45:00                                                              |
+      | field_post_links     | Link 1 - http://example.com, Link 2 - http://example.com                         |
+      | field_post_select    | Select value one, Select value two                                               |
+      | field_post_address   | country: BE - locality: Brussel - thoroughfare: Louisalaan 1 - postal_code: 1000 |
     Then I should see "Post title"
     And I should see "PLACEHOLDER BODY"
     And I should see "Page one"
@@ -35,19 +35,44 @@ Feature: FieldHandlers
     And I should see "1000"
     And I should see "Louisalaan 1"
 
-  # Entity reference titles containing ' - ' no longer need any escape under
-  # the modern parser - dashes are just literal characters in scalar mode.
-  @test-drupal @api
-  Scenario: Test entity reference with literal dash in title
+  # Entity reference values containing ' - ' must be double-quoted to prevent
+  # the compound column separator from splitting them.
+  @test-drupal @api @test-legacy-parser
+  Scenario: Test entity reference with compound separator in title
     Given the following "page" content:
       | title         |
       | Alpha - Bravo |
     When I am viewing a "post" content with the following fields:
-      | title                | Post with ref |
-      | field_post_reference | Alpha - Bravo |
+      | title                | Post with ref     |
+      | field_post_reference | "Alpha - Bravo"   |
     Then I should see "Alpha - Bravo"
 
-  @test-drupal @api
+  # Unquoted entity reference values containing ' - ' are still split by the
+  # compound column separator, which breaks the entity query.
+  @test-drupal @api @test-legacy-parser
+  Scenario: Assert "Given the following :type content:" fails for unquoted entity reference title containing compound separator
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api @test-legacy-parser":
+      """
+      Given the following "page" content:
+        | title         |
+        | Alpha - Bravo |
+      When I am viewing a "post" content with the following fields:
+        | title                | Post with ref |
+        | field_post_reference | Alpha - Bravo |
+      Then I should see "Alpha - Bravo"
+      """
+    When I run behat with drupal_legacy_parser profile
+    Then it should fail with a "Drupal\Core\Database\InvalidQueryException" exception:
+      """
+      must have an array compatible operator
+      """
+
+  # This is identical to the previous test, but uses human readable names for
+  # the field names. This is better from a BDD standpoint. Please have a look at
+  # FeatureContext::transformPostContentTable() to see how the mapping between
+  # the machine names and human readable names is defined.
+  @test-drupal @api @test-legacy-parser
   Scenario: Test using human readable names for fields using @Transform
     Given the following "page" content:
       | title      |
@@ -55,13 +80,13 @@ Feature: FieldHandlers
       | Page two   |
       | Page three |
     When I am viewing a "post" content with the following fields:
-      | title     | Post title                                                                            |
-      | body      | PLACEHOLDER BODY                                                                      |
-      | reference | Page one, Page two                                                                    |
-      | date      | 2015-02-08 17:45:00                                                                   |
-      | links     | title:"Link 1", uri:"http://example.com"; title:"Link 2", uri:"http://example.com"    |
-      | select    | Select value one, Select value two                                                    |
-      | address   | country:"BE", locality:"Brussel", thoroughfare:"Louisalaan 1", postal_code:"1000"     |
+      | title     | Post title                                                                       |
+      | body      | PLACEHOLDER BODY                                                                 |
+      | reference | Page one, Page two                                                               |
+      | date      | 2015-02-08 17:45:00                                                              |
+      | links     | Link 1 - http://example.com, Link 2 - http://example.com                         |
+      | select    | Select value one, Select value two                                               |
+      | address   | country: BE - locality: Brussel - thoroughfare: Louisalaan 1 - postal_code: 1000 |
     Then I should see "Page one"
     And I should see "Page two"
     And I should see "Sunday, February 8, 2015"
@@ -74,7 +99,7 @@ Feature: FieldHandlers
     And I should see "1000"
     And I should see "Louisalaan 1"
 
-  @test-drupal @api
+  @test-drupal @api @test-legacy-parser
   Scenario: Test alternative syntax for named field columns on node content
     When I am viewing a "post" content with the following fields:
       | title                           | Post title                  |
@@ -87,7 +112,7 @@ Feature: FieldHandlers
     And I should see "1 Avenue des Champs Elysées"
     And I should see "75008"
 
-  @test-drupal @api
+  @test-drupal @api @test-legacy-parser
   Scenario: Test shorthand syntax for named field columns on node content
     When I am viewing a "post" content with the following fields:
       | title                      | Post title      |
@@ -100,7 +125,7 @@ Feature: FieldHandlers
     And I should see "1 Oxford Street"
     And I should see "W1D 1AN"
 
-  @test-drupal @api
+  @test-drupal @api @test-legacy-parser
   Scenario: Test multivalue fields with named field columns on node content
     When I am viewing a "post" content with the following fields:
       | title                      | Post title                             |
@@ -117,7 +142,7 @@ Feature: FieldHandlers
     And I should see "Shibuya Crossing"
     And I should see "150-0040"
 
-  @test-drupal @api
+  @test-drupal @api @test-legacy-parser
   Scenario: Test various user field handlers.
     Given the following "tags" terms:
       | name    |
@@ -129,9 +154,9 @@ Feature: FieldHandlers
       | Page two   |
       | Page three |
     And the following users:
-      | name     | mail         | field_tags       | field_post_reference | field_post_address                                                                |
-      | Jane Doe |              |                  |                      |                                                                                   |
-      | John Doe | john@doe.com | Tag one, Tag two | Page one, Page two   | country:"BE", locality:"Brussel", thoroughfare:"Louisalaan 1", postal_code:"1000" |
+      | name     | mail         | field_tags       | field_post_reference | field_post_address                                                               |
+      | Jane Doe |              |                  |                      |                                                                                  |
+      | John Doe | john@doe.com | Tag one, Tag two | Page one, Page two   | country: BE - locality: Brussel - thoroughfare: Louisalaan 1 - postal_code: 1000 |
     And I am logged in as a user with the "administrator" role
     When I visit "admin/people"
     Then I should see the link "Jane Doe"
@@ -148,7 +173,7 @@ Feature: FieldHandlers
     And I should see "1000"
     And I should see "Louisalaan 1"
 
-  @test-drupal @api
+  @test-drupal @api @test-legacy-parser
   Scenario: Test using @Transform to provide human friendly aliases for named field columns
     Given the following users:
       | name     | mail             | street        | city     | postcode | country |
@@ -161,7 +186,7 @@ Feature: FieldHandlers
     And I should see "Pioneer Place"
     And I should see "OR 97204"
 
-  @test-drupal @api
+  @test-drupal @api @test-legacy-parser
   Scenario: Test taxonomy term reference field handler
     Given the following "tags" terms:
       | name       |

--- a/tests/behat/features/field_handlers_legacy.feature
+++ b/tests/behat/features/field_handlers_legacy.feature
@@ -1,58 +1,74 @@
-Feature: FieldHandlers
+Feature: FieldHandlersLegacyParser
   As a developer
-  I want to handle complex field types when creating entities
-  So that I can test content with references, dates, links, and addresses
+  I want the legacy field parser to remain available for migration
+  So that I can keep existing 5.x feature files running until the parser is removed in 6.1
 
-  # Drupal scenarios assume a "standard" install of Drupal and require the
-  # feature "fixtures/drupalN/modules/behat_test" to enabled on the site.
-  @test-drupal @api @test-legacy-parser
-  Scenario: Test various node field handlers
-    Given the following "page" content:
-      | title      |
-      | Page one   |
-      | Page two   |
-      | Page three |
-    When I am viewing a "post" content with the following fields:
-      | title                | Post title                                                                       |
-      | body                 | PLACEHOLDER BODY                                                                 |
-      | field_post_reference | Page one, Page two                                                               |
-      | field_post_date      | 2015-02-08 17:45:00                                                              |
-      | field_post_links     | Link 1 - http://example.com, Link 2 - http://example.com                         |
-      | field_post_select    | Select value one, Select value two                                               |
-      | field_post_address   | country: BE - locality: Brussel - thoroughfare: Louisalaan 1 - postal_code: 1000 |
-    Then I should see "Post title"
-    And I should see "PLACEHOLDER BODY"
-    And I should see "Page one"
-    And I should see "Page two"
-    And I should see "Sunday, February 8, 2015"
-    And I should see the link "Link 1"
-    And I should see the link "Link 2"
-    And I should see "Select value one"
-    And I should see "Select value two"
-    And I should not see "Select value three"
-    And I should see "Belgium"
-    And I should see "Brussel"
-    And I should see "1000"
-    And I should see "Louisalaan 1"
+  # Each scenario runs a Behat subprocess against an inline feature that
+  # uses the legacy syntax. The subprocess is configured with
+  # 'field_parser: legacy' so the deprecated parser handles the values;
+  # the parent scenario asserts the subprocess passes.
 
-  # Entity reference values containing ' - ' must be double-quoted to prevent
-  # the compound column separator from splitting them.
-  @test-drupal @api @test-legacy-parser
-  Scenario: Test entity reference with compound separator in title
-    Given the following "page" content:
-      | title         |
-      | Alpha - Bravo |
-    When I am viewing a "post" content with the following fields:
-      | title                | Post with ref     |
-      | field_post_reference | "Alpha - Bravo"   |
-    Then I should see "Alpha - Bravo"
-
-  # Unquoted entity reference values containing ' - ' are still split by the
-  # compound column separator, which breaks the entity query.
-  @test-drupal @api @test-legacy-parser
-  Scenario: Assert "Given the following :type content:" fails for unquoted entity reference title containing compound separator
+  @test-drupal @api
+  Scenario: Assert legacy positional and named compound syntax pass under field_parser:legacy
     Given some behat configuration
-    And scenario steps tagged with "@test-drupal @api @test-legacy-parser":
+    And the behat configuration uses the legacy field parser
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given the following "page" content:
+        | title      |
+        | Page one   |
+        | Page two   |
+        | Page three |
+      When I am viewing a "post" content with the following fields:
+        | title                | Post title                                                                       |
+        | body                 | PLACEHOLDER BODY                                                                 |
+        | field_post_reference | Page one, Page two                                                               |
+        | field_post_links     | Link 1 - http://example.com, Link 2 - http://example.com                         |
+        | field_post_address   | country: BE - locality: Brussel - thoroughfare: Louisalaan 1 - postal_code: 1000 |
+      Then I should see "Post title"
+      And I should see "Page one"
+      And I should see "Page two"
+      And I should see the link "Link 1"
+      And I should see the link "Link 2"
+      And I should see "Belgium"
+      And I should see "Brussel"
+      And I should see "1000"
+      And I should see "Louisalaan 1"
+      """
+    When I run behat with drupal profile
+    Then it should pass with:
+      """
+      1 scenario (1 passed)
+      """
+
+  @test-drupal @api
+  Scenario: Assert quoted entity reference with compound separator passes under field_parser:legacy
+    Given some behat configuration
+    And the behat configuration uses the legacy field parser
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given the following "page" content:
+        | title         |
+        | Alpha - Bravo |
+      When I am viewing a "post" content with the following fields:
+        | title                | Post with ref     |
+        | field_post_reference | "Alpha - Bravo"   |
+      Then I should see "Alpha - Bravo"
+      """
+    When I run behat with drupal profile
+    Then it should pass with:
+      """
+      1 scenario (1 passed)
+      """
+
+  # The legacy parser still has the silent-split bug for unquoted entity
+  # reference titles containing ' - '. This stays a negative test until the
+  # legacy parser is removed in 6.1.
+  @test-drupal @api
+  Scenario: Assert unquoted entity reference with compound separator fails under field_parser:legacy
+    Given some behat configuration
+    And the behat configuration uses the legacy field parser
+    And scenario steps tagged with "@test-drupal @api":
       """
       Given the following "page" content:
         | title         |
@@ -62,156 +78,8 @@ Feature: FieldHandlers
         | field_post_reference | Alpha - Bravo |
       Then I should see "Alpha - Bravo"
       """
-    When I run behat with drupal_legacy_parser profile
+    When I run behat with drupal profile
     Then it should fail with a "Drupal\Core\Database\InvalidQueryException" exception:
       """
       must have an array compatible operator
       """
-
-  # This is identical to the previous test, but uses human readable names for
-  # the field names. This is better from a BDD standpoint. Please have a look at
-  # FeatureContext::transformPostContentTable() to see how the mapping between
-  # the machine names and human readable names is defined.
-  @test-drupal @api @test-legacy-parser
-  Scenario: Test using human readable names for fields using @Transform
-    Given the following "page" content:
-      | title      |
-      | Page one   |
-      | Page two   |
-      | Page three |
-    When I am viewing a "post" content with the following fields:
-      | title     | Post title                                                                       |
-      | body      | PLACEHOLDER BODY                                                                 |
-      | reference | Page one, Page two                                                               |
-      | date      | 2015-02-08 17:45:00                                                              |
-      | links     | Link 1 - http://example.com, Link 2 - http://example.com                         |
-      | select    | Select value one, Select value two                                               |
-      | address   | country: BE - locality: Brussel - thoroughfare: Louisalaan 1 - postal_code: 1000 |
-    Then I should see "Page one"
-    And I should see "Page two"
-    And I should see "Sunday, February 8, 2015"
-    And I should see the link "Link 1"
-    And I should see the link "Link 2"
-    And I should see "Select value one"
-    And I should see "Select value two"
-    And I should see "Belgium"
-    And I should see "Brussel"
-    And I should see "1000"
-    And I should see "Louisalaan 1"
-
-  @test-drupal @api @test-legacy-parser
-  Scenario: Test alternative syntax for named field columns on node content
-    When I am viewing a "post" content with the following fields:
-      | title                           | Post title                  |
-      | field_post_address:country      | FR                          |
-      | field_post_address:locality     | Paris                       |
-      | field_post_address:thoroughfare | 1 Avenue des Champs Elysées |
-      | field_post_address:postal_code  | 75008                       |
-    Then I should see "France"
-    And I should see "Paris"
-    And I should see "1 Avenue des Champs Elysées"
-    And I should see "75008"
-
-  @test-drupal @api @test-legacy-parser
-  Scenario: Test shorthand syntax for named field columns on node content
-    When I am viewing a "post" content with the following fields:
-      | title                      | Post title      |
-      | field_post_address:country | GB              |
-      | :locality                  | London          |
-      | :thoroughfare              | 1 Oxford Street |
-      | :postal_code               | W1D 1AN         |
-    Then I should see "United Kingdom"
-    And I should see "London"
-    And I should see "1 Oxford Street"
-    And I should see "W1D 1AN"
-
-  @test-drupal @api @test-legacy-parser
-  Scenario: Test multivalue fields with named field columns on node content
-    When I am viewing a "post" content with the following fields:
-      | title                      | Post title                             |
-      | field_post_address:country | IT, JP                                 |
-      | :locality                  | Milan, Tokyo                           |
-      | :thoroughfare              | 1 Corso Buenos Aires, Shibuya Crossing |
-      | :postal_code               | 20124, 150-0040                        |
-    Then I should see "Italy"
-    And I should see "Milan"
-    And I should see "1 Corso Buenos Aires"
-    And I should see "20124"
-    And I should see "Japan"
-    And I should see "Tokyo"
-    And I should see "Shibuya Crossing"
-    And I should see "150-0040"
-
-  @test-drupal @api @test-legacy-parser
-  Scenario: Test various user field handlers.
-    Given the following "tags" terms:
-      | name    |
-      | Tag one |
-      | Tag two |
-    And the following "page" content:
-      | title      |
-      | Page one   |
-      | Page two   |
-      | Page three |
-    And the following users:
-      | name     | mail         | field_tags       | field_post_reference | field_post_address                                                               |
-      | Jane Doe |              |                  |                      |                                                                                  |
-      | John Doe | john@doe.com | Tag one, Tag two | Page one, Page two   | country: BE - locality: Brussel - thoroughfare: Louisalaan 1 - postal_code: 1000 |
-    And I am logged in as a user with the "administrator" role
-    When I visit "admin/people"
-    Then I should see the link "Jane Doe"
-    And I should see the link "John Doe"
-    When I click "John Doe"
-    Then I should see the link "Tag one"
-    And I should see the link "Tag two"
-    But I should not see the link "Tag three"
-    And I should see "Page one"
-    And I should see "Page two"
-    And I should not see "Page three"
-    And I should see "Belgium"
-    And I should see "Brussel"
-    And I should see "1000"
-    And I should see "Louisalaan 1"
-
-  @test-drupal @api @test-legacy-parser
-  Scenario: Test using @Transform to provide human friendly aliases for named field columns
-    Given the following users:
-      | name     | mail             | street        | city     | postcode | country |
-      | Jane Doe | jane@example.com | Pioneer Place | Portland | OR 97204 | US      |
-    And I am logged in as a user with the "administrator" role
-    When I visit "admin/people"
-    And I click "Jane Doe"
-    Then I should see "United States"
-    And I should see "Portland"
-    And I should see "Pioneer Place"
-    And I should see "OR 97204"
-
-  @test-drupal @api @test-legacy-parser
-  Scenario: Test taxonomy term reference field handler
-    Given the following "tags" terms:
-      | name       |
-      | Tag one    |
-      | Tag two    |
-      | Tag, three |
-      | Tag four   |
-    And the following "article" content:
-      | title           | body             | promote | field_tags                    |
-      # Field values containing commas should be escaped with double quotes.
-      # The comma separator can optionally be followed by a space.
-      | Article by Joe  | PLACEHOLDER BODY | 1       | Tag one, Tag two,"Tag, three" |
-      | Article by Mike | PLACEHOLDER BODY | 1       | Tag four                      |
-      | Article by Jane |                  |         |                               |
-    And I am logged in as a user with the "administrator" role
-    When I visit "admin/content"
-    Then I should see the link "Article by Joe"
-    And I should see the link "Article by Mike"
-    And I should see the link "Article by Jane"
-    When I am on the homepage
-    Then I should see the link "Article by Joe"
-    And I should see the link "Tag one"
-    And I should see the link "Tag two"
-    And I should see the link "Tag, three"
-    And I should see the link "Article by Mike"
-    And I should see the link "Tag four"
-    And I should see the link "Article by Joe"
-    And I should not see the link "Article by Jane"

--- a/tests/phpunit/src/Parser/EntityFieldParserTest.php
+++ b/tests/phpunit/src/Parser/EntityFieldParserTest.php
@@ -113,9 +113,9 @@ class EntityFieldParserTest extends TestCase {
   /**
    * Provides data for testParse().
    *
-   * Each yielded row mirrors a row of the validity table in the spec
-   * (.artifacts/spec-766-compound-syntax.md, section 6) so this provider
-   * reads as a top-to-bottom encoding of that table.
+   * Each yielded row mirrors a row of the syntax validity table in the
+   * issue description for #766, so this provider reads as a top-to-bottom
+   * encoding of that table.
    */
   public static function dataProviderParse(): \Iterator {
     // Row 1: scalar, single.

--- a/tests/phpunit/src/Parser/EntityFieldParserTest.php
+++ b/tests/phpunit/src/Parser/EntityFieldParserTest.php
@@ -354,8 +354,20 @@ class EntityFieldParserTest extends TestCase {
       ['role'],
     ];
     yield 'compound value with escape sequences' => [
-      ['field_test' => 'note:"line1\nline2\ttab\\\\back"'],
-      ['field_test' => [['note' => "line1\nline2\ttab\\back"]]],
+      ['field_test' => 'note:"line1\nline2\ttab\\\\back\rret"'],
+      ['field_test' => [['note' => "line1\nline2\ttab\\back\rret"]]],
+    ];
+    yield 'scalar trailing comma' => [
+      ['field_test' => 'a,'],
+      ['field_test' => ['a', '']],
+    ];
+    yield 'scalar trailing whitespace' => [
+      ['field_test' => 'a, '],
+      ['field_test' => ['a', '']],
+    ];
+    yield 'scalar quoted item then space then comma' => [
+      ['field_test' => '"a" , "b"'],
+      ['field_test' => ['a', 'b']],
     ];
     yield 'compound whitespace inside quoted string preserved' => [
       ['field_test' => 'note:"  spaced  value  "'],
@@ -499,6 +511,35 @@ class EntityFieldParserTest extends TestCase {
       ParseException::class,
       'invalid_column',
     ];
+    yield 'error: compound column with empty value' => [
+      ['field_test' => 'name:"OK", other:'],
+      [],
+      NULL,
+      NULL,
+      ParseException::class,
+      'unquoted_compound_value',
+    ];
+  }
+
+  /**
+   * Tests that errors detected across multiple cells are aggregated.
+   */
+  public function testMultiCellErrorsAggregated(): void {
+    $classifier = $this->createMock(FieldClassifierInterface::class);
+    $classifier->method('fieldIsConfigurable')->willReturn(TRUE);
+
+    $parser = new EntityFieldParser('node', $classifier);
+
+    try {
+      $parser->parse([
+        'field_a' => 'name:"unclosed',
+        'field_b' => 'a;b',
+      ]);
+      $this->fail('Expected MultipleParseException, none thrown.');
+    }
+    catch (MultipleParseException $e) {
+      $this->assertGreaterThanOrEqual(2, count($e->errors));
+    }
   }
 
 }

--- a/tests/phpunit/src/Parser/EntityFieldParserTest.php
+++ b/tests/phpunit/src/Parser/EntityFieldParserTest.php
@@ -113,9 +113,8 @@ class EntityFieldParserTest extends TestCase {
   /**
    * Provides data for testParse().
    *
-   * Each yielded row mirrors a row of the syntax validity table in the
-   * issue description for #766, so this provider reads as a top-to-bottom
-   * encoding of that table.
+   * Each yielded row encodes one row of the syntax validity table; see
+   * src/Drupal/DrupalExtension/Parser/README.md for the full table.
    */
   public static function dataProviderParse(): \Iterator {
     // Row 1: scalar, single.

--- a/tests/phpunit/src/Parser/EntityFieldParserTest.php
+++ b/tests/phpunit/src/Parser/EntityFieldParserTest.php
@@ -1,0 +1,441 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Tests\Parser;
+
+use Drupal\Driver\Core\Field\FieldClassifierInterface;
+use Drupal\DrupalExtension\Parser\EntityFieldParser;
+use Drupal\DrupalExtension\Parser\Exception\MultipleParseException;
+use Drupal\DrupalExtension\Parser\Exception\ParseException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the modern entity-field parser.
+ */
+#[CoversClass(EntityFieldParser::class)]
+class EntityFieldParserTest extends TestCase {
+
+  /**
+   * Tests parsing across the full happy-path and error matrix.
+   *
+   * @param array<string|int, mixed> $input
+   *   Raw stub values to feed the parser.
+   * @param array<string, mixed> $expected
+   *   The expected parsed output (ignored when an exception is expected).
+   * @param array<int, string>|null $configurable_fields
+   *   Field names the classifier should report as configurable, or NULL
+   *   to treat every field as configurable (the default).
+   * @param array<int, string>|null $base_fields
+   *   Field names the classifier should report as base fields.
+   * @param class-string<\Throwable>|null $exception
+   *   Expected exception class, or NULL when no exception is expected.
+   * @param string|null $error_code
+   *   Expected ParseException::$errorCode, when applicable.
+   * @param string|null $message
+   *   Expected exception message substring, when applicable.
+   * @param array<int, string> $ignored_properties
+   *   Property names passed to the parser via ignoring().
+   */
+  #[DataProvider('dataProviderParse')]
+  public function testParse(
+    array $input,
+    array $expected = [],
+    ?array $configurable_fields = NULL,
+    ?array $base_fields = NULL,
+    ?string $exception = NULL,
+    ?string $error_code = NULL,
+    ?string $message = NULL,
+    array $ignored_properties = [],
+  ): void {
+    $classifier = $this->createMock(FieldClassifierInterface::class);
+
+    if ($configurable_fields === NULL) {
+      $classifier->method('fieldIsConfigurable')->willReturn(TRUE);
+    }
+    else {
+      $classifier->method('fieldIsConfigurable')->willReturnCallback(
+        fn(string $entity_type, string $field_name): bool => in_array($field_name, $configurable_fields, TRUE)
+      );
+      $is_base = fn(string $entity_type, string $field_name): bool => in_array($field_name, $base_fields ?? [], TRUE);
+      $classifier->method('fieldIsBaseStandard')->willReturnCallback($is_base);
+      $classifier->method('fieldIsBaseComputedReadOnly')->willReturnCallback($is_base);
+      $classifier->method('fieldIsBaseComputedWritable')->willReturnCallback($is_base);
+      $classifier->method('fieldIsBaseCustomStorage')->willReturnCallback($is_base);
+    }
+
+    $parser = (new EntityFieldParser('node', $classifier))->ignoring($ignored_properties);
+
+    if ($exception !== NULL) {
+      try {
+        $parser->parse($input);
+        $this->fail(sprintf('Expected %s, none thrown.', $exception));
+      }
+      catch (\RuntimeException $caught) {
+        $this->assertInstanceOf($exception, $caught);
+
+        if ($error_code !== NULL) {
+          $this->assertInstanceOf(ParseException::class, $caught);
+          $this->assertSame($error_code, $caught->errorCode);
+        }
+
+        if ($message !== NULL) {
+          $this->assertStringContainsString($message, $caught->getMessage());
+        }
+      }
+
+      return;
+    }
+
+    $this->assertSame($expected, $parser->parse($input));
+  }
+
+  /**
+   * Tests that multi-error cells throw MultipleParseException with all errors.
+   */
+  public function testMultiErrorReportedTogether(): void {
+    $classifier = $this->createMock(FieldClassifierInterface::class);
+    $classifier->method('fieldIsConfigurable')->willReturn(TRUE);
+
+    $parser = new EntityFieldParser('node', $classifier);
+
+    try {
+      $parser->parse(['field_test' => 'a:"x";; b:"y", c:bad']);
+      $this->fail('Expected MultipleParseException, none thrown.');
+    }
+    catch (MultipleParseException $e) {
+      $this->assertGreaterThanOrEqual(2, count($e->errors));
+    }
+  }
+
+  /**
+   * Provides data for testParse().
+   *
+   * Each yielded row mirrors a row of the validity table in the spec
+   * (.artifacts/spec-766-compound-syntax.md, section 6) so this provider
+   * reads as a top-to-bottom encoding of that table.
+   */
+  public static function dataProviderParse(): \Iterator {
+    // Row 1: scalar, single.
+    yield '1. scalar, single' => [
+      ['field_test' => 'Hello'],
+      ['field_test' => ['Hello']],
+    ];
+    // Row 2: scalar, single, contains ":".
+    yield '2. scalar, single, contains ":"' => [
+      ['field_test' => 'Note: this is important'],
+      ['field_test' => ['Note: this is important']],
+    ];
+    // Row 3: scalar, single, contains ",".
+    yield '3. scalar, single, contains ","' => [
+      ['field_test' => '"Hello, world"'],
+      ['field_test' => ['Hello, world']],
+    ];
+    // Row 4: scalar, single, contains " - " (issue #642 resolved).
+    yield '4. scalar, single, contains " - "' => [
+      ['field_test' => 'Alpha - Bravo'],
+      ['field_test' => ['Alpha - Bravo']],
+    ];
+    // Row 5: scalar, single, contains ";" (must be quoted now).
+    yield '5. scalar, single, contains ";"' => [
+      ['field_test' => '"Hello; world"'],
+      ['field_test' => ['Hello; world']],
+    ];
+    // Row 6: scalar, looks like key:value but is not.
+    yield '6. scalar, looks like key:value' => [
+      ['field_test' => 'port:8080'],
+      ['field_test' => ['port:8080']],
+    ];
+    // Row 7: scalar, multi-value.
+    yield '7. scalar, multi-value' => [
+      ['field_test' => 'Tag one, Tag two'],
+      ['field_test' => ['Tag one', 'Tag two']],
+    ];
+    // Row 8: scalar, multi-value, item contains ",".
+    yield '8. scalar, multi-value, item contains ","' => [
+      ['field_test' => 'Tag one, "Tag, two"'],
+      ['field_test' => ['Tag one', 'Tag, two']],
+    ];
+    // Row 9: token, single.
+    yield '9. token, single' => [
+      ['field_test' => '[relative:-1 week]'],
+      ['field_test' => ['[relative:-1 week]']],
+    ];
+    // Row 10: token, multi.
+    yield '10. token, multi' => [
+      ['field_test' => '[relative:-1 week], [relative:-2 weeks]'],
+      ['field_test' => ['[relative:-1 week]', '[relative:-2 weeks]']],
+    ];
+    // Row 11: token in scalar prose.
+    yield '11. token in scalar prose' => [
+      ['field_test' => 'Posted [relative:-1 week] ago'],
+      ['field_test' => ['Posted [relative:-1 week] ago']],
+    ];
+    // Row 12: token at compound value position.
+    yield '12. token at compound value position' => [
+      ['field_test' => 'value:[relative:-1 week], end_value:[relative:+1 week]'],
+      [
+        'field_test' => [[
+          'value' => '[relative:-1 week]',
+          'end_value' => '[relative:+1 week]',
+        ],
+        ],
+      ],
+    ];
+    // Row 13: compound named, single (text_with_summary).
+    yield '13. compound named, single (text_with_summary)' => [
+      ['field_test' => 'value:"Body", summary:"Summary", format:"basic_html"'],
+      [
+        'field_test' => [[
+          'value' => 'Body',
+          'summary' => 'Summary',
+          'format' => 'basic_html',
+        ],
+        ],
+      ],
+    ];
+    // Row 14: compound named, single (address).
+    yield '14. compound named, single (address)' => [
+      ['field_test' => 'country:"BE", locality:"Brussel", postal_code:"1000"'],
+      [
+        'field_test' => [[
+          'country' => 'BE',
+          'locality' => 'Brussel',
+          'postal_code' => '1000',
+        ],
+        ],
+      ],
+    ];
+    // Row 15: compound named, single (daterange).
+    yield '15. compound named, single (daterange)' => [
+      ['field_test' => 'value:"2026-01-01", end_value:"2026-12-31"'],
+      [
+        'field_test' => [[
+          'value' => '2026-01-01',
+          'end_value' => '2026-12-31',
+        ],
+        ],
+      ],
+    ];
+    // Row 16: compound named, single (file/image).
+    yield '16. compound named, single (file/image)' => [
+      ['field_test' => 'target_id:"foo.jpg", alt:"A", title:"B"'],
+      [
+        'field_test' => [[
+          'target_id' => 'foo.jpg',
+          'alt' => 'A',
+          'title' => 'B',
+        ],
+        ],
+      ],
+    ];
+    // Row 17: compound named, value contains ",".
+    yield '17. compound named, value contains ","' => [
+      ['field_test' => 'country:"BE", locality:"Brussel, X", postal_code:"1000"'],
+      [
+        'field_test' => [[
+          'country' => 'BE',
+          'locality' => 'Brussel, X',
+          'postal_code' => '1000',
+        ],
+        ],
+      ],
+    ];
+    // Row 18: compound named, value contains ":".
+    yield '18. compound named, value contains ":"' => [
+      ['field_test' => 'street:"Main: 1", country:"BE"'],
+      [
+        'field_test' => [[
+          'street' => 'Main: 1',
+          'country' => 'BE',
+        ],
+        ],
+      ],
+    ];
+    // Row 19: compound named, value contains ";".
+    yield '19. compound named, value contains ";"' => [
+      ['field_test' => 'street:"A;B", country:"BE"'],
+      [
+        'field_test' => [[
+          'street' => 'A;B',
+          'country' => 'BE',
+        ],
+        ],
+      ],
+    ];
+    // Row 20: compound named, value contains escaped ".
+    yield '20. compound named, value contains escaped "' => [
+      ['field_test' => 'note:"He said \\"hi\\""'],
+      ['field_test' => [['note' => 'He said "hi"']]],
+    ];
+    // Row 21: compound named, multi (address).
+    yield '21. compound named, multi (address)' => [
+      ['field_test' => 'country:"BE", locality:"Brussel"; country:"FR", locality:"Paris"'],
+      [
+        'field_test' => [
+        ['country' => 'BE', 'locality' => 'Brussel'],
+        ['country' => 'FR', 'locality' => 'Paris'],
+        ],
+      ],
+    ];
+    // Row 22: compound named, multi (link, positional gone).
+    yield '22. compound named, multi (link)' => [
+      ['field_test' => 'title:"Link 1", uri:"http://a"; title:"Link 2", uri:"http://b"'],
+      [
+        'field_test' => [
+        ['title' => 'Link 1', 'uri' => 'http://a'],
+        ['title' => 'Link 2', 'uri' => 'http://b'],
+        ],
+      ],
+    ];
+    // Row 26: external multicolumn header, single.
+    yield '26. external multicolumn header, single' => [
+      [
+        'field_test:col_a' => 'value_a',
+        ':col_b' => 'value_b',
+      ],
+      [
+        'field_test' => [
+          0 => ['col_a' => 'value_a', 'col_b' => 'value_b'],
+        ],
+      ],
+    ];
+    // Row 26: external multicolumn header, multi.
+    yield '26. external multicolumn header, multi-value' => [
+      [
+        'field_test:col_a' => 'A1, A2',
+        ':col_b' => 'B1, B2',
+      ],
+      [
+        'field_test' => [
+          0 => ['col_a' => 'A1', 'col_b' => 'B1'],
+          1 => ['col_a' => 'A2', 'col_b' => 'B2'],
+        ],
+      ],
+    ];
+    // Row 27: whitespace tolerance (compact form).
+    yield '27. whitespace tolerance (compact)' => [
+      ['field_test' => 'name:"Alice",age:"42"'],
+      ['field_test' => [['name' => 'Alice', 'age' => '42']]],
+    ];
+    // Row 27: whitespace tolerance (spaced form).
+    yield '27. whitespace tolerance (spaced)' => [
+      ['field_test' => 'name : "Alice" , age : "42"'],
+      ['field_test' => [['name' => 'Alice', 'age' => '42']]],
+    ];
+
+    // Below: rows beyond the validity table - blank handling, base/ignored
+    // field semantics, and parse-error coverage.
+    yield 'blank value unsets field' => [
+      ['field_test' => ''],
+      [],
+    ];
+    yield 'base field passthrough' => [
+      ['title' => 'Some title'],
+      ['title' => 'Some title'],
+      [],
+      ['title'],
+    ];
+    yield 'mixed configurable and base fields' => [
+      ['title' => 'Foo', 'field_test' => 'bar'],
+      ['title' => 'Foo', 'field_test' => ['bar']],
+      ['field_test'],
+      ['title'],
+    ];
+    yield 'ignored property passes validation' => [
+      ['role' => 'administrator', 'field_test' => 'A'],
+      ['role' => 'administrator', 'field_test' => ['A']],
+      ['field_test'],
+      [],
+      NULL,
+      NULL,
+      NULL,
+      ['role'],
+    ];
+    yield 'compound value with escape sequences' => [
+      ['field_test' => 'note:"line1\nline2\ttab\\\\back"'],
+      ['field_test' => [['note' => "line1\nline2\ttab\\back"]]],
+    ];
+    yield 'compound whitespace inside quoted string preserved' => [
+      ['field_test' => 'note:"  spaced  value  "'],
+      ['field_test' => [['note' => '  spaced  value  ']]],
+    ];
+    yield 'error: orphan column continuation' => [
+      [':orphan' => 'value'],
+      [],
+      NULL,
+      NULL,
+      \RuntimeException::class,
+      NULL,
+      'Field name missing for :orphan',
+    ];
+    yield 'error: unknown field' => [
+      ['field_unknown' => 'value'],
+      [],
+      [],
+      [],
+      \RuntimeException::class,
+      NULL,
+      'Field "field_unknown" does not exist on entity type "node".',
+    ];
+    yield 'error: unclosed quote' => [
+      ['field_test' => 'name:"Alice'],
+      [],
+      NULL,
+      NULL,
+      ParseException::class,
+      'unclosed_quote',
+    ];
+    yield 'error: unknown escape sequence' => [
+      ['field_test' => 'name:"Alice\\xfoo"'],
+      [],
+      NULL,
+      NULL,
+      ParseException::class,
+      'unknown_escape',
+    ];
+    yield 'error: bare value in compound column' => [
+      ['field_test' => 'name:"OK", broken:bare'],
+      [],
+      NULL,
+      NULL,
+      ParseException::class,
+      'unquoted_compound_value',
+    ];
+    yield 'error: empty record' => [
+      ['field_test' => 'a:"x";; b:"y"'],
+      [],
+      NULL,
+      NULL,
+      ParseException::class,
+      'empty_record',
+    ];
+    yield 'error: empty column' => [
+      ['field_test' => 'a:"x",, b:"y"'],
+      [],
+      NULL,
+      NULL,
+      ParseException::class,
+      'empty_column',
+    ];
+    yield 'error: unclosed token' => [
+      ['field_test' => 'value:[relative:-1 week'],
+      [],
+      NULL,
+      NULL,
+      ParseException::class,
+      'unclosed_token',
+    ];
+    yield 'error: unquoted semicolon in scalar' => [
+      ['field_test' => 'a;b'],
+      [],
+      NULL,
+      NULL,
+      ParseException::class,
+      'unquoted_semicolon',
+    ];
+  }
+
+}

--- a/tests/phpunit/src/Parser/EntityFieldParserTest.php
+++ b/tests/phpunit/src/Parser/EntityFieldParserTest.php
@@ -435,6 +435,70 @@ class EntityFieldParserTest extends TestCase {
       ParseException::class,
       'unquoted_semicolon',
     ];
+    yield 'error: scalar with unclosed quote' => [
+      ['field_test' => '"unclosed scalar'],
+      [],
+      NULL,
+      NULL,
+      ParseException::class,
+      'unclosed_quote',
+    ];
+    yield 'error: scalar with dangling backslash' => [
+      ['field_test' => '"abc\\'],
+      [],
+      NULL,
+      NULL,
+      ParseException::class,
+      'unclosed_quote',
+    ];
+    yield 'error: scalar with unknown escape' => [
+      ['field_test' => '"abc\\xfoo"'],
+      [],
+      NULL,
+      NULL,
+      ParseException::class,
+      'unknown_escape',
+    ];
+    yield 'error: scalar with unexpected character after closing quote' => [
+      ['field_test' => '"valid"junk'],
+      [],
+      NULL,
+      NULL,
+      ParseException::class,
+      'unexpected_character',
+    ];
+    yield 'error: scalar with unexpected quote inside unquoted item' => [
+      ['field_test' => 'abc"def'],
+      [],
+      NULL,
+      NULL,
+      ParseException::class,
+      'unexpected_quote',
+    ];
+    yield 'error: compound trailing characters after closing quote' => [
+      ['field_test' => 'name:"Alice"junk'],
+      [],
+      NULL,
+      NULL,
+      ParseException::class,
+      'trailing_characters',
+    ];
+    yield 'error: compound trailing characters after token' => [
+      ['field_test' => 'value:[token:val]junk, other:"x"'],
+      [],
+      NULL,
+      NULL,
+      ParseException::class,
+      'trailing_characters',
+    ];
+    yield 'error: compound column missing key:value form' => [
+      ['field_test' => 'name:"OK", "no key here"'],
+      [],
+      NULL,
+      NULL,
+      ParseException::class,
+      'invalid_column',
+    ];
   }
 
 }

--- a/tests/phpunit/src/Parser/Exception/ParseExceptionTest.php
+++ b/tests/phpunit/src/Parser/Exception/ParseExceptionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Tests\Parser\Exception;
+
+use Drupal\DrupalExtension\Parser\Exception\MultipleParseException;
+use Drupal\DrupalExtension\Parser\Exception\ParseException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the parse-exception classes.
+ */
+#[CoversClass(ParseException::class)]
+#[CoversClass(MultipleParseException::class)]
+class ParseExceptionTest extends TestCase {
+
+  /**
+   * Tests that the exception message renders cell, caret, and description.
+   */
+  public function testParseExceptionMessageWithoutHint(): void {
+    $exception = new ParseException(
+      'unclosed_quote',
+      4,
+      'name:Alice',
+      'Quoted string is missing a closing double quote.',
+    );
+
+    $this->assertSame('unclosed_quote', $exception->errorCode);
+    $this->assertSame(4, $exception->offset);
+    $this->assertSame('name:Alice', $exception->cell);
+
+    $expected = "name:Alice\n    ^\nunclosed_quote at offset 4: Quoted string is missing a closing double quote.";
+    $this->assertSame($expected, $exception->getMessage());
+  }
+
+  /**
+   * Tests that an optional hint is appended to the message.
+   */
+  public function testParseExceptionMessageWithHint(): void {
+    $exception = new ParseException(
+      'unknown_escape',
+      6,
+      'a:"x\\xy"',
+      'Unknown escape sequence "\\x".',
+      'Supported escapes are \\", \\\\, \\n, \\t, \\r.',
+    );
+
+    $this->assertStringContainsString('Hint: Supported escapes are', $exception->getMessage());
+  }
+
+  /**
+   * Tests that MultipleParseException requires at least one error.
+   */
+  public function testMultipleParseExceptionRequiresErrors(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('MultipleParseException requires at least one error.');
+
+    new MultipleParseException([], 'cell');
+  }
+
+  /**
+   * Tests that MultipleParseException collects multiple errors and summarises.
+   */
+  public function testMultipleParseExceptionAggregates(): void {
+    $first = new ParseException('empty_record', 0, 'a:"x";; b:"y"', 'Empty compound record.');
+    $second = new ParseException('empty_column', 0, 'a:"x";; b:"y"', 'Empty compound column.');
+
+    $exception = new MultipleParseException([$first, $second], 'a:"x";; b:"y"');
+
+    $this->assertSame('empty_record', $exception->errorCode);
+    $this->assertSame(2, count($exception->errors));
+    $this->assertStringContainsString('2 parse errors: empty_record, empty_column', $exception->getMessage());
+  }
+
+  /**
+   * Tests that a single-error MultipleParseException keeps its description.
+   */
+  public function testMultipleParseExceptionWithSingleError(): void {
+    $error = new ParseException('unclosed_quote', 0, 'cell', 'Description here.');
+
+    $exception = new MultipleParseException([$error], 'cell');
+
+    $this->assertStringContainsString('Description here.', $exception->getMessage());
+  }
+
+}

--- a/tests/phpunit/src/RawDrupalContextTest.php
+++ b/tests/phpunit/src/RawDrupalContextTest.php
@@ -6,31 +6,81 @@ namespace Drupal\DrupalExtension\Tests;
 
 use Drupal\Driver\Core\CoreInterface;
 use Drupal\Driver\Core\Field\FieldClassifierInterface;
+use Drupal\Driver\DriverInterface;
 use Drupal\Driver\DrupalDriver;
 use Drupal\Driver\Entity\EntityStub;
 use Drupal\DrupalDriverManagerInterface;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Tests the RawDrupalContext class.
+ * Integration tests for RawDrupalContext.
+ *
+ * The full parsing matrices for each implementation live in their own
+ * tests ('LegacyEntityFieldParserTest' and 'EntityFieldParserTest'). This
+ * class tests only the context-level concerns: the driver precondition,
+ * the field_parser flag, and that parseEntityFields() delegates to the
+ * selected parser.
  */
 #[CoversClass(RawDrupalContext::class)]
 class RawDrupalContextTest extends TestCase {
 
   /**
-   * The context under test.
+   * Tests that parseEntityFields throws when the driver is not a DrupalDriver.
    */
-  protected RawDrupalContext $context;
+  public function testParseEntityFieldsRequiresDrupalDriver(): void {
+    $driver = $this->createMock(DriverInterface::class);
+
+    $drupal = $this->createMock(DrupalDriverManagerInterface::class);
+    $drupal->method('getDriver')->willReturn($driver);
+
+    $context = new RawDrupalContext();
+    $context->setDrupal($drupal);
+
+    $stub = new EntityStub('node', NULL, ['field_test' => 'A']);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('does not support field inspection');
+
+    $context->parseEntityFields($stub);
+  }
 
   /**
-   * Sets up test fixtures.
+   * Tests that parseEntityFields uses the modern parser by default.
    */
-  protected function setUp(): void {
-    $this->context = new RawDrupalContext();
+  public function testParseEntityFieldsUsesModernParserByDefault(): void {
+    $context = $this->buildContext();
 
+    $stub = new EntityStub('node', NULL, ['field_test' => 'name:"Alice", age:"42"']);
+    $context->parseEntityFields($stub);
+
+    $this->assertSame(
+      ['field_test' => [['name' => 'Alice', 'age' => '42']]],
+      $stub->getValues(),
+    );
+  }
+
+  /**
+   * Tests that parseEntityFields uses the legacy parser when configured.
+   */
+  public function testParseEntityFieldsUsesLegacyParserWhenConfigured(): void {
+    $context = $this->buildContext();
+    $context->setDrupalParameters(['field_parser' => 'legacy']);
+
+    $stub = new EntityStub('node', NULL, ['field_test' => 'A - B']);
+    $context->parseEntityFields($stub);
+
+    $this->assertSame(
+      ['field_test' => [['A', 'B']]],
+      $stub->getValues(),
+    );
+  }
+
+  /**
+   * Builds a context wired to an everything-configurable classifier.
+   */
+  protected function buildContext(): RawDrupalContext {
     $classifier = $this->createMock(FieldClassifierInterface::class);
     $classifier->method('fieldIsConfigurable')->willReturn(TRUE);
 
@@ -43,293 +93,10 @@ class RawDrupalContextTest extends TestCase {
     $drupal = $this->createMock(DrupalDriverManagerInterface::class);
     $drupal->method('getDriver')->willReturn($driver);
 
-    $this->context->setDrupal($drupal);
-  }
-
-  /**
-   * Tests parsing entity fields.
-   *
-   * @param array<string, mixed> $input
-   *   The input entity fields.
-   * @param array<string, mixed> $expected
-   *   The expected entity fields after parsing.
-   * @param array<int, string>|null $fields
-   *   The configurable fields.
-   * @param array<int, string>|null $baseFields
-   *   The base fields.
-   * @param string|null $exception
-   *   Expected exception message.
-   * @param array<int, string> $ignored_properties
-   *   The ignored properties.
-   */
-  #[DataProvider('dataProviderParseEntityFields')]
-  public function testParseEntityFields(array $input, array $expected, ?array $fields = NULL, ?array $baseFields = NULL, ?string $exception = NULL, array $ignored_properties = []): void {
-    if ($fields !== NULL) {
-      $is_base_field = fn(string $entity_type, string $field_name): bool => in_array($field_name, $baseFields ?? [], TRUE);
-
-      $classifier = $this->createMock(FieldClassifierInterface::class);
-      $classifier->method('fieldIsConfigurable')->willReturnCallback(
-        fn(string $entity_type, string $field_name): bool => in_array($field_name, $fields, TRUE)
-      );
-      $classifier->method('fieldIsBaseStandard')->willReturnCallback($is_base_field);
-      $classifier->method('fieldIsBaseComputedReadOnly')->willReturnCallback($is_base_field);
-      $classifier->method('fieldIsBaseComputedWritable')->willReturnCallback($is_base_field);
-      $classifier->method('fieldIsBaseCustomStorage')->willReturnCallback($is_base_field);
-
-      $core = $this->createMock(CoreInterface::class);
-      $core->method('getFieldClassifier')->willReturn($classifier);
-
-      $driver = $this->createMock(DrupalDriver::class);
-      $driver->method('getCore')->willReturn($core);
-
-      $drupal = $this->createMock(DrupalDriverManagerInterface::class);
-      $drupal->method('getDriver')->willReturn($driver);
-
-      $context = new RawDrupalContext();
-      $context->setDrupal($drupal);
-    }
-    else {
-      $context = $this->context;
-    }
-
-    if ($exception !== NULL) {
-      $this->expectException(\RuntimeException::class);
-      $this->expectExceptionMessage($exception);
-    }
-
-    $stub = new EntityStub('node', NULL, $input);
-    $context->parseEntityFields($stub, $ignored_properties);
-    $this->assertSame($expected, $stub->getValues());
-  }
-
-  /**
-   * Provides data for testParseEntityFields().
-   */
-  public static function dataProviderParseEntityFields(): \Iterator {
-    // All properties recognized as fields.
-    yield 'single value' => [
-      ['field_test' => 'A'],
-      ['field_test' => ['A']],
-    ];
-    yield 'multiple csv values' => [
-      ['field_test' => 'A, B, C'],
-      ['field_test' => ['A', 'B', 'C']],
-    ];
-    yield 'csv with quoted comma' => [
-      ['field_test' => 'A, "a value, containing a comma"'],
-      ['field_test' => ['A', 'a value, containing a comma']],
-    ];
-    yield 'compound separator' => [
-      ['field_test' => 'A - B'],
-      ['field_test' => [['A', 'B']]],
-    ];
-    yield 'inline named columns' => [
-      ['field_test' => 'x: A - y: B'],
-      ['field_test' => [['x' => 'A', 'y' => 'B']]],
-    ];
-    yield 'multi-value compound' => [
-      ['field_test' => 'A - B, C - D'],
-      ['field_test' => [['A', 'B'], ['C', 'D']]],
-    ];
-    yield 'multi-value named columns' => [
-      ['field_test' => 'x: A - y: B, x: C - y: D'],
-      ['field_test' => [['x' => 'A', 'y' => 'B'], ['x' => 'C', 'y' => 'D']]],
-    ];
-    yield 'quoted value with compound separator preserved' => [
-      ['field_test' => '"Alpha - Bravo"'],
-      ['field_test' => ['Alpha - Bravo']],
-    ];
-    yield 'quoted multi-value with compound separator preserved' => [
-      ['field_test' => '"Alpha - Bravo", "Charlie - Delta"'],
-      ['field_test' => ['Alpha - Bravo', 'Charlie - Delta']],
-    ];
-    yield 'mixed quoted and unquoted values' => [
-      ['field_test' => '"Alpha - Bravo", C - D'],
-      ['field_test' => ['Alpha - Bravo', ['C', 'D']]],
-    ];
-    yield 'blank value unsets field' => [
-      ['field_test' => ''],
-      [],
-    ];
-    yield 'multiple fields on one entity' => [
-      ['field_a' => 'X', 'field_b' => 'Y, Z'],
-      ['field_a' => ['X'], 'field_b' => ['Y', 'Z']],
-    ];
-    yield 'multicolumn' => [
-      ['field_test:col_a' => 'value_a', ':col_b' => 'value_b'],
-      ['field_test' => [0 => ['col_a' => 'value_a', 'col_b' => 'value_b']]],
-    ];
-    yield 'multicolumn multiple values' => [
-      ['field_test:col_a' => 'A1, A2', ':col_b' => 'B1, B2'],
-      ['field_test' => [0 => ['col_a' => 'A1', 'col_b' => 'B1'], 1 => ['col_a' => 'A2', 'col_b' => 'B2']]],
-    ];
-    yield 'multicolumn blank values preserved' => [
-      ['field_test:col_a' => '', ':col_b' => ''],
-      ['field_test' => [0 => ['col_a' => '', 'col_b' => '']]],
-    ];
-
-    // Selective field recognition (base fields pass through unchanged).
-    yield 'base field property left untouched' => [
-      ['title' => 'Some title'],
-      ['title' => 'Some title'],
-      [],
-      ['title'],
-    ];
-    yield 'base field with compound separator untouched' => [
-      ['title' => 'A - B'],
-      ['title' => 'A - B'],
-      [],
-      ['title'],
-    ];
-    yield 'multiple base field properties untouched' => [
-      ['title' => 'Foo', 'status' => '1', 'uid' => '5'],
-      ['title' => 'Foo', 'status' => '1', 'uid' => '5'],
-      [],
-      ['title', 'status', 'uid'],
-    ];
-    yield 'mixed field and base field properties' => [
-      ['title' => 'Foo', 'field_test' => 'bar'],
-      ['title' => 'Foo', 'field_test' => ['bar']],
-      ['field_test'],
-      ['title'],
-    ];
-    yield 'field parsed while base fields preserved' => [
-      ['title' => 'Foo', 'field_a' => 'X - Y', 'field_b' => 'A, B', 'status' => '1'],
-      ['title' => 'Foo', 'field_a' => [['X', 'Y']], 'field_b' => ['A', 'B'], 'status' => '1'],
-      ['field_a', 'field_b'],
-      ['title', 'status'],
-    ];
-    yield 'multicolumn base field left untouched' => [
-      ['title:col_a' => 'value_a', ':col_b' => 'value_b'],
-      ['title:col_a' => 'value_a', ':col_b' => 'value_b'],
-      [],
-      ['title'],
-    ];
-
-    // Exception cases.
-    yield 'orphaned column throws' => [
-      [':orphan' => 'value'],
-      [],
-      NULL,
-      NULL,
-      'Field name missing for :orphan',
-    ];
-    yield 'non-existent field throws' => [
-      ['field_does_not_exist' => 'value'],
-      [],
-      [],
-      [],
-      'Field "field_does_not_exist" does not exist on entity type "node".',
-    ];
-    yield 'non-existent field among valid fields throws' => [
-      ['title' => 'Foo', 'field_tags' => 'A', 'field_fake' => 'B'],
-      [],
-      ['field_tags'],
-      ['title'],
-      'Field "field_fake" does not exist on entity type "node".',
-    ];
-    yield 'non-existent multicolumn field throws' => [
-      ['field_fake:col_a' => 'value'],
-      [],
-      [],
-      [],
-      'Field "field_fake" does not exist on entity type "node".',
-    ];
-
-    // Ignored properties.
-    yield 'ignored property passes validation' => [
-      ['role' => 'administrator', 'field_test' => 'A'],
-      ['role' => 'administrator', 'field_test' => ['A']],
-      ['field_test'],
-      [],
-      NULL,
-      ['role'],
-    ];
-    yield 'multiple ignored properties pass validation' => [
-      ['role' => 'editor', 'vocabulary_machine_name' => 'tags'],
-      ['role' => 'editor', 'vocabulary_machine_name' => 'tags'],
-      [],
-      [],
-      NULL,
-      ['role', 'vocabulary_machine_name'],
-    ];
-  }
-
-  /**
-   * Tests that non-F1 base fields pass through without throwing.
-   *
-   * Regression guard: the v2 'fieldIsBase()' check covered all four base
-   * F-rows, so computed-writable base fields like 'moderation_state' (F3)
-   * must not trigger the unknown-field error in v3.
-   */
-  #[DataProvider('dataProviderParseEntityFieldsAcceptsNonStandardBaseFields')]
-  public function testParseEntityFieldsAcceptsNonStandardBaseFields(string $truePredicate): void {
-    $base_predicates = [
-      'fieldIsBaseStandard',
-      'fieldIsBaseComputedReadOnly',
-      'fieldIsBaseComputedWritable',
-      'fieldIsBaseCustomStorage',
-    ];
-
-    $classifier = $this->createMock(FieldClassifierInterface::class);
-    $classifier->method('fieldIsConfigurable')->willReturn(FALSE);
-
-    foreach ($base_predicates as $predicate) {
-      $classifier->method($predicate)->willReturn($predicate === $truePredicate);
-    }
-
-    $core = $this->createMock(CoreInterface::class);
-    $core->method('getFieldClassifier')->willReturn($classifier);
-
-    $driver = $this->createMock(DrupalDriver::class);
-    $driver->method('getCore')->willReturn($core);
-
-    $drupal = $this->createMock(DrupalDriverManagerInterface::class);
-    $drupal->method('getDriver')->willReturn($driver);
-
     $context = new RawDrupalContext();
     $context->setDrupal($drupal);
 
-    $stub = new EntityStub('node', NULL, ['moderation_state' => 'draft']);
-    $context->parseEntityFields($stub);
-
-    $this->assertSame(['moderation_state' => 'draft'], $stub->getValues());
-  }
-
-  /**
-   * Provides data for testParseEntityFieldsAcceptsNonStandardBaseFields().
-   */
-  public static function dataProviderParseEntityFieldsAcceptsNonStandardBaseFields(): \Iterator {
-    yield 'F1 base standard' => ['fieldIsBaseStandard'];
-    yield 'F2 base computed read-only' => ['fieldIsBaseComputedReadOnly'];
-    yield 'F3 base computed writable' => ['fieldIsBaseComputedWritable'];
-    yield 'F4 base custom storage' => ['fieldIsBaseCustomStorage'];
-  }
-
-  /**
-   * Tests that entity type is passed correctly to the driver.
-   */
-  public function testParseEntityFieldsPassesEntityType(): void {
-    $classifier = $this->createMock(FieldClassifierInterface::class);
-    $classifier->expects($this->once())
-      ->method('fieldIsConfigurable')
-      ->with('taxonomy_term', 'field_test')
-      ->willReturn(TRUE);
-
-    $core = $this->createMock(CoreInterface::class);
-    $core->method('getFieldClassifier')->willReturn($classifier);
-
-    $driver = $this->createMock(DrupalDriver::class);
-    $driver->method('getCore')->willReturn($core);
-
-    $drupal = $this->createMock(DrupalDriverManagerInterface::class);
-    $drupal->method('getDriver')->willReturn($driver);
-
-    $context = new RawDrupalContext();
-    $context->setDrupal($drupal);
-
-    $stub = new EntityStub('taxonomy_term', NULL, ['field_test' => 'value']);
-    $context->parseEntityFields($stub);
+    return $context;
   }
 
 }


### PR DESCRIPTION
Closes #766

## Summary

Introduces a new `EntityFieldParser` that replaces the legacy field-value parsing logic in `RawDrupalContext::parseEntityFields()`. The new parser uses a single uniform escape mechanism (double quotes), detects compound mode by value form rather than separator spacing, and surfaces clear `ParseException` / `MultipleParseException` errors instead of returning silently malformed data. A new `field_parser` configuration flag in `behat.yml` lets projects opt into the legacy parser during migration; the legacy parser emits a deprecation notice once per process and is removed entirely in 6.1.

This also resolves #642 as a consequence: entity reference titles that contain ` - ` (e.g. `"My article - Part 2"`) no longer require any escaping in scalar mode, because dashes are treated as literal text and are not interpreted as compound separators by the modern parser.

## Changes

### New parser (`src/Drupal/DrupalExtension/Parser/`)

- `EntityFieldParser` - full rewrite of the field-value grammar with named column support, quoted-scalar detection, token syntax (`[relative:-1 week]`), and unambiguous compound detection via `key:"value"` pairs.
- `Exception/ParseException` - structured single-value error with file/line context for use in step-definition error messages.
- `Exception/MultipleParseException` - aggregates parse errors across a table so all failures surface in one shot.

### Context changes (`src/Drupal/DrupalExtension/Context/RawDrupalContext.php`)

- `parseEntityFields()` delegates to whichever parser is selected by `field_parser` config.
- New `getFieldParser()` factory reads the config flag and returns either `EntityFieldParser` or `LegacyEntityFieldParser` (with a one-time deprecation notice when `legacy` is chosen).

### Configuration (`src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php`)

- `field_parser` key added to the extension's config tree (values: `default` | `legacy`).

### Test coverage

- `tests/phpunit/src/Parser/EntityFieldParserTest.php` - 441 assertions covering all grammar branches, error paths, and edge cases.
- `tests/behat/features/field_handlers.feature` - updated to use modern syntax.
- `tests/behat/features/field_handlers_legacy.feature` - new file; exercises the legacy parser under the `drupal_legacy_parser` Behat profile.

### Migration docs

- `MIGRATION.md` - new "Field syntax" section with side-by-side syntax table and named-column reference.

## Before / After

### Parser selection flow

```
behat.yml: field_parser: default | legacy
                |
                v
     RawDrupalContext::parseEntityFields()
                |
                v
     RawDrupalContext::getFieldParser($entity_type, $classifier)
                |
                +-- field_parser == 'legacy'  ---> LegacyEntityFieldParser
                |   (also emits deprecation notice once per process)
                |
                +-- otherwise                 ---> EntityFieldParser
```

### Syntax comparison (selected cases)

```
                          Legacy                 Modern
                          ------                 ------
Compound single:          country: BE            country:"BE", locality:"Brussel"
                          - locality: Brussel

Scalar with dash:         "Alpha - Bravo"        Alpha - Bravo   (no escape needed)
   (resolves #642)        (workaround required)

Scalar with semicolon:    Hello; world           "Hello; world"

Token at compound pos:    (not expressible)      value:[relative:-1 week]
```

## Deprecation timeline

- **6.0 (this PR)**: `field_parser: legacy` is opt-in; selecting it emits a deprecation notice once per process.
- **6.1**: `field_parser: legacy` is removed; setting it produces a hard configuration error.

## Related

- https://github.com/jhedstrom/DrupalDriver/issues/365 - tracks future work in `drupal/drupal-driver` to formalize creation-hint property aliases; no driver change is required for this PR, but the issue is informational for field-type discoverability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced field-value parsing with structured key/value syntax, improved escape handling, and character-offset error reporting that aggregates multiple issues per cell.

* **Documentation**
  * Added migration guidance and parser reference documenting modern syntax, escape rules, whitespace semantics, and error-reporting behavior.

* **Configuration**
  * New parser selection option (modern default) with a deprecated legacy mode slated for removal.

* **Tests**
  * Expanded and reorganized test/feature suites to cover modern and legacy parsing, edge cases, and aggregated error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->