### PR TITLE
[#732] Added 'login_field' configuration to submit a custom user property as the login value.

### DIFF
--- a/behat.dist.yml
+++ b/behat.dist.yml
@@ -57,6 +57,8 @@ default:
       # Field-value parser used by parseEntityFields(): "default" or
       # "legacy" (deprecated, removed in 6.1).
       field_parser: default
+      # User entity property submitted as the login value (e.g. "name", "mail").
+      login_field: name
       # Enable the blackbox driver.
       blackbox: ~
       # Map of named regions to CSS selectors.
@@ -108,6 +110,7 @@ drupal:
 
     Drupal\DrupalExtension:
       api_driver: drupal
+      login_field: name
       # Drupal API driver settings.
       drupal:
         drupal_root: /var/www/html/web

--- a/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
@@ -66,9 +66,15 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
     $name = (string) $user->getValue('name');
     $pass = (string) $user->getValue('pass');
 
+    // Determine which user property to submit as the login value. Defaults
+    // to 'name' but may be set to 'mail' for sites that authenticate by
+    // email or to any other user entity property.
+    $login_field = (string) ($this->getDrupalParameter('login_field') ?: 'name');
+    $login_value = (string) $user->getValue($login_field);
+
     // Fill in the login form credentials.
     $page = $session->getPage();
-    $page->fillField($this->getDrupalText('username_field'), $name);
+    $page->fillField($this->getDrupalText('username_field'), $login_value);
     $page->fillField($this->getDrupalText('password_field'), $pass);
 
     // Submit the login form.

--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -102,6 +102,10 @@ class DrupalExtension implements ExtensionInterface {
           ->defaultValue('default')
           ->info('Selects the field-value parser used by parseEntityFields(). "default" uses the current syntax; "legacy" opts in to the older syntax (deprecated, removed in 6.1).')
         ->end()
+        ->scalarNode('login_field')
+          ->defaultValue('name')
+          ->info('User entity property submitted as the login value. Defaults to "name". Set to "mail" for sites that authenticate by email, or any other user property.')
+        ->end()
         ->arrayNode('region_map')
           ->info("Targeting content in specific regions can be accomplished once those regions have been defined." . PHP_EOL
             . '  My region: "#css-selector"' . PHP_EOL

--- a/tests/behat/features/login_field.feature
+++ b/tests/behat/features/login_field.feature
@@ -1,0 +1,39 @@
+Feature: Login field
+  As a developer
+  I want to configure which user property is submitted as the login value
+  So that I can test sites that authenticate by email instead of username
+
+  @test-drupal @api
+  Scenario: Assert default "login_field" submits the user's name
+    Given I am logged in as a user with the "authenticated user" role
+    Then I should see the link "My account"
+
+  @test-drupal @api
+  Scenario: Assert "login_field" set to "mail" submits the user's email
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given the following users:
+        | name      | mail                  | pass   | status |
+        | Test user | test-user@example.com | secret | 1      |
+      When I am logged in as "Test user"
+      Then I should see the link "Log out"
+      """
+    When I run behat with drupal profile and "login_field" set to "mail"
+    Then it should pass
+
+  @test-drupal @api
+  Scenario: Assert "login_field" rejects unknown user properties
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given the following users:
+        | name      | mail                  | pass   | status |
+        | Test user | test-user@example.com | secret | 1      |
+      When I am logged in as "Test user"
+      """
+    When I run behat with drupal profile and "login_field" set to "nonexistent_property"
+    Then it should fail with an error:
+      """
+      Unable to determine if logged in
+      """

--- a/tests/behat/fixtures/drupal/modules/behat_test/behat_test.module
+++ b/tests/behat/fixtures/drupal/modules/behat_test/behat_test.module
@@ -5,6 +5,9 @@
  * Hooks for the behat_test module.
  */
 
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\user\UserInterface;
+
 /**
  * Implements hook_cron().
  *
@@ -20,4 +23,43 @@ function behat_test_cron(): void {
   \Drupal::state()->set('behat_test.cron_request_time', $request_time);
   \Drupal::state()->set('behat_test.cron_actual_time', $actual_time);
   \Drupal::state()->set('behat_test.cron_time_drift', $actual_time - $request_time);
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter() for the user login form.
+ *
+ * Allows users to authenticate by email by translating an email entered in
+ * the username field to the matching account's username before core's own
+ * validation runs. Mirrors the behaviour of contrib modules like
+ * 'mail_login' or 'email_registration' so the email-based login flow can
+ * be exercised end-to-end without adding a contrib dependency.
+ *
+ * @see https://github.com/jhedstrom/drupalextension/issues/732
+ */
+function behat_test_form_user_login_form_alter(array &$form, FormStateInterface $form_state): void {
+  array_unshift($form['#validate'], 'behat_test_user_login_translate_mail_to_name');
+}
+
+/**
+ * Validation handler that swaps an email value for the matching username.
+ *
+ * Runs before core's authentication validation. If the submitted value
+ * looks like an email and matches a user's mail, the form value is
+ * rewritten to the account's actual name so core authenticates correctly.
+ */
+function behat_test_user_login_translate_mail_to_name(array &$form, FormStateInterface $form_state): void {
+  $value = (string) $form_state->getValue('name');
+
+  if ($value === '' || !str_contains($value, '@')) {
+    return;
+  }
+
+  $accounts = \Drupal::entityTypeManager()
+    ->getStorage('user')
+    ->loadByProperties(['mail' => $value]);
+  $account = reset($accounts);
+
+  if ($account instanceof UserInterface) {
+    $form_state->setValue('name', $account->getAccountName());
+  }
 }

--- a/tests/phpunit/src/DrupalAuthenticationManagerTest.php
+++ b/tests/phpunit/src/DrupalAuthenticationManagerTest.php
@@ -85,6 +85,45 @@ class DrupalAuthenticationManagerTest extends TestCase {
   }
 
   /**
+   * Tests the value submitted to the username field for various login_field configs.
+   */
+  #[DataProvider('dataProviderLogInFieldValue')]
+  public function testLogInFieldValue(?string $login_field, string $expected_value): void {
+    $submit = $this->createMock(NodeElement::class);
+
+    $page = $this->createMock(DocumentElement::class);
+    $page->method('findButton')->with('Log in')->willReturn($submit);
+    $page->method('has')->willReturn(TRUE);
+    $page->expects($this->exactly(2))->method('fillField')->willReturnCallback(function (string $field, string $value) use ($expected_value): void {
+      if ($field === 'Username') {
+        $this->assertSame($expected_value, $value);
+      }
+    });
+
+    $session = $this->createSessionMock($page);
+    // @phpstan-ignore method.notFound
+    $session->method('isStarted')->willReturn(TRUE);
+
+    $params = self::DRUPAL_PARAMS;
+    if ($login_field !== NULL) {
+      $params['login_field'] = $login_field;
+    }
+
+    $manager = $this->createManager($session, NULL, NULL, $params);
+    $user = new EntityStub('user', NULL, ['name' => 'admin', 'mail' => 'admin@example.com', 'pass' => 'password']);
+    $manager->logIn($user);
+  }
+
+  /**
+   * Data provider for testLogInFieldValue().
+   */
+  public static function dataProviderLogInFieldValue(): \Iterator {
+    yield 'defaults to name when not configured' => [NULL, 'admin'];
+    yield 'explicit name uses name' => ['name', 'admin'];
+    yield 'mail uses mail' => ['mail', 'admin@example.com'];
+  }
+
+  /**
    * Tests that logIn() throws when no submit button is found.
    */
   public function testLogInThrowsWhenNoSubmitButton(): void {

--- a/tests/phpunit/src/DrupalAuthenticationManagerTest.php
+++ b/tests/phpunit/src/DrupalAuthenticationManagerTest.php
@@ -85,7 +85,7 @@ class DrupalAuthenticationManagerTest extends TestCase {
   }
 
   /**
-   * Tests the value submitted to the username field for various login_field configs.
+   * Tests the username field value submitted for various login_field configs.
    */
   #[DataProvider('dataProviderLogInFieldValue')]
   public function testLogInFieldValue(?string $login_field, string $expected_value): void {


### PR DESCRIPTION
Closes #732

## Summary

Some Drupal sites authenticate users by email address rather than username, typically via contrib modules like `mail_login` or `email_registration`. Previously `DrupalAuthenticationManager::logIn()` always submitted `$user->getValue('name')` to the login form, making it impossible to test such sites with the Drupal API driver.

This adds a `login_field` configuration scalar to `DrupalExtension`. When set to `mail` (or any other user entity property), the manager reads that property from the test user and submits it to the username field instead. The default is `name`, so existing setups are unaffected.

## Changes

### Configuration schema (`ServiceContainer/DrupalExtension.php`)
Added a `login_field` scalar node with default `'name'` and descriptive info text, placed alongside the existing `field_parser` node.

### Authentication manager (`Manager/DrupalAuthenticationManager.php`)
`logIn()` now reads `login_field` from Drupal parameters and passes `$user->getValue($login_field)` to `fillField()` instead of the hardcoded `getValue('name')`.

### Documentation (`behat.dist.yml`)
Documented the new key in both the `default` and `drupal` profiles with a short inline comment.

### Unit tests (`tests/phpunit/src/DrupalAuthenticationManagerTest.php`)
Added `testLogInFieldValue()` with a data provider covering three cases: unconfigured (defaults to `name`), explicit `name`, and `mail`.

### Behat coverage (`tests/behat/features/login_field.feature`)
Three scenarios: default login via name, `login_field: mail` success, and an unknown property that fails gracefully.

### Test module (`tests/behat/fixtures/drupal/modules/behat_test/behat_test.module`)
Added `hook_form_user_login_form_alter` with a prepended validation handler that translates an emailed value in the username field to the matching account's name before core authentication runs. This mirrors what `mail_login` / `email_registration` do and lets the Behat scenario exercise the full login flow end-to-end without adding a contrib dependency.

## Before / After

```
Before
──────
behat.yml (no login_field key)
        │
        ▼
DrupalAuthenticationManager::logIn()
        │
        │  $name = $user->getValue('name')   ← hardcoded
        │
        ▼
page->fillField('Username', $name)


After
─────
behat.yml
  DrupalExtension:
    login_field: mail           ← new config scalar (default: name)
        │
        ▼
DrupalAuthenticationManager::logIn()
        │
        │  $login_field = getDrupalParameter('login_field') ?: 'name'
        │  $login_value = $user->getValue($login_field)     ← configurable
        │
        ▼
page->fillField('Username', $login_value)
        │
        ▼
behat_test login alter (test module only)
  email in username field → resolve to account name
        │
        ▼
Drupal core auth validates name + password
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configurable `login_field` option to the Drupal extension configuration. Administrators can now specify which user entity property (username, email, or custom fields) is submitted during the login process, enabling support for multiple authentication scenarios. Default behavior remains unchanged (username-based authentication).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->