### PR TITLE
Moved 'ClassGenerator' out of 'Context/ContextClass/' into a top-level 'Generator/' namespace.

### DIFF
--- a/src/Drupal/DrupalExtension/Generator/ClassGenerator.php
+++ b/src/Drupal/DrupalExtension/Generator/ClassGenerator.php
@@ -2,13 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Drupal\DrupalExtension\Context\ContextClass;
+namespace Drupal\DrupalExtension\Generator;
 
 use Behat\Behat\Context\ContextClass\ClassGenerator as BehatClassGenerator;
 use Behat\Testwork\Suite\Suite;
 
 /**
  * Generates a starting class that extends the RawDrupalContext.
+ *
+ * Replaces Behat's default 'Behat\Behat\Context\ContextClass\ClassGenerator'
+ * for the 'context.class_generator.simple' service tag.
  */
 class ClassGenerator implements BehatClassGenerator {
 

--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -9,7 +9,7 @@ use Behat\Testwork\ServiceContainer\Extension as ExtensionInterface;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
 use Drupal\DrupalExtension\Compiler\DriverPass;
 use Drupal\DrupalExtension\Compiler\EventSubscriberPass;
-use Drupal\DrupalExtension\Context\ContextClass\ClassGenerator;
+use Drupal\DrupalExtension\Generator\ClassGenerator;
 use Behat\Mink\Element\DocumentElement as MinkDocumentElement;
 use Drupal\DrupalExtension\Element\DocumentElement;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -362,6 +362,36 @@ EOL;
   }
 
   /**
+   * Asserts a file in the working directory matches the expected content.
+   *
+   * Mirrors the upstream "<path> file should contain:" step but does not
+   * depend on PHPUnit. CI runs strip 'phpunit/phpunit' from the non-coverage
+   * matrix, where the upstream step fatals on the missing 'Assert' class.
+   */
+  #[Then('the file :path should match:')]
+  public function behatCliAssertFileMatches(string $path, PyStringNode $text): void {
+    $absolute = $this->workingDir . DIRECTORY_SEPARATOR . $path;
+
+    if (!is_file($absolute)) {
+      throw new \RuntimeException(sprintf('Expected file "%s" does not exist.', $absolute));
+    }
+
+    $actual = trim((string) file_get_contents($absolute));
+
+    if (PHP_EOL !== "\n") {
+      $actual = str_replace(PHP_EOL, "\n", $actual);
+    }
+
+    $expected = trim((string) $text);
+
+    if ($actual === $expected) {
+      return;
+    }
+
+    throw new \RuntimeException(sprintf("File \"%s\" content does not match expected.\n--- Expected ---\n%s\n--- Actual ---\n%s", $path, $expected, $actual));
+  }
+
+  /**
    * Helper to print file comments.
    */
   protected static function behatCliPrintFileContents(string $filename, string $title = '') {

--- a/tests/behat/features/class_generator.feature
+++ b/tests/behat/features/class_generator.feature
@@ -1,0 +1,102 @@
+@class_generator
+Feature: Class generator integration
+
+  In order to scaffold context classes that integrate with the Drupal Extension
+  As a Behat user with the Drupal Extension enabled
+  I want 'behat --init' to produce a starter context class extending RawDrupalContext
+
+  @test-blackbox
+  Scenario: Assert "behat --init" generates a context class extending 'RawDrupalContext' for a non-namespaced suite context
+    Given a file named "behat.yml" with:
+      """
+      default:
+        suites:
+          default:
+            contexts:
+              - GeneratedFeatureContext
+        extensions:
+          Drupal\MinkExtension:
+            browserkit_http: ~
+            base_url: http://blackbox
+          Drupal\DrupalExtension:
+            blackbox: ~
+      """
+    When I run "behat --init --no-colors"
+    Then it should pass with:
+      """
+      """
+    And "features/bootstrap/GeneratedFeatureContext.php" file should contain:
+      """
+      <?php
+
+      use Drupal\DrupalExtension\Context\RawDrupalContext;
+      use Behat\Gherkin\Node\PyStringNode;
+      use Behat\Gherkin\Node\TableNode;
+      use Behat\Behat\Tester\Exception\PendingException;
+
+      /**
+       * Defines application features from the specific context.
+       */
+      class GeneratedFeatureContext extends RawDrupalContext {
+
+        /**
+         * Initializes context.
+         *
+         * Every scenario gets its own context instance.
+         * You can also pass arbitrary arguments to the
+         * context constructor through behat.yml.
+         */
+        public function __construct() {
+        }
+
+      }
+      """
+
+  @test-blackbox
+  Scenario: Assert "behat --init" generates a namespaced context class extending 'RawDrupalContext'
+    Given a file named "behat.yml" with:
+      """
+      default:
+        suites:
+          default:
+            contexts:
+              - App\Tests\Behat\GeneratedFeatureContext
+        extensions:
+          Drupal\MinkExtension:
+            browserkit_http: ~
+            base_url: http://blackbox
+          Drupal\DrupalExtension:
+            blackbox: ~
+      """
+    When I run "behat --init --no-colors"
+    Then it should pass with:
+      """
+      """
+    And "features/bootstrap/App/Tests/Behat/GeneratedFeatureContext.php" file should contain:
+      """
+      <?php
+
+      namespace App\Tests\Behat;
+
+      use Drupal\DrupalExtension\Context\RawDrupalContext;
+      use Behat\Gherkin\Node\PyStringNode;
+      use Behat\Gherkin\Node\TableNode;
+      use Behat\Behat\Tester\Exception\PendingException;
+
+      /**
+       * Defines application features from the specific context.
+       */
+      class GeneratedFeatureContext extends RawDrupalContext {
+
+        /**
+         * Initializes context.
+         *
+         * Every scenario gets its own context instance.
+         * You can also pass arbitrary arguments to the
+         * context constructor through behat.yml.
+         */
+        public function __construct() {
+        }
+
+      }
+      """

--- a/tests/behat/features/class_generator.feature
+++ b/tests/behat/features/class_generator.feature
@@ -25,7 +25,7 @@ Feature: Class generator integration
     Then it should pass with:
       """
       """
-    And "features/bootstrap/GeneratedFeatureContext.php" file should contain:
+    And the file "features/bootstrap/GeneratedFeatureContext.php" should match:
       """
       <?php
 
@@ -72,7 +72,7 @@ Feature: Class generator integration
     Then it should pass with:
       """
       """
-    And "features/bootstrap/App/Tests/Behat/GeneratedFeatureContext.php" file should contain:
+    And the file "features/bootstrap/App/Tests/Behat/GeneratedFeatureContext.php" should match:
       """
       <?php
 

--- a/tests/phpunit/src/ClassGeneratorTest.php
+++ b/tests/phpunit/src/ClassGeneratorTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Tests;
+
+use Behat\Testwork\Suite\Suite;
+use Drupal\DrupalExtension\Generator\ClassGenerator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the starter context class generator.
+ */
+#[CoversClass(ClassGenerator::class)]
+class ClassGeneratorTest extends TestCase {
+
+  /**
+   * Tests that the generator declares support for any suite and class.
+   */
+  public function testSupportsSuiteAndClassReturnsTrue(): void {
+    $generator = new ClassGenerator();
+    $suite = $this->createMock(Suite::class);
+
+    $this->assertTrue($generator->supportsSuiteAndClass($suite, 'Anything'));
+  }
+
+  /**
+   * Tests starter class output for namespaced and rootless context classes.
+   *
+   * @param string $context_class
+   *   Fully qualified class name passed to the generator.
+   * @param string $expected
+   *   Exact expected generated source.
+   */
+  #[DataProvider('dataProviderGenerateClass')]
+  public function testGenerateClass(string $context_class, string $expected): void {
+    $generator = new ClassGenerator();
+    $suite = $this->createMock(Suite::class);
+
+    $this->assertSame($expected, $generator->generateClass($suite, $context_class));
+  }
+
+  /**
+   * Provides FQCN inputs and the exact source the generator should emit.
+   *
+   * @return \Iterator<string, array{string, string}>
+   *   Cases keyed by description, each [context class FQCN, expected source].
+   */
+  public static function dataProviderGenerateClass(): \Iterator {
+    $namespaced = <<<'PHP'
+<?php
+
+namespace App\Tests\Behat;
+
+use Drupal\DrupalExtension\Context\RawDrupalContext;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Behat\Tester\Exception\PendingException;
+
+/**
+ * Defines application features from the specific context.
+ */
+class FeatureContext extends RawDrupalContext {
+
+  /**
+   * Initializes context.
+   *
+   * Every scenario gets its own context instance.
+   * You can also pass arbitrary arguments to the
+   * context constructor through behat.yml.
+   */
+  public function __construct() {
+  }
+
+}
+
+PHP;
+
+    $rootless = <<<'PHP'
+<?php
+
+use Drupal\DrupalExtension\Context\RawDrupalContext;
+use Behat\Gherkin\Node\PyStringNode;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Behat\Tester\Exception\PendingException;
+
+/**
+ * Defines application features from the specific context.
+ */
+class FeatureContext extends RawDrupalContext {
+
+  /**
+   * Initializes context.
+   *
+   * Every scenario gets its own context instance.
+   * You can also pass arbitrary arguments to the
+   * context constructor through behat.yml.
+   */
+  public function __construct() {
+  }
+
+}
+
+PHP;
+
+    yield 'fully qualified class name' => ['App\\Tests\\Behat\\FeatureContext', $namespaced];
+    yield 'class without namespace' => ['FeatureContext', $rootless];
+  }
+
+}


### PR DESCRIPTION
## Summary

The `ClassGenerator` class - Behat's `behat --init` scaffolder for Drupal context classes - previously lived at `src/Drupal/DrupalExtension/Context/ContextClass/ClassGenerator.php`, mirroring the upstream Behat namespace structure. This placed a non-context class directly alongside the actual step-defining contexts (`DrupalContext`, `MarkupContext`, `MailContext`, etc.), making the `Context/` directory confusing to navigate.

This PR moves `ClassGenerator` to a dedicated `Generator/` namespace that accurately describes its role: generating starter context class files. The `ServiceContainer/DrupalExtension.php` `use` statement is updated accordingly, and a PHPUnit test is added covering both namespaced and rootless context-class FQCNs plus a `supportsSuiteAndClass` smoke test.

No public API consumed by downstream user code is affected - `ClassGenerator` is only ever instantiated via Behat's DI from inside the extension itself.

## Changes

**Moved and renamed namespace:**
- `src/Drupal/DrupalExtension/Context/ContextClass/ClassGenerator.php` - moved to `src/Drupal/DrupalExtension/Generator/ClassGenerator.php`
- Namespace updated from `Drupal\DrupalExtension\Context\ContextClass` to `Drupal\DrupalExtension\Generator`
- Added docblock note explaining the class replaces Behat's default `Behat\Behat\Context\ContextClass\ClassGenerator` for the `context.class_generator.simple` service tag
- `Context/ContextClass/` directory removed (now empty)

**Updated consumer:**
- `src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php` - updated `use` statement to reference the new namespace

**New test:**
- `tests/phpunit/src/ClassGeneratorTest.php` - 3 tests covering `supportsSuiteAndClass()` returns true, and `generateClass()` output for both namespaced FQCNs and rootless class names, using data providers and heredoc exact-match assertions

## Before / After

```
Before:
  src/Drupal/DrupalExtension/
    Context/
      DrupalContext.php
      MarkupContext.php
      MailContext.php
      MinkContext.php
      ...
      ContextClass/
        ClassGenerator.php   <- not a context; confusing neighbour
      Initializer/
      Environment/
    ServiceContainer/
      DrupalExtension.php    <- use Context\ContextClass\ClassGenerator

After:
  src/Drupal/DrupalExtension/
    Context/
      DrupalContext.php
      MarkupContext.php
      MailContext.php
      MinkContext.php
      ...
      Initializer/
      Environment/
    Generator/
      ClassGenerator.php     <- new home; honest name
    ServiceContainer/
      DrupalExtension.php    <- use Generator\ClassGenerator
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal class generator structure for better code organization.

* **Tests**
  * Added comprehensive test coverage for class generation and Behat integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->