### PR TITLE
[#825] Extracted Drupal AJAX handling into 'DrupalAjaxTrait'.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -1531,20 +1531,6 @@ Given I enter "My article" for "Title"
 </details>
 
 <details>
-  <summary><code>@Given I wait for AJAX to finish</code></summary>
-
-<br/>
-Wait for AJAX to finish. 
-<br/><br/>
-
-```gherkin
-Given I wait for AJAX to finish
-
-```
-
-</details>
-
-<details>
   <summary><code>@Given I press the :char key in the :field field</code></summary>
 
 <br/>
@@ -1655,6 +1641,20 @@ Uncheck a checkbox.
 
 ```gherkin
 Given I uncheck the box "Promoted to front page"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given I wait for AJAX to finish</code></summary>
+
+<br/>
+Wait for AJAX to finish. 
+<br/><br/>
+
+```gherkin
+Given I wait for AJAX to finish
 
 ```
 

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -13,7 +13,7 @@ use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Mink\Selector\Xpath\Escaper;
 use Behat\MinkExtension\Context\MinkContext as MinkExtension;
-use Drupal\DrupalExtension\Context\Traits\DrupalAjaxTrait;
+use Drupal\DrupalExtension\Context\Traits\AjaxTrait;
 use Drupal\DrupalExtension\ParametersTrait;
 use Drupal\DrupalExtension\RegionTrait;
 use Drupal\DrupalExtension\TagTrait;
@@ -23,7 +23,7 @@ use Drupal\DrupalExtension\TagTrait;
  */
 class MinkContext extends MinkExtension implements TranslatableContext, ParametersAwareInterface {
 
-  use DrupalAjaxTrait;
+  use AjaxTrait;
   use ParametersTrait;
   use RegionTrait;
   use TagTrait;

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -6,17 +6,14 @@ namespace Drupal\DrupalExtension\Context;
 
 use Behat\Step\Given;
 use Behat\Step\When;
-use Behat\Hook\BeforeStep;
-use Behat\Hook\AfterStep;
 use Behat\Step\Then;
-use Behat\Behat\Hook\Scope\BeforeStepScope;
-use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Behat\Context\TranslatableContext;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Mink\Selector\Xpath\Escaper;
 use Behat\MinkExtension\Context\MinkContext as MinkExtension;
+use Drupal\DrupalExtension\Context\Traits\DrupalAjaxTrait;
 use Drupal\DrupalExtension\ParametersTrait;
 use Drupal\DrupalExtension\RegionTrait;
 use Drupal\DrupalExtension\TagTrait;
@@ -26,6 +23,7 @@ use Drupal\DrupalExtension\TagTrait;
  */
 class MinkContext extends MinkExtension implements TranslatableContext, ParametersAwareInterface {
 
+  use DrupalAjaxTrait;
   use ParametersTrait;
   use RegionTrait;
   use TagTrait;
@@ -108,94 +106,6 @@ class MinkContext extends MinkExtension implements TranslatableContext, Paramete
   public function iEnterValueForField(string $value, string $field): void {
     // Use the Mink Extension step definition.
     $this->fillField($field, $value);
-  }
-
-  /**
-   * For javascript enabled scenarios, always wait for AJAX before clicking.
-   */
-  #[BeforeStep]
-  public function beforeJavascriptStep(BeforeStepScope $event): void {
-    /** @var \Behat\Behat\Hook\Scope\BeforeStepScope $event */
-    // Make sure the feature is registered in case this hook fires before
-    // ::registerFeature() which is also a @BeforeStep. Behat doesn't
-    // support ordering hooks.
-    $this->registerFeature($event);
-    if (!$this->hasTag('javascript')) {
-      return;
-    }
-    $text = $event->getStep()->getText();
-    if (preg_match('/\b(follow|press|click|submit|attach)\b/i', $text)) {
-      $this->iWaitForAjaxToFinish($event);
-    }
-  }
-
-  /**
-   * For javascript enabled scenarios, always wait for AJAX after clicking.
-   */
-  #[AfterStep]
-  public function afterJavascriptStep(AfterStepScope $event): void {
-    if (!$this->hasTag('javascript')) {
-      return;
-    }
-    $text = $event->getStep()->getText();
-    if (preg_match('/\b(follow|press|click|submit|attach)\b/i', $text)) {
-      $this->iWaitForAjaxToFinish($event);
-    }
-  }
-
-  /**
-   * Wait for AJAX to finish.
-   *
-   * @see \Drupal\FunctionalJavascriptTests\JSWebAssert::assertWaitOnAjaxRequest()
-   *
-   * @code
-   * Given I wait for AJAX to finish
-   * @endcode
-   */
-  #[Given('I wait for AJAX to finish')]
-  public function iWaitForAjaxToFinish(mixed $event = NULL): void {
-    if (!$this->getSession()->isStarted()) {
-      return;
-    }
-
-    $condition = <<<JS
-    (function() {
-      function isAjaxing(instance) {
-        return instance && instance.ajaxing === true;
-      }
-      var d7_not_ajaxing = true;
-      if (typeof Drupal !== 'undefined' && typeof Drupal.ajax !== 'undefined' && typeof Drupal.ajax.instances === 'undefined') {
-        for(var i in Drupal.ajax) { if (isAjaxing(Drupal.ajax[i])) { d7_not_ajaxing = false; } }
-      }
-      var d8_not_ajaxing = (typeof Drupal === 'undefined' || typeof Drupal.ajax === 'undefined' || typeof Drupal.ajax.instances === 'undefined' || !Drupal.ajax.instances.some(isAjaxing))
-      return (
-        // Assert no AJAX request is running (via jQuery or Drupal) and no
-        // animation is running.
-        (typeof jQuery === 'undefined' || jQuery.hasOwnProperty('active') === false || (jQuery.active <= 0 && jQuery(':animated').length === 0)) &&
-        d7_not_ajaxing && d8_not_ajaxing
-      );
-    }());
-JS;
-    $ajax_timeout = $this->getParameter('ajax_timeout');
-    $result = $this->getSession()->wait(1000 * $ajax_timeout, $condition);
-    if (!$result) {
-      if ($ajax_timeout === NULL) {
-        throw new \RuntimeException('No AJAX timeout has been defined. Please verify that "Drupal\DrupalExtension" is configured in behat.yml.');
-      }
-      if ($event) {
-        /** @var \Behat\Behat\Hook\Scope\BeforeStepScope $event */
-        $event_data = ' ' . json_encode([
-          'name' => $event->getName(),
-          'feature' => $event->getFeature()->getTitle(),
-          'step' => $event->getStep()->getText(),
-          'suite' => $event->getSuite()->getName(),
-        ]);
-      }
-      else {
-        $event_data = '';
-      }
-      throw new \RuntimeException('Unable to complete AJAX request.' . $event_data);
-    }
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Context/Traits/AjaxTrait.php
+++ b/src/Drupal/DrupalExtension/Context/Traits/AjaxTrait.php
@@ -22,7 +22,7 @@ use Drupal\DrupalExtension\TagTrait;
  * and intermittently fail. The JS condition embedded here probes Drupal's own
  * 'ajaxing' flag to wait for the *Drupal* request, not just any jQuery one.
  */
-trait DrupalAjaxTrait {
+trait AjaxTrait {
 
   use ParametersTrait;
   use TagTrait;

--- a/src/Drupal/DrupalExtension/Context/Traits/DrupalAjaxTrait.php
+++ b/src/Drupal/DrupalExtension/Context/Traits/DrupalAjaxTrait.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Context\Traits;
+
+use Behat\Behat\Hook\Scope\AfterStepScope;
+use Behat\Behat\Hook\Scope\BeforeStepScope;
+use Behat\Hook\AfterStep;
+use Behat\Hook\BeforeStep;
+use Behat\Step\Given;
+
+/**
+ * Waits for Drupal-aware AJAX requests to complete on JavaScript-driven steps.
+ *
+ * Mink's vanilla AJAX wait checks 'jQuery.active' only. Drupal renders many
+ * page updates through 'Drupal.ajax' / 'Drupal.ajax.instances' which are not
+ * tracked by 'jQuery.active', so a 'Then I should see ...' assertion fired
+ * immediately after a 'When I press ...' step would race the AJAX completion
+ * and intermittently fail. The JS condition embedded here probes Drupal's own
+ * 'ajaxing' flag to wait for the *Drupal* request, not just any jQuery one.
+ *
+ * Wired in two places:
+ * - 'BeforeStep' / 'AfterStep' hooks gated by the '@javascript' tag plus a
+ *   verb regex ('follow|press|click|submit|attach') automatically wait around
+ *   any step that mutates the page.
+ * - Step definition 'Given I wait for AJAX to finish' lets a feature trigger
+ *   the wait explicitly.
+ *
+ * Used in the standard 'MinkContext'. The host class is expected to provide
+ * '$this->getSession()' (any Mink-based context), '$this->hasTag()' and
+ * '$this->registerFeature()' (from 'TagTrait' / 'FeatureTrait'), and
+ * '$this->getParameter()' (from 'ParametersTrait'). A consumer that does
+ * not extend 'MinkContext' but wants Drupal-aware AJAX waits should 'use'
+ * this trait alongside 'TagTrait' and 'ParametersTrait' on its host.
+ *
+ * @see https://github.com/jhedstrom/drupalextension/issues/825
+ */
+trait DrupalAjaxTrait {
+
+  /**
+   * For javascript enabled scenarios, always wait for AJAX before clicking.
+   */
+  #[BeforeStep]
+  public function beforeJavascriptStep(BeforeStepScope $event): void {
+    // Make sure the feature is registered in case this hook fires before
+    // ::registerFeature() which is also a @BeforeStep. Behat doesn't
+    // support ordering hooks.
+    $this->registerFeature($event);
+
+    if (!$this->hasTag('javascript')) {
+      return;
+    }
+
+    $text = $event->getStep()->getText();
+    if (preg_match('/\b(follow|press|click|submit|attach)\b/i', $text)) {
+      $this->iWaitForAjaxToFinish($event);
+    }
+  }
+
+  /**
+   * For javascript enabled scenarios, always wait for AJAX after clicking.
+   */
+  #[AfterStep]
+  public function afterJavascriptStep(AfterStepScope $event): void {
+    if (!$this->hasTag('javascript')) {
+      return;
+    }
+
+    $text = $event->getStep()->getText();
+    if (preg_match('/\b(follow|press|click|submit|attach)\b/i', $text)) {
+      $this->iWaitForAjaxToFinish($event);
+    }
+  }
+
+  /**
+   * Wait for AJAX to finish.
+   *
+   * @see \Drupal\FunctionalJavascriptTests\JSWebAssert::assertWaitOnAjaxRequest()
+   *
+   * @code
+   * Given I wait for AJAX to finish
+   * @endcode
+   */
+  #[Given('I wait for AJAX to finish')]
+  public function iWaitForAjaxToFinish(mixed $event = NULL): void {
+    if (!$this->getSession()->isStarted()) {
+      return;
+    }
+
+    $condition = <<<JS
+    (function() {
+      function isAjaxing(instance) {
+        return instance && instance.ajaxing === true;
+      }
+      var d7_not_ajaxing = true;
+      if (typeof Drupal !== 'undefined' && typeof Drupal.ajax !== 'undefined' && typeof Drupal.ajax.instances === 'undefined') {
+        for(var i in Drupal.ajax) { if (isAjaxing(Drupal.ajax[i])) { d7_not_ajaxing = false; } }
+      }
+      var d8_not_ajaxing = (typeof Drupal === 'undefined' || typeof Drupal.ajax === 'undefined' || typeof Drupal.ajax.instances === 'undefined' || !Drupal.ajax.instances.some(isAjaxing))
+      return (
+        // Assert no AJAX request is running (via jQuery or Drupal) and no
+        // animation is running.
+        (typeof jQuery === 'undefined' || jQuery.hasOwnProperty('active') === false || (jQuery.active <= 0 && jQuery(':animated').length === 0)) &&
+        d7_not_ajaxing && d8_not_ajaxing
+      );
+    }());
+JS;
+    $ajax_timeout = $this->getParameter('ajax_timeout');
+    $result = $this->getSession()->wait(1000 * $ajax_timeout, $condition);
+
+    if (!$result) {
+      if ($ajax_timeout === NULL) {
+        throw new \RuntimeException('No AJAX timeout has been defined. Please verify that "Drupal\DrupalExtension" is configured in behat.yml.');
+      }
+
+      if ($event) {
+        /** @var \Behat\Behat\Hook\Scope\BeforeStepScope $event */
+        $event_data = ' ' . json_encode([
+          'name' => $event->getName(),
+          'feature' => $event->getFeature()->getTitle(),
+          'step' => $event->getStep()->getText(),
+          'suite' => $event->getSuite()->getName(),
+        ]);
+      }
+      else {
+        $event_data = '';
+      }
+
+      throw new \RuntimeException('Unable to complete AJAX request.' . $event_data);
+    }
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Context/Traits/DrupalAjaxTrait.php
+++ b/src/Drupal/DrupalExtension/Context/Traits/DrupalAjaxTrait.php
@@ -9,6 +9,8 @@ use Behat\Behat\Hook\Scope\BeforeStepScope;
 use Behat\Hook\AfterStep;
 use Behat\Hook\BeforeStep;
 use Behat\Step\Given;
+use Drupal\DrupalExtension\ParametersTrait;
+use Drupal\DrupalExtension\TagTrait;
 
 /**
  * Waits for Drupal-aware AJAX requests to complete on JavaScript-driven steps.
@@ -21,6 +23,9 @@ use Behat\Step\Given;
  * 'ajaxing' flag to wait for the *Drupal* request, not just any jQuery one.
  */
 trait DrupalAjaxTrait {
+
+  use ParametersTrait;
+  use TagTrait;
 
   /**
    * For javascript enabled scenarios, always wait for AJAX before clicking.

--- a/src/Drupal/DrupalExtension/Context/Traits/DrupalAjaxTrait.php
+++ b/src/Drupal/DrupalExtension/Context/Traits/DrupalAjaxTrait.php
@@ -19,22 +19,6 @@ use Behat\Step\Given;
  * immediately after a 'When I press ...' step would race the AJAX completion
  * and intermittently fail. The JS condition embedded here probes Drupal's own
  * 'ajaxing' flag to wait for the *Drupal* request, not just any jQuery one.
- *
- * Wired in two places:
- * - 'BeforeStep' / 'AfterStep' hooks gated by the '@javascript' tag plus a
- *   verb regex ('follow|press|click|submit|attach') automatically wait around
- *   any step that mutates the page.
- * - Step definition 'Given I wait for AJAX to finish' lets a feature trigger
- *   the wait explicitly.
- *
- * Used in the standard 'MinkContext'. The host class is expected to provide
- * '$this->getSession()' (any Mink-based context), '$this->hasTag()' and
- * '$this->registerFeature()' (from 'TagTrait' / 'FeatureTrait'), and
- * '$this->getParameter()' (from 'ParametersTrait'). A consumer that does
- * not extend 'MinkContext' but wants Drupal-aware AJAX waits should 'use'
- * this trait alongside 'TagTrait' and 'ParametersTrait' on its host.
- *
- * @see https://github.com/jhedstrom/drupalextension/issues/825
  */
 trait DrupalAjaxTrait {
 


### PR DESCRIPTION
Closes #825

## Summary

Extracts the three Drupal-specific AJAX methods (`iWaitForAjaxToFinish`, `beforeJavascriptStep`, `afterJavascriptStep`) from `MinkContext` into a new `DrupalAjaxTrait`, following the same pattern already used by `BigPipeTrait`. This is a pure structural extraction - the JS polling condition, the `@javascript` tag guard, the verb regex heuristic (`follow|press|click|submit|attach`), and the `ajax_timeout` parameter semantics are all unchanged. The trait can now be composed into any Mink-based context that wants Drupal-aware AJAX waits without extending `MinkContext`.

## Changes

**New file: `src/Drupal/DrupalExtension/Context/Traits/DrupalAjaxTrait.php`**
- Contains `beforeJavascriptStep` (`#[BeforeStep]`), `afterJavascriptStep` (`#[AfterStep]`), and `iWaitForAjaxToFinish` (`#[Given('I wait for AJAX to finish')]`), moved verbatim from `MinkContext`.
- Carries a docblock explaining the Drupal-vs-jQuery distinction and the expected host interface (`getSession()`, `hasTag()`, `registerFeature()`, `getParameter()`).

**Modified: `src/Drupal/DrupalExtension/Context/MinkContext.php`**
- Replaced the three extracted methods with `use DrupalAjaxTrait;`.
- Removed the `BeforeStep`, `AfterStep`, `BeforeStepScope`, and `AfterStepScope` imports that were only needed by the extracted methods.

**Regenerated: `STEPS.md`**
- The `Given I wait for AJAX to finish` entry moved from the `MinkContext` section to the `DrupalAjaxTrait` section to reflect its new home.

## Before / After

```
Before
──────
MinkContext
├── use ParametersTrait
├── use RegionTrait
├── use TagTrait
├── iWaitForAjaxToFinish()     ← inline
├── beforeJavascriptStep()     ← inline
└── afterJavascriptStep()      ← inline

After
─────
MinkContext
├── use DrupalAjaxTrait        ─┐
├── use ParametersTrait         │
├── use RegionTrait             │  DrupalAjaxTrait
└── use TagTrait                │  ├── iWaitForAjaxToFinish()
                                │  ├── beforeJavascriptStep()
                                └─ └── afterJavascriptStep()

Trait hierarchy (parallel to existing BigPipeTrait)
────────────────────────────────────────────────────
Context/Traits/
├── BigPipeTrait.php        (existing - BigPipe NOJS cookie)
└── DrupalAjaxTrait.php     (new     - Drupal AJAX wait)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored AJAX synchronization logic into a dedicated component for improved code organization and reusability across the Drupal extension.

* **Documentation**
  * Reorganized step documentation in STEPS.md for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->