### PR TITLE
[#824] Converted 'BatchContext' into 'BatchTrait' on 'DrupalContext'.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -234,6 +234,50 @@ in the table above. Other entries under
 `Drupal\DrupalExtension.selectors:` (`login_form_selector`,
 `logged_in_selector`) are unaffected.
 
+## BatchContext removed
+
+`Drupal\DrupalExtension\Context\BatchContext` no longer exists. Its two
+step definitions are now provided by `DrupalContext` via the new
+`Drupal\DrupalExtension\Context\Traits\BatchTrait` trait.
+
+Both steps are Drupal-specific - `Given I wait for the batch job to
+finish` polls the `#updateprogress` element rendered by Drupal's
+Batch API, and `Given the following item is in the system queue:`
+writes directly to the `queue` table managed by Drupal's
+`SystemQueue`. Hosting them on `DrupalContext` (which extends
+`RawDrupalContext` and is only loaded with the API driver) keeps
+`\Drupal::` calls inside a bootstrapped Drupal kernel, removing the
+silent failures that occurred when the steps were invoked under the
+Blackbox or Drush drivers.
+
+Remove the `BatchContext` entry from your `behat.yml` suites:
+
+```yaml
+# 5.x
+default:
+  suites:
+    default:
+      contexts:
+        - Drupal\DrupalExtension\Context\DrupalContext
+        - Drupal\DrupalExtension\Context\BatchContext
+
+# 6.0
+default:
+  suites:
+    default:
+      contexts:
+        - Drupal\DrupalExtension\Context\DrupalContext
+```
+
+If your suite already registers `DrupalContext`, the two batch/queue
+steps remain available without any feature-file changes. If you
+registered `BatchContext` without `DrupalContext`, add `DrupalContext`
+to the suite to keep the steps.
+
+If you subclass `BatchContext` directly, change the parent to
+`DrupalContext` (or extend `RawDrupalContext` and `use BatchTrait;`
+yourself).
+
 ## RandomContext base class
 
 `RandomContext` no longer extends `RawDrupalContext`. It now implements

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ the [full documentation](docs/README.md).
 
 | Class | Description |
 | --- | --- |
-| [BatchContext](STEPS.md#batchcontext) | Extensions to the Mink Extension. |
 | [ConfigContext](STEPS.md#configcontext) | Provides pre-built step definitions for interacting with Drupal config. |
 | [DrupalContext](STEPS.md#drupalcontext) | Provides pre-built step definitions for interacting with Drupal. |
 | [DrushContext](STEPS.md#drushcontext) | Provides step definitions for interacting directly with Drush commands. |

--- a/STEPS.md
+++ b/STEPS.md
@@ -2,7 +2,6 @@
 
 | Class | Description |
 | --- | --- |
-| [BatchContext](#batchcontext) | Extensions to the Mink Extension. |
 | [ConfigContext](#configcontext) | Provides pre-built step definitions for interacting with Drupal config. |
 | [DrupalContext](#drupalcontext) | Provides pre-built step definitions for interacting with Drupal. |
 | [DrushContext](#drushcontext) | Provides step definitions for interacting directly with Drush commands. |
@@ -13,45 +12,6 @@
 
 
 ---
-
-## BatchContext
-
-[Source](src/Drupal/DrupalExtension/Context/BatchContext.php), [Example](tests/behat/features/batch.feature)
-
-> Extensions to the Mink Extension.
-
-
-<details>
-  <summary><code>@Given I wait for the batch job to finish</code></summary>
-
-<br/>
-Wait for the Batch API to finish. 
-<br/><br/>
-
-```gherkin
-Given I wait for the batch job to finish
-
-```
-
-</details>
-
-<details>
-  <summary><code>@Given the following item is in the system queue:</code></summary>
-
-<br/>
-Creates a queue item. Defaults inputs if none are available. 
-<br/><br/>
-
-```gherkin
-  Given the following item is in the system queue:
-    | name    | my_queue              |
-    | data    | {"key":"value"}       |
-    | created | 1700000000            |
-    | expire  | 0                     |
-
-```
-
-</details>
 
 ## ConfigContext
 
@@ -469,6 +429,38 @@ Creates one or more languages.
     | languages |
     | en        |
     | fr        |
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given I wait for the batch job to finish</code></summary>
+
+<br/>
+Wait for the Batch API to finish. 
+<br/><br/>
+
+```gherkin
+Given I wait for the batch job to finish
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given the following item is in the system queue:</code></summary>
+
+<br/>
+Creates a queue item. Defaults inputs if none are available. 
+<br/><br/>
+
+```gherkin
+  Given the following item is in the system queue:
+    | name    | my_queue              |
+    | data    | {"key":"value"}       |
+    | created | 1700000000            |
+    | expire  | 0                     |
 
 ```
 

--- a/behat.dist.yml
+++ b/behat.dist.yml
@@ -102,7 +102,6 @@ drupal:
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\MarkupContext
         - Drupal\DrupalExtension\Context\DrushContext
-        - Drupal\DrupalExtension\Context\BatchContext
         - Drupal\DrupalExtension\Context\MailContext
         - Drupal\DrupalExtension\Context\RandomContext
         - Drupal\DrupalExtension\Context\ConfigContext

--- a/behat.yml
+++ b/behat.yml
@@ -16,9 +16,9 @@
 #    selectors mapped to the Drupal theme). This dual testing proves that
 #    the contexts are truly driver-agnostic.
 #
-# 3. Drupal API contexts (e.g. DrupalContext, DrushContext, BatchContext)
-#    require a running Drupal site and the API driver. They can only run
-#    in the drupal profile.
+# 3. Drupal API contexts (e.g. DrupalContext, DrushContext) require a
+#    running Drupal site and the API driver. They can only run in the
+#    drupal profile.
 #
 # Profile-selection tags control which profile runs a given scenario.
 # These use a "test-" prefix to distinguish them from functional tags
@@ -128,7 +128,6 @@ drupal:
       contexts:
         # Contexts under tests - Drupal contexts.
         - Drupal\DrupalExtension\Context\ConfigContext
-        - Drupal\DrupalExtension\Context\BatchContext
         - Drupal\DrupalExtension\Context\DrupalContext
         - Drupal\DrupalExtension\Context\DrushContext
         - Drupal\DrupalExtension\Context\MinkContext

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -10,11 +10,10 @@ declared explicitly.
 | Context | Purpose |
 | --- | --- |
 | `Drupal\DrupalExtension\Context\RawDrupalContext` | Base class with Drupal and Mink session helpers but no step definitions. Extend this in your `FeatureContext`. |
-| `Drupal\DrupalExtension\Context\DrupalContext` | Steps for users, nodes, taxonomy terms, and login flows. |
+| `Drupal\DrupalExtension\Context\DrupalContext` | Steps for users, nodes, taxonomy terms, login flows, and the Drupal Batch API and queue items. |
 | `Drupal\DrupalExtension\Context\MinkContext` | Region-aware extensions over the Mink Extension's default steps. |
 | `Drupal\DrupalExtension\Context\MarkupContext` | Low-level markup assertions - tags, classes, attributes. |
 | `Drupal\DrupalExtension\Context\MessageContext` | Steps for Drupal status, error, and warning messages. |
-| `Drupal\DrupalExtension\Context\BatchContext` | Steps for the Drupal Batch API and queue items. |
 | `Drupal\DrupalExtension\Context\ConfigContext` | Steps that read and write Drupal configuration. |
 | `Drupal\DrupalExtension\Context\DrushContext` | Steps that invoke arbitrary Drush commands. |
 | `Drupal\DrupalExtension\Context\MailContext` | Steps that assert against the Drupal mail collector. |
@@ -47,8 +46,8 @@ In this configuration, scenarios have access to:
 - Steps you defined in `tests/bootstrap/FeatureContext.php`.
 - Steps you defined in `CustomContext`.
 
-They do **not** have access to `MarkupContext`, `BatchContext`,
-`DrushContext`, or any context not declared in this list.
+They do **not** have access to `MarkupContext`, `DrushContext`,
+or any context not declared in this list.
 
 ## RawDrupalContext
 

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -19,6 +19,7 @@ use Drupal\Driver\Capability\RoleCapabilityInterface;
 use Drupal\Driver\Capability\UserCapabilityInterface;
 use Drupal\Driver\Entity\EntityStub;
 use Drupal\Driver\Entity\EntityStubInterface;
+use Drupal\DrupalExtension\Context\Traits\BatchTrait;
 use Drupal\DrupalExtension\Context\Traits\BigPipeTrait;
 
 /**
@@ -26,6 +27,7 @@ use Drupal\DrupalExtension\Context\Traits\BigPipeTrait;
  */
 class DrupalContext extends RawDrupalContext implements TranslatableContext {
 
+  use BatchTrait;
   use BigPipeTrait;
 
   /**

--- a/src/Drupal/DrupalExtension/Context/Traits/BatchTrait.php
+++ b/src/Drupal/DrupalExtension/Context/Traits/BatchTrait.php
@@ -2,16 +2,26 @@
 
 declare(strict_types=1);
 
-namespace Drupal\DrupalExtension\Context;
+namespace Drupal\DrupalExtension\Context\Traits;
 
-use Behat\Step\Given;
 use Behat\Gherkin\Node\TableNode;
-use Behat\MinkExtension\Context\RawMinkContext;
+use Behat\Step\Given;
 
 /**
- * Extensions to the Mink Extension.
+ * Drupal-specific batch and queue helpers.
+ *
+ * Both steps are Drupal-aware: 'iWaitForTheBatchJobToFinish' polls the
+ * '#updateprogress' element rendered by Drupal's Batch API, and
+ * 'thereIsAnItemInTheSystemQueue' writes directly to the 'queue' table
+ * managed by Drupal's SystemQueue. The trait is therefore consumed by the
+ * Drupal-aware 'DrupalContext' rather than a Mink-only context, which keeps
+ * '\Drupal::' calls behind the API driver and avoids silent failures under
+ * Blackbox/Drush drivers.
+ *
+ * The host class is expected to extend 'RawDrupalContext' so '$this->getSession()'
+ * is available and the Drupal kernel is bootstrapped.
  */
-class BatchContext extends RawMinkContext {
+trait BatchTrait {
 
   /**
    * Wait for the Batch API to finish.
@@ -43,10 +53,8 @@ class BatchContext extends RawMinkContext {
    */
   #[Given('the following item is in the system queue:')]
   public function thereIsAnItemInTheSystemQueue(TableNode $table): void {
-    // Gather the data.
     $fields = $table->getRowsHash();
 
-    // Default data field separately since this is longish.
     if (empty($fields['data'])) {
       $fields['data'] = json_encode([]);
     }

--- a/src/Drupal/DrupalExtension/Context/Traits/BatchTrait.php
+++ b/src/Drupal/DrupalExtension/Context/Traits/BatchTrait.php
@@ -18,8 +18,8 @@ use Behat\Step\Given;
  * '\Drupal::' calls behind the API driver and avoids silent failures under
  * Blackbox/Drush drivers.
  *
- * The host class is expected to extend 'RawDrupalContext' so '$this->getSession()'
- * is available and the Drupal kernel is bootstrapped.
+ * The host class is expected to extend 'RawDrupalContext' so
+ * '$this->getSession()' is available and the Drupal kernel is bootstrapped.
  */
 trait BatchTrait {
 

--- a/tests/behat/features/batch.feature
+++ b/tests/behat/features/batch.feature
@@ -1,4 +1,4 @@
-Feature: BatchContext
+Feature: Drupal Batch API and queue
   As a developer
   I want to create queue items and manage batch operations
   So that I can test background processing behaviour


### PR DESCRIPTION
Closes #824

## Summary

`BatchContext` has been converted into `BatchTrait` and composed into `DrupalContext` via `use BatchTrait;`. Both steps (`iWaitForTheBatchJobToFinish` and `thereIsAnItemInTheSystemQueue`) are Drupal-specific - one polls a DOM element rendered by Drupal's Batch API, the other writes directly to the `queue` table managed by `SystemQueue`. Hosting them on `DrupalContext` (which only loads with the API driver) keeps all `\Drupal::` calls behind a bootstrapped Drupal kernel and prevents silent failures under Blackbox or Drush drivers. The alternative capability-interface approach proposed in the original issue was considered but rejected in favour of simplicity - no new `QueueCapabilityInterface` is needed when the steps are inherently Drupal-only.

## Changes

### New trait

- `src/Drupal/DrupalExtension/Context/Traits/BatchTrait.php` - contains both step methods, moved from `BatchContext` with the class-level docblock updated to explain the driver constraint.

### Deleted class

- `src/Drupal/DrupalExtension/Context/BatchContext.php` - removed; steps are now provided by `DrupalContext`.

### Modified contexts

- `src/Drupal/DrupalExtension/Context/DrupalContext.php` - added `use BatchTrait;` alongside `use BigPipeTrait;`.

### Configuration

- `behat.yml`, `behat.dist.yml` - removed the `BatchContext` registration; the steps are now available through `DrupalContext`.

### Documentation and tests

- `docs/contexts.md` - removed the `BatchContext` row; expanded the `DrupalContext` description to mention batch and queue steps.
- `README.md`, `STEPS.md` - removed `BatchContext` entry; batch/queue steps now appear under `DrupalContext`.
- `tests/behat/features/batch.feature` - feature title updated from `BatchContext` to `Drupal Batch API and queue`.

## Before / After

```
Before:                                   After:
──────────────────────────────────        ──────────────────────────────────
RawMinkContext                            RawDrupalContext
  └─ BatchContext (standalone)              └─ DrupalContext
       ├─ iWaitForTheBatchJobToFinish             uses BatchTrait
       └─ thereIsAnItemInTheSystemQueue               ├─ iWaitForTheBatchJobToFinish
                                                      └─ thereIsAnItemInTheSystemQueue
behat.yml
  drupal profile:
    - DrupalContext                        behat.yml
    - BatchContext   ◄── explicit            drupal profile:
    - DrushContext                             - DrupalContext  ◄── batch steps
    - ...                                      - DrushContext       included
                                               - ...
```
