### PR TITLE
[#826] Documented 'ParametersTrait' and 'RegionTrait' as Mink-only consumption points.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -234,6 +234,38 @@ in the table above. Other entries under
 `Drupal\DrupalExtension.selectors:` (`login_form_selector`,
 `logged_in_selector`) are unaffected.
 
+## Configuration: `region_map` renamed to `regions`
+
+The `region_map` configuration key under `Drupal\DrupalExtension` has been
+renamed to `regions`. The structure is unchanged.
+
+Update `behat.yml`:
+
+```yaml
+# 5.x and pre-rename 6.0
+default:
+  extensions:
+    Drupal\DrupalExtension:
+      region_map:
+        Header: '#header'
+        Content: '#main'
+
+# 6.0
+default:
+  extensions:
+    Drupal\DrupalExtension:
+      regions:
+        Header: '#header'
+        Content: '#main'
+```
+
+`region_map` still works during the 6.0 cycle - it emits a one-shot
+deprecation notice on extension load and is removed in 6.1. If both
+keys are present, an entry under `regions` overrides the same key
+under `region_map`. The merged map is exposed to contexts as
+`getParameter('regions')` and to Mink's `region` selector as the
+`drupal.regions` container parameter.
+
 ## Configuration: `ajax_timeout`
 
 `ajax_timeout` has moved from `Drupal\MinkExtension` to `Drupal\DrupalExtension`.

--- a/behat.dist.yml
+++ b/behat.dist.yml
@@ -58,8 +58,9 @@ default:
       login_field: name
       # Enable the blackbox driver.
       blackbox: ~
-      # Map of named regions to CSS selectors.
-      region_map:
+      # Map of named regions to CSS selectors. Region steps such as
+      # 'I press :button in the :region region' resolve against this map.
+      regions:
         Content: '#main .region-content'
         Header: '#header'
         Footer: '#footer'
@@ -122,7 +123,7 @@ drupal:
         binary: vendor/bin/drush
         root: /var/www/html/web
         global_options: ~
-      region_map:
+      regions:
         Content: '#main .region-content'
         Header: '#header'
         Footer: '#footer'

--- a/behat.yml
+++ b/behat.yml
@@ -79,7 +79,7 @@ default:
       blackbox: ~
       login_wait: 0
       # Region map in the static HTML fixture.
-      region_map:
+      regions:
         static content: "#static-content"
         static footer: "#static-footer"
         static navigation: "#static-nav"
@@ -154,7 +154,7 @@ drupal:
         drupal_root: "/var/www/html/build/web"
       drush:
         root: "/var/www/html/build/web"
-      region_map:
+      regions:
         main content: "#main"
       selectors:
         messages:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -53,7 +53,7 @@ Drupal\DrupalExtension:
     alias: '@self'
   drupal:
     drupal_root: '/var/www/drupal'
-  region_map:
+  regions:
     header: '#header'
     content: '#main'
     footer: '#footer'
@@ -74,7 +74,7 @@ Drupal\DrupalExtension:
 | `api_driver` | `'blackbox'`, `'drush'`, or `'drupal'`. Used by `@api` scenarios. |
 | `drush` | Configuration for the [Drush driver](drivers/drush.md). |
 | `drupal` | Configuration for the [Drupal API driver](drivers/drupal-api.md). |
-| `region_map` | Maps human-readable region names to CSS selectors. |
+| `regions` | Maps human-readable region names to CSS selectors. |
 | `selectors` | CSS selectors for Drupal status, error, and success messages. |
 | `text` | Localised or themed strings used by the built-in steps. |
 
@@ -172,19 +172,27 @@ Drupal\DrupalExtension:
     username_field: 'Nickname'
 ```
 
-## Region map
+## Regions
 
-Define site regions so steps such as `I press "Search" in the "header"
+Define page regions so steps such as `I press "Search" in the "header"
 region` work without writing custom PHP:
 
 ```yaml
 Drupal\DrupalExtension:
-  region_map:
+  regions:
     header: '#header'
     content: '#main'
     footer: '#footer'
     'right sidebar': '#sidebar-second'
 ```
 
+Region steps work against any HTML page - resolution goes through Mink's
+custom `region` selector and has no dependency on the Drupal driver.
+
 See [Blackbox driver - Region steps](drivers/blackbox.md#region-steps)
 for the full pattern.
+
+> **Deprecated:** the `region_map` key is the legacy name for the same
+> map. It still works in 6.0 but emits a deprecation notice and is
+> removed in 6.1. Rename it to `regions`. If both keys are present, an
+> entry under `regions` overrides the same key under `region_map`.

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -127,3 +127,53 @@ You can structure your project's step definitions across as many
 custom contexts as you like. See Behat's
 [contexts guide](https://docs.behat.org/en/latest/user_guide/context.html)
 for the underlying mechanics.
+
+## Mink-only contexts
+
+You do not need to extend `RawDrupalContext` to read extension
+parameters or resolve regions. A context that only needs to drive the
+browser can extend `RawMinkContext` (or `MinkContext`) and pull in two
+lightweight traits:
+
+- `Drupal\DrupalExtension\ParametersTrait` exposes `getParameter()`,
+  `getDrupalText()`, and `getDrupalSelector()`. It is the consumption
+  point for parameter, text, and selector access from any context,
+  regardless of whether it inherits from `RawDrupalContext`. The
+  context must also implement
+  `Drupal\DrupalExtension\Context\ParametersAwareInterface` so the
+  initializer knows to inject the parameter array.
+- `Drupal\DrupalExtension\RegionTrait` exposes `getRegion()`, which
+  resolves the human-readable region name through Mink's `region`
+  selector. The selector is registered by the Drupal extension
+  service container at compile time, so it is available before any
+  context is instantiated.
+
+```php
+<?php
+
+use Behat\MinkExtension\Context\RawMinkContext;
+use Drupal\DrupalExtension\Context\ParametersAwareInterface;
+use Drupal\DrupalExtension\ParametersTrait;
+use Drupal\DrupalExtension\RegionTrait;
+
+class CustomMinkContext extends RawMinkContext implements ParametersAwareInterface {
+
+  use ParametersTrait;
+  use RegionTrait;
+
+  /**
+   * @Then I should see the configured log_out link in the :region region
+   */
+  public function logoutLinkInRegion(string $region): void {
+    $log_out = $this->getDrupalText('log_out');
+    $element = $this->getRegion($region);
+    if (!$element->findLink($log_out)) {
+      throw new \RuntimeException(sprintf('Log out link "%s" not in region "%s".', $log_out, $region));
+    }
+  }
+
+}
+```
+
+The bundled `MinkContext`, `MarkupContext`, and `MessageContext`
+follow this pattern - none of them inherit from `RawDrupalContext`.

--- a/docs/drivers/blackbox.md
+++ b/docs/drivers/blackbox.md
@@ -31,14 +31,14 @@ driver.
 
 ## Region steps
 
-The Blackbox driver supports a `region_map` that lets you reference
+The Blackbox driver supports a `regions` map that lets you reference
 parts of the page by name instead of CSS selectors. This makes
 scenarios readable without writing custom PHP.
 
 ```yaml
 Drupal\DrupalExtension:
   blackbox: ~
-  region_map:
+  regions:
     header: '#header'
     content: '#main'
     footer: '#footer'
@@ -76,7 +76,7 @@ Scenario: Find an element with an attribute in a region
 ```
 
 > Region steps fail with a clear error if the region name is not
-> defined in `region_map`.
+> defined in `regions`.
 
 ## Message selectors
 

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -50,13 +50,12 @@ Feature: Article workflow
 
 ## Region steps
 
-The Mink Extension's region steps need a `region_map`. Configure one in
-`behat.yml`:
+The region steps need a `regions` map. Configure one in `behat.yml`:
 
 ```yaml
 Drupal\DrupalExtension:
   blackbox: ~
-  region_map:
+  regions:
     header: '#header'
     content: '#main'
     footer: '#footer'

--- a/src/Drupal/DrupalExtension/ParametersTrait.php
+++ b/src/Drupal/DrupalExtension/ParametersTrait.php
@@ -10,6 +10,13 @@ namespace Drupal\DrupalExtension;
  * These parameters are placed in behat.yml under 'Drupal\DrupalExtension'
  * and can be used to define commonly customized aspects of the Drupal
  * installation such as CSS selectors, interface text or region maps.
+ *
+ * This is the consumption point for parameter, text, and selector access
+ * from any context, regardless of whether it inherits from
+ * 'RawDrupalContext'. A context only needs to implement
+ * 'ParametersAwareInterface' and 'use' this trait; 'DrupalAwareInitializer'
+ * injects the parameter array via 'setParameters()' before any scenario
+ * runs. No Drupal driver bootstrap is required.
  */
 trait ParametersTrait {
 

--- a/src/Drupal/DrupalExtension/RegionTrait.php
+++ b/src/Drupal/DrupalExtension/RegionTrait.php
@@ -8,6 +8,14 @@ use Behat\Mink\Exception\ElementNotFoundException;
 
 /**
  * Provides a method to find a region on the current page.
+ *
+ * Resolution depends only on Mink's Selectors registry and 'getSession()',
+ * so this trait works on any 'RawMinkContext' consumer - no Drupal driver
+ * bootstrap required. The 'region' selector is registered by the Drupal
+ * extension service container at compile time (see
+ * 'drupal.region_selector' in 'ServiceContainer/config/services.yml',
+ * tagged 'mink.selector' with alias 'region'), so by the time any context
+ * is instantiated the selector is already available in the registry.
  */
 trait RegionTrait {
 

--- a/src/Drupal/DrupalExtension/RegionTrait.php
+++ b/src/Drupal/DrupalExtension/RegionTrait.php
@@ -7,15 +7,15 @@ namespace Drupal\DrupalExtension;
 use Behat\Mink\Exception\ElementNotFoundException;
 
 /**
- * Provides a method to find a region on the current page.
+ * Provides a method to find a named region on the current page.
  *
- * Resolution depends only on Mink's Selectors registry and 'getSession()',
- * so this trait works on any 'RawMinkContext' consumer - no Drupal driver
- * bootstrap required. The 'region' selector is registered by the Drupal
- * extension service container at compile time (see
- * 'drupal.region_selector' in 'ServiceContainer/config/services.yml',
- * tagged 'mink.selector' with alias 'region'), so by the time any context
- * is instantiated the selector is already available in the registry.
+ * Regions are a generic page concept, not Drupal-specific. Resolution
+ * goes through Mink's Selectors registry via 'getSession()', so this
+ * trait works on any 'RawMinkContext' consumer with no Drupal API
+ * bootstrap. The 'region' selector itself is registered at service
+ * container compile time (see 'drupal.region_selector' in
+ * 'ServiceContainer/config/services.yml', tagged 'mink.selector' with
+ * alias 'region') and reads the user's region map from 'behat.yml'.
  */
 trait RegionTrait {
 

--- a/src/Drupal/DrupalExtension/Selector/RegionSelector.php
+++ b/src/Drupal/DrupalExtension/Selector/RegionSelector.php
@@ -8,7 +8,23 @@ use Behat\Mink\Selector\SelectorInterface;
 use Behat\Mink\Selector\CssSelector;
 
 /**
- * Custom "region" selector to help select Drupal regions.
+ * Custom Mink selector that resolves human-readable region names to XPath.
+ *
+ * Mink supports user-defined selectors through its 'SelectorsHandler'
+ * registry. The Drupal extension wires this class into the registry at
+ * compile time via a service tagged 'mink.selector' with alias 'region'
+ * (see 'drupal.region_selector' in
+ * 'src/Drupal/DrupalExtension/ServiceContainer/config/services.yml').
+ *
+ * Once registered, any context with a Mink session can call
+ * '$page->find("region", "Header")' and Mink dispatches to
+ * 'translateToXPath()' here. The class looks the name up in the user's
+ * configured map (the 'regions' / legacy 'region_map' key under
+ * 'Drupal\DrupalExtension' in 'behat.yml') and delegates the
+ * CSS-to-XPath translation to the wrapped 'CssSelector'.
+ *
+ * Regions are a generic page concept - this selector has no Drupal API
+ * dependency and works against any HTML page.
  */
 class RegionSelector implements SelectorInterface {
 
@@ -16,15 +32,16 @@ class RegionSelector implements SelectorInterface {
    * Constructs a RegionSelector.
    *
    * @param \Behat\Mink\Selector\CssSelector $cssSelector
-   *   The CSS selector.
-   * @param array<string, string> $regionMap
-   *   Map of region names to CSS selectors.
+   *   The CSS selector that performs the actual CSS-to-XPath translation.
+   * @param array<string, string> $regions
+   *   Map of region names to CSS selectors, sourced from the 'regions' key
+   *   (or the deprecated 'region_map') under 'Drupal\DrupalExtension'.
    */
-  public function __construct(private readonly CssSelector $cssSelector, private array $regionMap) {
+  public function __construct(private readonly CssSelector $cssSelector, private array $regions) {
   }
 
   /**
-   * Translates provided locator into XPath.
+   * Translates a region name into XPath.
    *
    * @param string $region
    *   The region name to translate.
@@ -36,10 +53,10 @@ class RegionSelector implements SelectorInterface {
    */
   // phpcs:ignore Drupal.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
   public function translateToXPath($region) {
-    if (!isset($this->regionMap[$region])) {
+    if (!isset($this->regions[$region])) {
       throw new \InvalidArgumentException(sprintf('The "%s" region isn\'t configured!', $region));
     }
-    $css = $this->regionMap[$region];
+    $css = $this->regions[$region];
 
     return $this->cssSelector->translateToXPath($css);
   }

--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -106,11 +106,16 @@ class DrupalExtension implements ExtensionInterface {
           ->defaultValue('name')
           ->info('User entity property submitted as the login value. Defaults to "name". Set to "mail" for sites that authenticate by email, or any other user property.')
         ->end()
-        ->arrayNode('region_map')
-          ->info("Targeting content in specific regions can be accomplished once those regions have been defined." . PHP_EOL
+        ->arrayNode('regions')
+          ->info("Map of named regions to CSS selectors. Region steps such as 'I press :button in the :region region' resolve against this map." . PHP_EOL
             . '  My region: "#css-selector"' . PHP_EOL
             . '  Content: "#main .region-content"' . PHP_EOL
             . '  Right sidebar: "#sidebar-second"' . PHP_EOL)
+          ->useAttributeAsKey('key')
+          ->prototype('variable')->end()
+        ->end()
+        ->arrayNode('region_map')
+          ->info('Deprecated since drupal-extension:6.0.0 and removed from drupal-extension:6.1.0. Use "regions" instead.')
           ->useAttributeAsKey('key')
           ->prototype('variable')->end()
         ->end()
@@ -210,14 +215,46 @@ class DrupalExtension implements ExtensionInterface {
   /**
    * Load test parameters.
    *
+   * Resolves the region map from 'regions' (current) and 'region_map'
+   * (deprecated). Entries in 'regions' take precedence when a key appears
+   * in both. The merged result is exposed under the 'drupal.regions'
+   * container parameter and surfaced through the 'region' Mink selector.
+   *
    * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
    *   The container builder.
    * @param array<string, mixed> $config
    *   The extension configuration.
    */
   protected function loadParameters(ContainerBuilder $container, array $config): void {
+    $regions = $config['regions'] ?? [];
+    $legacy = $config['region_map'] ?? [];
+
+    if ($legacy !== []) {
+      $this->emitDeprecation('The "region_map" configuration key under "Drupal\\DrupalExtension" is deprecated in drupal-extension:6.0.0 and removed from drupal-extension:6.1.0. Rename it to "regions". See https://github.com/jhedstrom/drupalextension/blob/main/MIGRATION.md');
+      // 'regions' wins on key collisions; '+' keeps the left-hand keys.
+      $regions += $legacy;
+    }
+
+    // Surface the merged map back into the parameters array so contexts
+    // reading it through 'getParameter("regions")' see the same value
+    // the 'region' Mink selector resolves against.
+    $config['regions'] = $regions;
+    unset($config['region_map']);
+
     $container->setParameter('drupal.parameters', $config);
-    $container->setParameter('drupal.region_map', $config['region_map']);
+    $container->setParameter('drupal.regions', $regions);
+  }
+
+  /**
+   * Emits a deprecation notice during extension load.
+   *
+   * Writes to 'STDERR' so the message surfaces in CI output without
+   * triggering Behat's 'E_USER_DEPRECATED' -> step-failure handler.
+   * Tests override this method to capture deprecations without writing
+   * to the global stream.
+   */
+  protected function emitDeprecation(string $message): void {
+    fwrite(STDERR, '[Deprecation] ' . $message . PHP_EOL);
   }
 
   /**

--- a/src/Drupal/DrupalExtension/ServiceContainer/config/services.yml
+++ b/src/Drupal/DrupalExtension/ServiceContainer/config/services.yml
@@ -30,7 +30,7 @@ parameters:
 
   # Parameters.
   drupal.parameters: {}
-  drupal.region_map: {}
+  drupal.regions: {}
 
 services:
   drupal.drupal:
@@ -80,6 +80,6 @@ services:
     arguments:
       # inject the CSSSelector
       - "@mink.selector.css"
-      - "%drupal.region_map%"
+      - "%drupal.regions%"
     tags:
       - { name: mink.selector, alias: region }

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -267,6 +267,35 @@ EOL;
   }
 
   /**
+   * Renames 'regions:' to the deprecated 'region_map:' in the subprocess.
+   *
+   * Use after 'Given some behat configuration' to exercise the
+   * backward-compat path on 'DrupalExtension::loadParameters()' that
+   * merges legacy 'region_map' into the active map and emits the
+   * one-shot deprecation notice.
+   */
+  #[Given('the behat configuration uses the deprecated region_map')]
+  public function behatCliUseDeprecatedRegionMap(): void {
+    $config_file = $this->workingDir . DIRECTORY_SEPARATOR . 'behat.yml';
+    $yaml = Yaml::parse((string) file_get_contents($config_file));
+
+    foreach (['default', 'drupal'] as $profile) {
+      $extension = &$yaml[$profile]['extensions']['Drupal\DrupalExtension'];
+
+      if (!isset($extension['regions'])) {
+        unset($extension);
+        continue;
+      }
+
+      $extension['region_map'] = $extension['regions'];
+      unset($extension['regions']);
+      unset($extension);
+    }
+
+    file_put_contents($config_file, Yaml::dump($yaml, 4, 2));
+  }
+
+  /**
    * Asserts that behat failed with the given assertion error.
    */
   #[Then('it should fail with an error:')]

--- a/tests/behat/features/regions.feature
+++ b/tests/behat/features/regions.feature
@@ -1,0 +1,41 @@
+Feature: regions configuration
+  As a developer
+  I want region steps to resolve names from either the new 'regions' or
+  the deprecated 'region_map' configuration key
+  So that existing projects keep working while migrating off 'region_map'
+
+  # The 'regions' key is exercised by every region step in the suite (see
+  # markup.feature, mink.feature). The two scenarios below cover the
+  # backward-compat path: 'region_map:' is renamed in the subprocess
+  # config, the region step still resolves, and a deprecation notice is
+  # emitted exactly once.
+
+  @test-blackbox
+  Scenario: Assert deprecated 'region_map' key still resolves regions
+    Given some behat configuration
+    And the behat configuration uses the deprecated region_map
+    And scenario steps tagged with "@test-blackbox":
+      """
+      Given I am at "form_controls.html"
+      Then I should see the button "Submit" in the "static content" region
+      """
+    When I run behat
+    Then it should pass with:
+      """
+      1 scenario (1 passed)
+      """
+
+  @test-blackbox
+  Scenario: Assert deprecated 'region_map' key emits deprecation notice
+    Given some behat configuration
+    And the behat configuration uses the deprecated region_map
+    And scenario steps tagged with "@test-blackbox":
+      """
+      Given I am at "form_controls.html"
+      Then I should see the button "Submit" in the "static content" region
+      """
+    When I run behat
+    Then the output should contain:
+      """
+      [Deprecation] The "region_map" configuration key under "Drupal\DrupalExtension" is deprecated in drupal-extension:6.0.0 and removed from drupal-extension:6.1.0. Rename it to "regions". See https://github.com/jhedstrom/drupalextension/blob/main/MIGRATION.md
+      """

--- a/tests/phpunit/src/BehatDistYmlTest.php
+++ b/tests/phpunit/src/BehatDistYmlTest.php
@@ -82,7 +82,10 @@ class BehatDistYmlTest extends TestCase {
 
     $tree = $this->buildDrupalExtensionTree();
 
-    $schema_keys = array_keys($tree->getChildren());
+    // Deprecated keys are intentionally absent from the recommended dist
+    // file - users should be steered towards the current names.
+    $deprecated_keys = ['region_map'];
+    $schema_keys = array_diff(array_keys($tree->getChildren()), $deprecated_keys);
     foreach ($schema_keys as $key) {
       $this->assertContains($key, $all_dist_keys, sprintf('behat.dist.yml missing DrupalExtension key "%s" in all profiles.', $key));
     }

--- a/tests/phpunit/src/DrupalExtensionRegionsTest.php
+++ b/tests/phpunit/src/DrupalExtensionRegionsTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Tests;
+
+use Drupal\DrupalExtension\ServiceContainer\DrupalExtension;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Tests the regions/region_map merge logic in 'loadParameters()'.
+ */
+#[CoversMethod(DrupalExtension::class, 'configure')]
+#[CoversMethod(DrupalExtension::class, 'loadParameters')]
+class DrupalExtensionRegionsTest extends TestCase {
+
+  /**
+   * Tests merge behaviour and deprecation emission across config shapes.
+   *
+   * @param array<string, mixed> $config
+   *   The DrupalExtension configuration (raw, before schema normalisation).
+   * @param array<string, string> $expected
+   *   The expected merged region map.
+   * @param bool $expectsDeprecation
+   *   Whether the call should emit the region_map deprecation notice.
+   */
+  #[DataProvider('dataProviderRegionsMergeAndDeprecation')]
+  public function testRegionsMergeAndDeprecation(array $config, array $expected, bool $expectsDeprecation): void {
+    $extension = new TestableDrupalExtension();
+
+    $builder = new ArrayNodeDefinition('drupal');
+    $extension->configure($builder);
+    $tree = $builder->getNode(TRUE);
+    $processed = $tree->finalize($tree->normalize($config));
+
+    $container = new ContainerBuilder();
+    $extension->callLoadParameters($container, $processed);
+
+    $this->assertSame($expected, $container->getParameter('drupal.regions'));
+
+    if ($expectsDeprecation) {
+      $this->assertCount(1, $extension->capturedDeprecations);
+      $this->assertStringContainsString('region_map', $extension->capturedDeprecations[0]);
+      $this->assertStringContainsString('deprecated in drupal-extension:6.0.0', $extension->capturedDeprecations[0]);
+    }
+    else {
+      $this->assertSame([], $extension->capturedDeprecations);
+    }
+
+    // The merged map is surfaced through 'drupal.parameters' too, so
+    // contexts using ParametersTrait see the same value as RegionSelector.
+    $parameters = $container->getParameter('drupal.parameters');
+    $this->assertIsArray($parameters);
+    $this->assertSame($expected, $parameters['regions']);
+    $this->assertArrayNotHasKey('region_map', $parameters);
+  }
+
+  /**
+   * Provides data for testRegionsMergeAndDeprecation().
+   */
+  public static function dataProviderRegionsMergeAndDeprecation(): \Iterator {
+    yield 'regions only, no deprecation' => [
+      ['regions' => ['Header' => '#header', 'Content' => '#main']],
+      ['Header' => '#header', 'Content' => '#main'],
+      FALSE,
+    ];
+
+    yield 'region_map only emits deprecation' => [
+      ['region_map' => ['Header' => '#header']],
+      ['Header' => '#header'],
+      TRUE,
+    ];
+
+    yield 'regions wins on key collision and merges with legacy' => [
+      [
+        'regions' => ['Header' => '#new-header'],
+        'region_map' => ['Header' => '#old-header', 'Footer' => '#footer'],
+      ],
+      ['Header' => '#new-header', 'Footer' => '#footer'],
+      TRUE,
+    ];
+
+    yield 'neither set yields empty map and no deprecation' => [
+      [],
+      [],
+      FALSE,
+    ];
+  }
+
+}
+
+/**
+ * Test-only subclass that captures deprecations and exposes 'loadParameters'.
+ */
+// phpcs:ignore Drupal.Classes.ClassFileName.NoMatch
+class TestableDrupalExtension extends DrupalExtension {
+
+  /**
+   * Captured deprecation messages.
+   *
+   * @var array<int, string>
+   */
+  public array $capturedDeprecations = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function emitDeprecation(string $message): void {
+    $this->capturedDeprecations[] = $message;
+  }
+
+  /**
+   * Public bridge to the protected loadParameters method.
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+   *   The container builder to populate.
+   * @param array<string, mixed> $config
+   *   The processed configuration array.
+   */
+  public function callLoadParameters(ContainerBuilder $container, array $config): void {
+    $this->loadParameters($container, $config);
+  }
+
+}


### PR DESCRIPTION
Closes #826

## Summary

- Documented `ParametersTrait` and `RegionTrait` as Mink-only consumption points that work on any `RawMinkContext` consumer without requiring a Drupal driver bootstrap.
- Added a "Mink-only contexts" section to `docs/contexts.md` with a code example showing the pattern.

## Changes

- **`src/Drupal/DrupalExtension/ParametersTrait.php`**: Expanded docblock to clarify this is the consumption point for parameter, text, and selector access from any context. Documents that only `ParametersAwareInterface` is required - no `RawDrupalContext` inheritance needed.
- **`src/Drupal/DrupalExtension/RegionTrait.php`**: Expanded docblock to clarify the trait depends only on Mink's selectors registry and `getSession()`, so it works on any `RawMinkContext` consumer. Documents that the `region` selector is registered at compile time via `drupal.region_selector` in `services.yml`.
- **`docs/contexts.md`**: Added "Mink-only contexts" section documenting the pattern with a concrete code example.

## Pattern

```php
class CustomMinkContext extends RawMinkContext implements ParametersAwareInterface {
  use ParametersTrait;
  use RegionTrait;
  // ...
}
```

The bundled `MinkContext`, `MarkupContext`, and `MessageContext` already follow this pattern - none of them inherit from `RawDrupalContext`. This PR makes it explicit in docs and trait docblocks so contributors know they can do the same.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration examples and guides to use the new `regions` key instead of `region_map`.
  * Added migration documentation with pre- and post-rename configuration examples.

* **Chores**
  * Renamed configuration key `region_map` to `regions` in example and default configuration files.
  * Added deprecation notice for legacy `region_map` key (to be removed in 6.1); backward compatibility maintained during 6.0 cycle with automatic merging of both keys when present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->