### PR TITLE
Moved 'ParametersAwareInterface' to root namespace alongside 'ParametersTrait'.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -292,7 +292,7 @@ Subclasses that read the value need to switch from
 `$this->getMinkParameter('ajax_timeout')` to
 `$this->getParameter('ajax_timeout')`. Reading the value requires the
 context to use `Drupal\DrupalExtension\ParametersTrait` and implement
-`Drupal\DrupalExtension\Context\ParametersAwareInterface` (the bundled
+`Drupal\DrupalExtension\ParametersAwareInterface` (the bundled
 `MinkContext` already does).
 
 ## Parameters interface and trait renames
@@ -304,7 +304,7 @@ redundant.
 
 | 5.x                                                              | 6.0                                                          |
 |------------------------------------------------------------------|--------------------------------------------------------------|
-| `Drupal\DrupalExtension\Context\DrupalParametersAwareInterface`  | `Drupal\DrupalExtension\Context\ParametersAwareInterface`    |
+| `Drupal\DrupalExtension\Context\DrupalParametersAwareInterface`  | `Drupal\DrupalExtension\ParametersAwareInterface`            |
 | `Drupal\DrupalExtension\DrupalParametersTrait`                   | `Drupal\DrupalExtension\ParametersTrait`                     |
 | `setDrupalParameters(array $parameters): void`                   | `setParameters(array $parameters): void`                     |
 | `getDrupalParameter(string $name): mixed`                        | `getParameter(string $name): mixed`                          |

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -140,7 +140,7 @@ lightweight traits:
   point for parameter, text, and selector access from any context,
   regardless of whether it inherits from `RawDrupalContext`. The
   context must also implement
-  `Drupal\DrupalExtension\Context\ParametersAwareInterface` so the
+  `Drupal\DrupalExtension\ParametersAwareInterface` so the
   initializer knows to inject the parameter array.
 - `Drupal\DrupalExtension\RegionTrait` exposes `getRegion()`, which
   resolves the human-readable region name through Mink's `region`
@@ -152,7 +152,7 @@ lightweight traits:
 <?php
 
 use Behat\MinkExtension\Context\RawMinkContext;
-use Drupal\DrupalExtension\Context\ParametersAwareInterface;
+use Drupal\DrupalExtension\ParametersAwareInterface;
 use Drupal\DrupalExtension\ParametersTrait;
 use Drupal\DrupalExtension\RegionTrait;
 

--- a/src/Drupal/DrupalExtension/Context/DrupalAwareInterface.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalAwareInterface.php
@@ -10,6 +10,7 @@ use Behat\Testwork\Hook\HookDispatcher;
 use Drupal\DrupalDriverManagerInterface;
 use Drupal\DrupalExtension\Manager\DrupalAuthenticationManagerInterface;
 use Drupal\DrupalExtension\Manager\DrupalUserManagerInterface;
+use Drupal\DrupalExtension\ParametersAwareInterface;
 
 /**
  * Interface for contexts that are aware of the Drupal driver manager.

--- a/src/Drupal/DrupalExtension/Context/Initializer/DrupalAwareInitializer.php
+++ b/src/Drupal/DrupalExtension/Context/Initializer/DrupalAwareInitializer.php
@@ -10,9 +10,9 @@ use Behat\Testwork\Hook\HookDispatcher;
 
 use Drupal\DrupalDriverManager;
 use Drupal\DrupalExtension\Context\DrupalAwareInterface;
-use Drupal\DrupalExtension\Context\ParametersAwareInterface;
 use Drupal\DrupalExtension\Manager\DrupalAuthenticationManagerInterface;
 use Drupal\DrupalExtension\Manager\DrupalUserManagerInterface;
+use Drupal\DrupalExtension\ParametersAwareInterface;
 
 /**
  * Initializes DrupalAwareInterface contexts with required dependencies.

--- a/src/Drupal/DrupalExtension/Context/MessageContext.php
+++ b/src/Drupal/DrupalExtension/Context/MessageContext.php
@@ -12,6 +12,7 @@ use Behat\Step\Given;
 use Behat\Step\Then;
 use Drupal\DrupalExtension\DeprecationInterface;
 use Drupal\DrupalExtension\DeprecationTrait;
+use Drupal\DrupalExtension\ParametersAwareInterface;
 use Drupal\DrupalExtension\ParametersTrait;
 
 /**

--- a/src/Drupal/DrupalExtension/Context/MinkContext.php
+++ b/src/Drupal/DrupalExtension/Context/MinkContext.php
@@ -14,6 +14,7 @@ use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Mink\Selector\Xpath\Escaper;
 use Behat\MinkExtension\Context\MinkContext as MinkExtension;
 use Drupal\DrupalExtension\Context\Traits\AjaxTrait;
+use Drupal\DrupalExtension\ParametersAwareInterface;
 use Drupal\DrupalExtension\ParametersTrait;
 use Drupal\DrupalExtension\RegionTrait;
 use Drupal\DrupalExtension\TagTrait;

--- a/src/Drupal/DrupalExtension/ParametersAwareInterface.php
+++ b/src/Drupal/DrupalExtension/ParametersAwareInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Drupal\DrupalExtension\Context;
+namespace Drupal\DrupalExtension;
 
 /**
  * Declares Drupal extension parameters availability.


### PR DESCRIPTION
## Summary

`ParametersAwareInterface` has been relocated from `Drupal\DrupalExtension\Context` to the root `Drupal\DrupalExtension` namespace, where it now sits alongside its companion `ParametersTrait`. The interface is a generic set/get parameter contract with no tie to the `Context` sub-namespace, so the root namespace is the natural home - mirroring the placement of `ParametersTrait` and `RegionTrait`. There are no behavior or API contract changes; the `setParameters` / `getParameter` signatures are unchanged.

## Changes

- **Interface relocation**: `src/Drupal/DrupalExtension/Context/ParametersAwareInterface.php` renamed to `src/Drupal/DrupalExtension/ParametersAwareInterface.php`; namespace updated from `Drupal\DrupalExtension\Context` to `Drupal\DrupalExtension`.
- **Updated `use` statements**: Four files updated to import from the new FQN - `DrupalAwareInitializer.php` (replaced old import), `DrupalAwareInterface.php` (added explicit import, previously resolved via same-namespace extension), `MinkContext.php` (added explicit import), and `MessageContext.php` (added explicit import).
- **Documentation**: `MIGRATION.md` - corrected the 6.0 rename table row and the supporting paragraph to reference the root-namespace FQN. `docs/contexts.md` - updated prose and the Mink-only code example to import from `Drupal\DrupalExtension` instead of `Drupal\DrupalExtension\Context`.

## Before / After

```
Before:
  Drupal\DrupalExtension\
    ├── ParametersTrait        (trait)
    ├── RegionTrait            (trait)
    └── Context\
        └── ParametersAwareInterface  (interface)

After:
  Drupal\DrupalExtension\
    ├── ParametersAwareInterface  (interface) <- moved up
    ├── ParametersTrait           (trait)
    ├── RegionTrait               (trait)
    └── Context\
        └── (no longer here)
```
