### PR TITLE
[#823] Rebased 'RandomContext' on bare Behat context interface.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -234,6 +234,27 @@ in the table above. Other entries under
 `Drupal\DrupalExtension.selectors:` (`login_form_selector`,
 `logged_in_selector`) are unaffected.
 
+## RandomContext base class
+
+`RandomContext` no longer extends `RawDrupalContext`. It now implements
+`Behat\Behat\Context\Context` directly, so it can be registered in a suite
+that does not load `Drupal\MinkExtension` or `Drupal\DrupalExtension`.
+
+The class instantiates `Drupal\Component\Utility\Random` directly to
+generate placeholder values; the previous indirection through
+`getDriver()->getRandom()` is gone. `RandomContext` no longer calls
+`getDriver()` or `getSession()`.
+
+If you subclass `RandomContext`, the inherited `RawDrupalContext` helpers
+(`getDriver()`, `getSession()`, `getParameter()`, `getDrupalText()`,
+`getDrupalSelector()`) are no longer available. To keep them, change the
+parent of your subclass to `RawDrupalContext` (or `RawMinkContext`)
+explicitly. To compose only what you need, `use ParametersTrait;` together
+with `implements ParametersAwareInterface` for parameter access without
+booting Drupal or Mink.
+
+Step definitions and the placeholder regex are unchanged.
+
 ## Configuration: `region_map` renamed to `regions`
 
 The `region_map` configuration key under `Drupal\DrupalExtension` has been

--- a/behat.dist.yml
+++ b/behat.dist.yml
@@ -13,6 +13,7 @@ default:
         - Drupal\DrupalExtension\Context\MinkContext
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\MarkupContext
+        - Drupal\DrupalExtension\Context\RandomContext
 
   extensions:
     Drupal\MinkExtension:

--- a/behat.yml
+++ b/behat.yml
@@ -47,6 +47,7 @@ default:
         - Drupal\DrupalExtension\Context\DrupalContext
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\MarkupContext
+        - Drupal\DrupalExtension\Context\RandomContext
         # Helper contexts for test execution and reporting.
         - FeatureContext
         - BehatCliContext

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -18,7 +18,7 @@ declared explicitly.
 | `Drupal\DrupalExtension\Context\ConfigContext` | Steps that read and write Drupal configuration. |
 | `Drupal\DrupalExtension\Context\DrushContext` | Steps that invoke arbitrary Drush commands. |
 | `Drupal\DrupalExtension\Context\MailContext` | Steps that assert against the Drupal mail collector. |
-| `Drupal\DrupalExtension\Context\RandomContext` | Transforms placeholders such as `<?title>` into random strings. |
+| `Drupal\DrupalExtension\Context\RandomContext` | Transforms placeholders such as `<?title>` into random strings. Pure Behat context - no Drupal driver, no Mink session. |
 
 For a complete reference of every step each context exposes, see
 [`STEPS.md`](../STEPS.md).
@@ -177,3 +177,8 @@ class CustomMinkContext extends RawMinkContext implements ParametersAwareInterfa
 
 The bundled `MinkContext`, `MarkupContext`, and `MessageContext`
 follow this pattern - none of them inherit from `RawDrupalContext`.
+
+`RandomContext` goes one step further: it implements
+`Behat\Behat\Context\Context` directly and uses no Mink session at all.
+A consumer can register it in any Behat suite, even one that does not
+load `Drupal\MinkExtension`.

--- a/src/Drupal/DrupalExtension/Context/RandomContext.php
+++ b/src/Drupal/DrupalExtension/Context/RandomContext.php
@@ -4,22 +4,34 @@ declare(strict_types=1);
 
 namespace Drupal\DrupalExtension\Context;
 
-use Behat\Transformation\Transform;
-use Behat\Hook\BeforeScenario;
-use Behat\Hook\AfterScenario;
+use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\ScenarioScope;
 use Behat\Gherkin\Node\TableNode;
+use Behat\Hook\AfterScenario;
+use Behat\Hook\BeforeScenario;
+use Behat\Transformation\Transform;
+use Drupal\Component\Utility\Random;
 
 /**
  * Transform tokens into random variables.
+ *
+ * Operates purely on Gherkin step text - no Mink session, no Drupal driver.
+ * Can be registered in any Behat suite, including ones that load neither
+ * 'Drupal\MinkExtension' nor 'Drupal\DrupalExtension'.
  */
-class RandomContext extends RawDrupalContext {
+class RandomContext implements Context {
+
   /**
    * Tracks variable names for consistent replacement during a given scenario.
    *
    * @var array<string, string>
    */
   protected array $values = [];
+
+  /**
+   * Random string generator.
+   */
+  private ?Random $random = NULL;
 
   /**
    * The regex to use for variable replacement.
@@ -82,7 +94,7 @@ class RandomContext extends RawDrupalContext {
       }
       foreach ($variables_found as $variable_found) {
         if (!isset($this->values[$variable_found])) {
-          $value = $this->getDriver()->getRandom()->name(10);
+          $value = $this->getRandom()->name(10);
           // Value forced to lowercase to ensure it is machine-readable.
           $this->values[$variable_found] = strtolower((string) $value);
         }
@@ -96,6 +108,13 @@ class RandomContext extends RawDrupalContext {
   #[AfterScenario]
   public function afterScenarioResetVariables(ScenarioScope $scope): void {
     $this->values = [];
+  }
+
+  /**
+   * Lazily resolves the random string generator.
+   */
+  private function getRandom(): Random {
+    return $this->random ??= new Random();
   }
 
 }

--- a/tests/behat/features/random.feature
+++ b/tests/behat/features/random.feature
@@ -36,3 +36,32 @@ Feature: RandomContext functionality
       """
     When I run behat with drupal profile
     Then it should fail
+
+  # The two scenarios below prove that 'RandomContext' can run without the
+  # Drupal API driver. They register against the 'default' (blackbox) profile
+  # and rely on the placeholder transform happening before the assertion.
+
+  @test-blackbox @random
+  Scenario: Assert random variable transform passes in blackbox profile
+    Given some behat configuration
+    And scenario steps tagged with "@test-blackbox @random":
+      """
+      Given I am at "index.html"
+      Then I should not see the text "<?token>"
+      """
+    When I run behat
+    Then it should pass with:
+      """
+      1 scenario (1 passed)
+      """
+
+  @test-blackbox @random
+  Scenario: Assert random variable transform fails when token text expected
+    Given some behat configuration
+    And scenario steps tagged with "@test-blackbox @random":
+      """
+      Given I am at "index.html"
+      Then I should see the text "<?token>"
+      """
+    When I run behat
+    Then it should fail

--- a/tests/phpunit/src/RandomContextTest.php
+++ b/tests/phpunit/src/RandomContextTest.php
@@ -13,6 +13,7 @@ use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
 use Drupal\DrupalExtension\Context\RandomContext;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -44,58 +45,71 @@ class RandomContextTest extends TestCase {
   }
 
   /**
-   * Tests that 'RandomContext' implements the bare Behat context interface.
+   * Tests the bare-Behat structural promise of the rebase.
    *
-   * Documents the contract that the class can be loaded in a suite that
-   * does not register Mink or the Drupal extension.
+   * 'RandomContext' must implement 'Behat\Behat\Context\Context' directly
+   * with no parent class, so it can be loaded in suites that do not
+   * register Mink or the Drupal extension.
    */
-  public function testImplementsBareBehatContext(): void {
+  public function testImplementsBareBehatContextWithoutAncestors(): void {
     $this->assertInstanceOf(Context::class, $this->context);
-  }
-
-  /**
-   * Tests that the class no longer extends Drupal- or Mink-specific bases.
-   *
-   * Guards the structural promise of the rebase: no inherited 'getDriver()'
-   * or 'getSession()' surface.
-   */
-  public function testHasNoDrupalOrMinkAncestor(): void {
     $this->assertSame([], class_parents($this->context));
   }
 
   /**
-   * Tests that 'transformVariables()' returns the input when no tokens.
+   * Tests 'transformVariables()' substitution behaviour.
+   *
+   * @param array<string, string> $values
+   *   Token-to-value map to seed before invoking the transform.
+   * @param string $message
+   *   The input message to transform.
+   * @param string $expected
+   *   The expected message after substitution.
    */
-  public function testTransformVariablesReturnsInputWhenNoTokens(): void {
-    $this->valuesProperty->setValue($this->context, []);
-    $this->assertSame('plain text', $this->context->transformVariables('plain text'));
+  #[DataProvider('dataProviderTransformVariables')]
+  public function testTransformVariables(array $values, string $message, string $expected): void {
+    $this->valuesProperty->setValue($this->context, $values);
+    $this->assertSame($expected, $this->context->transformVariables($message));
   }
 
   /**
-   * Tests that 'transformVariables()' substitutes a stored token.
+   * Provides data for testTransformVariables().
+   *
+   * @return \Iterator<string, array{array<string, string>, string, string}>
+   *   Cases keyed by description, each [stored values, input message,
+   *   expected output].
    */
-  public function testTransformVariablesSubstitutesToken(): void {
-    $this->valuesProperty->setValue($this->context, ['<?token>' => 'abcdef']);
-    $this->assertSame('value: abcdef', $this->context->transformVariables('value: <?token>'));
-  }
-
-  /**
-   * Tests that the same token resolves to the same value across uses.
-   */
-  public function testTransformVariablesIsConsistentForRepeatedToken(): void {
-    $this->valuesProperty->setValue($this->context, ['<?token>' => 'abcdef']);
-    $this->assertSame('abcdef and abcdef', $this->context->transformVariables('<?token> and <?token>'));
-  }
-
-  /**
-   * Tests that different tokens resolve to their own stored values.
-   */
-  public function testTransformVariablesUsesDistinctValuesForDistinctTokens(): void {
-    $this->valuesProperty->setValue($this->context, [
-      '<?one>' => 'aaaaaa',
-      '<?two>' => 'bbbbbb',
-    ]);
-    $this->assertSame('aaaaaa and bbbbbb', $this->context->transformVariables('<?one> and <?two>'));
+  public static function dataProviderTransformVariables(): \Iterator {
+    yield 'no tokens returns input unchanged' => [
+      [],
+      'plain text',
+      'plain text',
+    ];
+    yield 'single token is substituted' => [
+      ['<?token>' => 'abcdef'],
+      'value: <?token>',
+      'value: abcdef',
+    ];
+    yield 'repeated token resolves to same value' => [
+      ['<?token>' => 'abcdef'],
+      '<?token> and <?token>',
+      'abcdef and abcdef',
+    ];
+    yield 'distinct tokens resolve to their own values' => [
+      ['<?one>' => 'aaaaaa', '<?two>' => 'bbbbbb'],
+      '<?one> and <?two>',
+      'aaaaaa and bbbbbb',
+    ];
+    yield 'surrounding characters are preserved' => [
+      ['<?abc>' => 'value'],
+      '[<?abc>]',
+      '[value]',
+    ];
+    yield 'identifier with underscore is supported' => [
+      ['<?my_token>' => 'value'],
+      'see <?my_token>',
+      'see value',
+    ];
   }
 
   /**
@@ -118,99 +132,68 @@ class RandomContextTest extends TestCase {
   }
 
   /**
-   * Tests that 'beforeScenarioSetVariables()' populates values from steps.
+   * Tests that 'beforeScenarioSetVariables()' collects tokens from steps.
+   *
+   * Covers tokens in step text, in 'TableNode' step arguments, and in
+   * background steps; same-token reuse and distinct-token uniqueness.
+   *
+   * @param list<string> $expected_tokens
+   *   Tokens expected to be present in the populated values map, in
+   *   order of first appearance.
+   * @param list<\Behat\Gherkin\Node\StepNode> $scenario_steps
+   *   Scenario steps to attach to the constructed scope.
+   * @param list<\Behat\Gherkin\Node\StepNode>|null $background_steps
+   *   Optional background steps; NULL omits the background.
    */
-  public function testBeforeScenarioPopulatesValuesFromScenarioSteps(): void {
-    $scope = $this->createScenarioScope([
-      $this->createStep('Given a string <?token>'),
-    ]);
+  #[DataProvider('dataProviderBeforeScenarioCollectsTokens')]
+  public function testBeforeScenarioCollectsTokens(array $expected_tokens, array $scenario_steps, ?array $background_steps = NULL): void {
+    $background = $background_steps === NULL ? NULL : new BackgroundNode(NULL, $background_steps, 'Background', 1);
+    $scope = $this->createScenarioScope($scenario_steps, $background);
 
     $this->context->beforeScenarioSetVariables($scope);
     $values = $this->valuesProperty->getValue($this->context);
 
-    $this->assertArrayHasKey('<?token>', $values);
-    $this->assertMatchesRegularExpression('/^[a-z0-9]{10}$/', $values['<?token>']);
+    $this->assertSame($expected_tokens, array_keys($values));
+    foreach ($values as $value) {
+      $this->assertMatchesRegularExpression('/^[a-z0-9]{10}$/', (string) $value);
+    }
+    if (count($expected_tokens) > 1) {
+      $this->assertSame(count($expected_tokens), count(array_unique($values)));
+    }
   }
 
   /**
-   * Tests that the same token in multiple steps reuses the same value.
+   * Provides data for testBeforeScenarioCollectsTokens().
+   *
+   * @return \Iterator<string, array{0: list<string>, 1: list<\Behat\Gherkin\Node\StepNode>, 2?: list<\Behat\Gherkin\Node\StepNode>|null}>
+   *   Cases keyed by description, each [expected token list, scenario
+   *   steps, optional background steps].
    */
-  public function testBeforeScenarioReusesValuesForRepeatedTokens(): void {
-    $scope = $this->createScenarioScope([
-      $this->createStep('Given a string <?token>'),
-      $this->createStep('Then I see <?token>'),
-    ]);
-
-    $this->context->beforeScenarioSetVariables($scope);
-    $values = $this->valuesProperty->getValue($this->context);
-
-    $this->assertCount(1, $values);
-    $this->assertArrayHasKey('<?token>', $values);
-  }
-
-  /**
-   * Tests that distinct tokens get distinct generated values.
-   */
-  public function testBeforeScenarioGeneratesDistinctValuesForDistinctTokens(): void {
-    $scope = $this->createScenarioScope([
-      $this->createStep('Given <?one> and <?two>'),
-    ]);
-
-    $this->context->beforeScenarioSetVariables($scope);
-    $values = $this->valuesProperty->getValue($this->context);
-
-    $this->assertCount(2, $values);
-    $this->assertArrayHasKey('<?one>', $values);
-    $this->assertArrayHasKey('<?two>', $values);
-    $this->assertNotSame($values['<?one>'], $values['<?two>']);
-  }
-
-  /**
-   * Tests that token values are lowercase and 10 chars long.
-   */
-  public function testBeforeScenarioGeneratesLowercaseValues(): void {
-    $scope = $this->createScenarioScope([
-      $this->createStep('Given <?token>'),
-    ]);
-
-    $this->context->beforeScenarioSetVariables($scope);
-    $value = (string) $this->valuesProperty->getValue($this->context)['<?token>'];
-
-    $this->assertSame(strtolower($value), $value);
-    $this->assertSame(10, strlen($value));
-  }
-
-  /**
-   * Tests that tokens in TableNode step arguments are picked up.
-   */
-  public function testBeforeScenarioPicksUpTokensFromStepTableArguments(): void {
-    $table = new TableNode([
-      ['title', '<?random_page>'],
-    ]);
-    $scope = $this->createScenarioScope([
-      new StepNode('Given', 'a page with the following fields:', [$table], 1),
-    ]);
-
-    $this->context->beforeScenarioSetVariables($scope);
-    $values = $this->valuesProperty->getValue($this->context);
-
-    $this->assertArrayHasKey('<?random_page>', $values);
-  }
-
-  /**
-   * Tests that tokens in background steps are picked up.
-   */
-  public function testBeforeScenarioPicksUpTokensFromBackgroundSteps(): void {
-    $background = new BackgroundNode(NULL, [$this->createStep('Given <?from_background>')], 'Background', 1);
-    $scope = $this->createScenarioScope([
-      $this->createStep('Then <?from_scenario>'),
-    ], $background);
-
-    $this->context->beforeScenarioSetVariables($scope);
-    $values = $this->valuesProperty->getValue($this->context);
-
-    $this->assertArrayHasKey('<?from_background>', $values);
-    $this->assertArrayHasKey('<?from_scenario>', $values);
+  public static function dataProviderBeforeScenarioCollectsTokens(): \Iterator {
+    yield 'token in scenario step text' => [
+      ['<?token>'],
+      [new StepNode('Given', 'a string <?token>', [], 1)],
+    ];
+    yield 'repeated token across steps reuses one value' => [
+      ['<?token>'],
+      [
+        new StepNode('Given', 'a string <?token>', [], 1),
+        new StepNode('Then', 'I see <?token>', [], 2),
+      ],
+    ];
+    yield 'distinct tokens in one step yield distinct values' => [
+      ['<?one>', '<?two>'],
+      [new StepNode('Given', '<?one> and <?two>', [], 1)],
+    ];
+    yield 'token in TableNode step argument is picked up' => [
+      ['<?random_page>'],
+      [new StepNode('Given', 'a page with the following fields:', [new TableNode([['title', '<?random_page>']])], 1)],
+    ];
+    yield 'tokens in background and scenario steps are merged' => [
+      ['<?from_background>', '<?from_scenario>'],
+      [new StepNode('Then', '<?from_scenario>', [], 2)],
+      [new StepNode('Given', '<?from_background>', [], 1)],
+    ];
   }
 
   /**
@@ -223,26 +206,6 @@ class RandomContextTest extends TestCase {
     $this->context->afterScenarioResetVariables($scope);
 
     $this->assertSame([], $this->valuesProperty->getValue($this->context));
-  }
-
-  /**
-   * Tests that surrounding characters in the message are preserved.
-   *
-   * Guards against the literal '?' inside the placeholder unintentionally
-   * being treated as a regex quantifier when building the substitution
-   * pattern from the token text.
-   */
-  public function testTransformVariablesPreservesSurroundingCharacters(): void {
-    $this->valuesProperty->setValue($this->context, ['<?abc>' => 'value']);
-    $this->assertSame('[value]', $this->context->transformVariables('[<?abc>]'));
-  }
-
-  /**
-   * Tests that token identifiers may contain underscores.
-   */
-  public function testTransformVariablesSupportsTokensWithUnderscores(): void {
-    $this->valuesProperty->setValue($this->context, ['<?my_token>' => 'value']);
-    $this->assertSame('see value', $this->context->transformVariables('see <?my_token>'));
   }
 
   /**
@@ -272,13 +235,6 @@ class RandomContextTest extends TestCase {
     $scope->method('getScenario')->willReturn($scenario);
 
     return $scope;
-  }
-
-  /**
-   * Builds a 'StepNode' from raw text, defaulting to a 'Given' keyword.
-   */
-  protected function createStep(string $text): StepNode {
-    return new StepNode('Given', $text, [], 1);
   }
 
 }

--- a/tests/phpunit/src/RandomContextTest.php
+++ b/tests/phpunit/src/RandomContextTest.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Tests;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Hook\Scope\ScenarioScope;
+use Behat\Gherkin\Node\BackgroundNode;
+use Behat\Gherkin\Node\FeatureNode;
+use Behat\Gherkin\Node\ScenarioNode;
+use Behat\Gherkin\Node\StepNode;
+use Behat\Gherkin\Node\TableNode;
+use Drupal\DrupalExtension\Context\RandomContext;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the RandomContext class.
+ *
+ * The class is exercised standalone - no Behat extension, no Mink session,
+ * no Drupal driver - to prove that none of those subsystems are required
+ * to load and use 'RandomContext'.
+ */
+#[CoversClass(RandomContext::class)]
+class RandomContextTest extends TestCase {
+
+  /**
+   * The context under test.
+   */
+  protected RandomContext $context;
+
+  /**
+   * Reflection of the protected $values property.
+   */
+  protected \ReflectionProperty $valuesProperty;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    $this->context = new RandomContext();
+    $this->valuesProperty = new \ReflectionProperty(RandomContext::class, 'values');
+  }
+
+  /**
+   * Tests that 'RandomContext' implements the bare Behat context interface.
+   *
+   * Documents the contract that the class can be loaded in a suite that
+   * does not register Mink or the Drupal extension.
+   */
+  public function testImplementsBareBehatContext(): void {
+    $this->assertInstanceOf(Context::class, $this->context);
+  }
+
+  /**
+   * Tests that the class no longer extends Drupal- or Mink-specific bases.
+   *
+   * Guards the structural promise of the rebase: no inherited 'getDriver()'
+   * or 'getSession()' surface.
+   */
+  public function testHasNoDrupalOrMinkAncestor(): void {
+    $this->assertSame([], class_parents($this->context));
+  }
+
+  /**
+   * Tests that 'transformVariables()' returns the input when no tokens.
+   */
+  public function testTransformVariablesReturnsInputWhenNoTokens(): void {
+    $this->valuesProperty->setValue($this->context, []);
+    $this->assertSame('plain text', $this->context->transformVariables('plain text'));
+  }
+
+  /**
+   * Tests that 'transformVariables()' substitutes a stored token.
+   */
+  public function testTransformVariablesSubstitutesToken(): void {
+    $this->valuesProperty->setValue($this->context, ['<?token>' => 'abcdef']);
+    $this->assertSame('value: abcdef', $this->context->transformVariables('value: <?token>'));
+  }
+
+  /**
+   * Tests that the same token resolves to the same value across uses.
+   */
+  public function testTransformVariablesIsConsistentForRepeatedToken(): void {
+    $this->valuesProperty->setValue($this->context, ['<?token>' => 'abcdef']);
+    $this->assertSame('abcdef and abcdef', $this->context->transformVariables('<?token> and <?token>'));
+  }
+
+  /**
+   * Tests that different tokens resolve to their own stored values.
+   */
+  public function testTransformVariablesUsesDistinctValuesForDistinctTokens(): void {
+    $this->valuesProperty->setValue($this->context, [
+      '<?one>' => 'aaaaaa',
+      '<?two>' => 'bbbbbb',
+    ]);
+    $this->assertSame('aaaaaa and bbbbbb', $this->context->transformVariables('<?one> and <?two>'));
+  }
+
+  /**
+   * Tests that 'transformTable()' substitutes tokens in cells.
+   */
+  public function testTransformTableSubstitutesTokensInCells(): void {
+    $this->valuesProperty->setValue($this->context, ['<?title>' => 'mytitle']);
+
+    $table = new TableNode([
+      ['title', 'value'],
+      ['<?title>', 'static'],
+    ]);
+
+    $transformed = $this->context->transformTable($table);
+
+    $this->assertSame([
+      ['title', 'value'],
+      ['mytitle', 'static'],
+    ], $transformed->getRows());
+  }
+
+  /**
+   * Tests that 'beforeScenarioSetVariables()' populates values from steps.
+   */
+  public function testBeforeScenarioPopulatesValuesFromScenarioSteps(): void {
+    $scope = $this->createScenarioScope([
+      $this->createStep('Given a string <?token>'),
+    ]);
+
+    $this->context->beforeScenarioSetVariables($scope);
+    $values = $this->valuesProperty->getValue($this->context);
+
+    $this->assertArrayHasKey('<?token>', $values);
+    $this->assertMatchesRegularExpression('/^[a-z0-9]{10}$/', $values['<?token>']);
+  }
+
+  /**
+   * Tests that the same token in multiple steps reuses the same value.
+   */
+  public function testBeforeScenarioReusesValuesForRepeatedTokens(): void {
+    $scope = $this->createScenarioScope([
+      $this->createStep('Given a string <?token>'),
+      $this->createStep('Then I see <?token>'),
+    ]);
+
+    $this->context->beforeScenarioSetVariables($scope);
+    $values = $this->valuesProperty->getValue($this->context);
+
+    $this->assertCount(1, $values);
+    $this->assertArrayHasKey('<?token>', $values);
+  }
+
+  /**
+   * Tests that distinct tokens get distinct generated values.
+   */
+  public function testBeforeScenarioGeneratesDistinctValuesForDistinctTokens(): void {
+    $scope = $this->createScenarioScope([
+      $this->createStep('Given <?one> and <?two>'),
+    ]);
+
+    $this->context->beforeScenarioSetVariables($scope);
+    $values = $this->valuesProperty->getValue($this->context);
+
+    $this->assertCount(2, $values);
+    $this->assertArrayHasKey('<?one>', $values);
+    $this->assertArrayHasKey('<?two>', $values);
+    $this->assertNotSame($values['<?one>'], $values['<?two>']);
+  }
+
+  /**
+   * Tests that token values are lowercase and 10 chars long.
+   */
+  public function testBeforeScenarioGeneratesLowercaseValues(): void {
+    $scope = $this->createScenarioScope([
+      $this->createStep('Given <?token>'),
+    ]);
+
+    $this->context->beforeScenarioSetVariables($scope);
+    $value = (string) $this->valuesProperty->getValue($this->context)['<?token>'];
+
+    $this->assertSame(strtolower($value), $value);
+    $this->assertSame(10, strlen($value));
+  }
+
+  /**
+   * Tests that tokens in TableNode step arguments are picked up.
+   */
+  public function testBeforeScenarioPicksUpTokensFromStepTableArguments(): void {
+    $table = new TableNode([
+      ['title', '<?random_page>'],
+    ]);
+    $scope = $this->createScenarioScope([
+      new StepNode('Given', 'a page with the following fields:', [$table], 1),
+    ]);
+
+    $this->context->beforeScenarioSetVariables($scope);
+    $values = $this->valuesProperty->getValue($this->context);
+
+    $this->assertArrayHasKey('<?random_page>', $values);
+  }
+
+  /**
+   * Tests that tokens in background steps are picked up.
+   */
+  public function testBeforeScenarioPicksUpTokensFromBackgroundSteps(): void {
+    $background = new BackgroundNode(NULL, [$this->createStep('Given <?from_background>')], 'Background', 1);
+    $scope = $this->createScenarioScope([
+      $this->createStep('Then <?from_scenario>'),
+    ], $background);
+
+    $this->context->beforeScenarioSetVariables($scope);
+    $values = $this->valuesProperty->getValue($this->context);
+
+    $this->assertArrayHasKey('<?from_background>', $values);
+    $this->assertArrayHasKey('<?from_scenario>', $values);
+  }
+
+  /**
+   * Tests that 'afterScenarioResetVariables()' clears the stored map.
+   */
+  public function testAfterScenarioClearsValues(): void {
+    $this->valuesProperty->setValue($this->context, ['<?token>' => 'abcdef']);
+
+    $scope = $this->createScenarioScope([]);
+    $this->context->afterScenarioResetVariables($scope);
+
+    $this->assertSame([], $this->valuesProperty->getValue($this->context));
+  }
+
+  /**
+   * Tests that a placeholder with regex special characters is handled.
+   */
+  #[DataProvider('dataProviderTransformVariablesEscapesRegexMetachars')]
+  public function testTransformVariablesEscapesRegexMetachars(string $token, string $value, string $message, string $expected): void {
+    $this->valuesProperty->setValue($this->context, [$token => $value]);
+    $this->assertSame($expected, $this->context->transformVariables($message));
+  }
+
+  /**
+   * Provides data for testTransformVariablesEscapesRegexMetachars().
+   *
+   * @return \Iterator<string, array<int, string>>
+   *   Cases keyed by description, each [token, value, input message,
+   *   expected message after substitution].
+   */
+  public static function dataProviderTransformVariablesEscapesRegexMetachars(): \Iterator {
+    yield 'simple alphanumeric token' => ['<?abc>', 'value', '[<?abc>]', '[value]'];
+    yield 'token with underscore' => ['<?my_token>', 'value', 'see <?my_token>', 'see value'];
+  }
+
+  /**
+   * Builds a 'ScenarioScope' over a fixed list of scenario steps.
+   *
+   * @param array<int, \Behat\Gherkin\Node\StepNode> $steps
+   *   Steps to attach to the scenario.
+   * @param \Behat\Gherkin\Node\BackgroundNode|null $background
+   *   Optional background to attach to the feature.
+   */
+  protected function createScenarioScope(array $steps, ?BackgroundNode $background = NULL): ScenarioScope {
+    $scenario = new ScenarioNode('Scenario title', [], $steps, 'Scenario', 1);
+    $feature = new FeatureNode(
+      'Feature title',
+      NULL,
+      [],
+      $background,
+      [$scenario],
+      'Feature',
+      'en',
+      NULL,
+      1,
+    );
+
+    $scope = $this->createMock(ScenarioScope::class);
+    $scope->method('getFeature')->willReturn($feature);
+    $scope->method('getScenario')->willReturn($scenario);
+
+    return $scope;
+  }
+
+  /**
+   * Builds a 'StepNode' from raw text, defaulting to a 'Given' keyword.
+   */
+  protected function createStep(string $text): StepNode {
+    return new StepNode('Given', $text, [], 1);
+  }
+
+}

--- a/tests/phpunit/src/RandomContextTest.php
+++ b/tests/phpunit/src/RandomContextTest.php
@@ -13,7 +13,6 @@ use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
 use Drupal\DrupalExtension\Context\RandomContext;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -227,24 +226,23 @@ class RandomContextTest extends TestCase {
   }
 
   /**
-   * Tests that a placeholder with regex special characters is handled.
+   * Tests that surrounding characters in the message are preserved.
+   *
+   * Guards against the literal '?' inside the placeholder unintentionally
+   * being treated as a regex quantifier when building the substitution
+   * pattern from the token text.
    */
-  #[DataProvider('dataProviderTransformVariablesEscapesRegexMetachars')]
-  public function testTransformVariablesEscapesRegexMetachars(string $token, string $value, string $message, string $expected): void {
-    $this->valuesProperty->setValue($this->context, [$token => $value]);
-    $this->assertSame($expected, $this->context->transformVariables($message));
+  public function testTransformVariablesPreservesSurroundingCharacters(): void {
+    $this->valuesProperty->setValue($this->context, ['<?abc>' => 'value']);
+    $this->assertSame('[value]', $this->context->transformVariables('[<?abc>]'));
   }
 
   /**
-   * Provides data for testTransformVariablesEscapesRegexMetachars().
-   *
-   * @return \Iterator<string, array<int, string>>
-   *   Cases keyed by description, each [token, value, input message,
-   *   expected message after substitution].
+   * Tests that token identifiers may contain underscores.
    */
-  public static function dataProviderTransformVariablesEscapesRegexMetachars(): \Iterator {
-    yield 'simple alphanumeric token' => ['<?abc>', 'value', '[<?abc>]', '[value]'];
-    yield 'token with underscore' => ['<?my_token>', 'value', 'see <?my_token>', 'see value'];
+  public function testTransformVariablesSupportsTokensWithUnderscores(): void {
+    $this->valuesProperty->setValue($this->context, ['<?my_token>' => 'value']);
+    $this->assertSame('see value', $this->context->transformVariables('see <?my_token>'));
   }
 
   /**


### PR DESCRIPTION
Closes #823

## Summary

`RandomContext` previously extended `RawDrupalContext`, inheriting Drupal and Mink
bootstrapping surface that it never needed. The class only used
`getDriver()->getRandom()` to obtain a `Drupal\Component\Utility\Random` instance,
which is stateless and requires no Drupal bootstrap. This PR cuts that dependency:
`RandomContext` now implements `Behat\Behat\Context\Context` directly, instantiates
`Random` lazily via a private accessor, and can be registered in any Behat suite
regardless of whether `Drupal\MinkExtension` or `Drupal\DrupalExtension` is loaded.

## Changes

**Class rebase (`RandomContext`)**
- Changed `extends RawDrupalContext` to `implements Context` (bare Behat interface).
- Added a lazy `private ?Random $random` property and a `getRandom(): Random` accessor
  to replace the removed `getDriver()->getRandom()` call.
- No changes to step definitions, the placeholder regex, or public behaviour.

**Profile registration (`behat.yml`, `behat.dist.yml`)**
- Registered `RandomContext` in the `default` (blackbox) profile so CI exercises
  the no-Drupal-driver code path.

**Behat integration tests (`tests/behat/features/random.feature`)**
- Added two `@test-blackbox @random` scenarios using the `BehatCliTrait` subprocess
  pattern: one verifying the token transform passes in the blackbox profile, one
  verifying the assertion fails when the raw token text is expected on the page.

**PHPUnit unit tests (`tests/phpunit/src/RandomContextTest.php`)**
- New test class that instantiates `RandomContext` standalone with no Behat
  plumbing, Mink, or Drupal driver present.
- Covers: structural promise (no parent classes, implements `Context`),
  `transformVariables()` substitution, `transformTable()` over `TableNode`,
  `beforeScenarioSetVariables()` populating values from scenario steps,
  table-argument and background-step token discovery, same-token consistency,
  distinct-token uniqueness, generated-value format (lowercase, 10 chars),
  `afterScenarioResetVariables()` clearing state, surrounding-character
  preservation, and underscore identifiers.

**Documentation and migration (`docs/contexts.md`, `MIGRATION.md`)**
- Updated the `RandomContext` row in the contexts table to note it is a pure Behat
  context with no Mink or Drupal driver.
- Added a paragraph in the `Mink-only contexts` section describing the leaner
  inheritance.
- Added a `## RandomContext base class` section in `MIGRATION.md` documenting
  the breaking change and what subclassers need to do to restore inherited helpers.

## Before / After

### Class hierarchy

```
Before
──────
RandomContext
  └─ extends RawDrupalContext
       └─ implements Context, SnippetAcceptingContext, ...
            (loads Drupal driver + Mink session on boot)

After
─────
RandomContext
  └─ implements Context          (bare Behat - nothing else)
       uses: Drupal\Component\Utility\Random  (lazy, no driver)
```

### Test and profile coverage

```
┌─────────────────────────────┬───────────┬────────────┐
│ Coverage area               │  Before   │   After    │
├─────────────────────────────┼───────────┼────────────┤
│ Blackbox profile (no driver)│    ✗      │     ✓      │
│ Drupal API profile          │    ✓      │     ✓      │
│ PHPUnit standalone tests    │    ✗      │     ✓      │
│ Token substitution contract │  implicit │  explicit  │
│ Background step discovery   │  implicit │  explicit  │
│ Table argument discovery    │  implicit │  explicit  │
└─────────────────────────────┴───────────┴────────────┘
```
