### PR TITLE
Renamed 'assert' action steps and tightened validator.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -34,6 +34,44 @@ Update each occurrence in your `.feature` files.
 | `Then I should be able to edit a/an :type content`                         | `Then I should be able to edit the :type content`                                        |
 | `Then break` / `Then I break`                                              | `When break` / `When I break` (re-categorised from `Then`)                               |
 | `Then I log out`                                                           | `When I log out` (re-categorised from `Then`)                                            |
+| `Given I should not see the error message ...`                             | `Then I should not see the error message ...` (re-categorised from `Given`)              |
+| `Given I should not see the success message ...`                           | `Then I should not see the success message ...` (re-categorised from `Given`)            |
+| `Given I should not see the warning message ...`                           | `Then I should not see the warning message ...` (re-categorised from `Given`)            |
+
+Note: Behat treats `Given`, `When` and `Then` as interchangeable when matching
+step text, so existing scenarios that still use the old keyword continue to
+work. The right-hand column is the canonical form documented in `STEPS.md` and
+shown by IDE autocomplete in 6.0.
+
+## Method renames
+
+Version 6.0 enforces that only `@Then` step methods may carry "Assert" in
+their name. Any subclass that overrode the following `@Given` or `@When`
+methods must be updated to use the new method name.
+
+| Context          | 5.x method name                              | 6.0 method name                          |
+| ---------------- | -------------------------------------------- | ---------------------------------------- |
+| `DrupalContext`  | `assertAuthenticatedByRole`                  | `iAmLoggedInAsUserWithRole`              |
+| `DrupalContext`  | `assertAuthenticatedByRoleShort`             | `iAmLoggedInAsRole`                      |
+| `DrupalContext`  | `assertAuthenticatedByRoleWithGivenFields`   | `iAmLoggedInAsUserWithRoleAndFields`     |
+| `DrupalContext`  | `assertLoggedInByName`                       | `iAmLoggedInAs`                          |
+| `DrupalContext`  | `assertLoggedInWithPermissions`              | `iAmLoggedInAsUserWithPermissions`       |
+| `DrupalContext`  | `assertClickInTableRow`                      | `iClickInTableRow`                       |
+| `DrupalContext`  | `assertPressInTableRow`                      | `iPressInTableRow`                       |
+| `DrupalContext`  | `assertCacheClear`                           | `clearCache`                             |
+| `DrupalContext`  | `assertCron`                                 | `iRunCron`                               |
+| `DrupalContext`  | `assertViewingNode`                          | `iAmViewingNodeWithFields`               |
+| `DrupalContext`  | `assertViewingNodeContent`                   | `iAmViewingNodeContentWithFields`        |
+| `DrushContext`   | `assertDrushCommand`                         | `iRunDrush`                              |
+| `DrushContext`   | `assertDrushCommandWithArgument`             | `iRunDrushWithArguments`                 |
+| `MessageContext` | `assertNotErrorVisible`                      | `errorMessageAssertIsNotVisible`         |
+| `MessageContext` | `assertNotSuccessMessage`                    | `successMessageAssertIsNotVisible`       |
+| `MessageContext` | `assertNotWarningMessage`                    | `warningMessageAssertIsNotVisible`       |
+
+The step text bound to each method is unchanged (with the exception of the
+three `MessageContext` keyword changes documented in the table above), so
+feature files only need updating where they relied on the old `Given`
+keyword for the negative-message steps.
 
 ## Field syntax
 

--- a/STEPS.md
+++ b/STEPS.md
@@ -70,7 +70,7 @@ Sets complex configuration.
   <summary><code>@Given I am an anonymous user</code></summary>
 
 <br/>
-Assert the user is anonymous. 
+Log the current user out so the session is anonymous. 
 <br/><br/>
 
 ```gherkin
@@ -84,7 +84,7 @@ Given I am an anonymous user
   <summary><code>@Given I am not logged in</code></summary>
 
 <br/>
-Assert the user is not logged in. 
+Log the current user out. 
 <br/><br/>
 
 ```gherkin
@@ -1257,51 +1257,6 @@ Then I should see "Notice" in the "div" element with the "color" CSS property se
 
 
 <details>
-  <summary><code>@Given I should not see the error message( containing) :message</code></summary>
-
-<br/>
-Checks if the current page does not contain the given error message. 
-<br/><br/>
-
-```gherkin
-  Given I should not see the error message "Access denied"
-  Given I should not see the error message containing "Access"
-
-```
-
-</details>
-
-<details>
-  <summary><code>@Given I should not see the success message( containing) :message</code></summary>
-
-<br/>
-Checks the page does not contain the given success message. 
-<br/><br/>
-
-```gherkin
-  Given I should not see the success message "saved"
-  Given I should not see the success message containing "saved"
-
-```
-
-</details>
-
-<details>
-  <summary><code>@Given I should not see the warning message( containing) :message</code></summary>
-
-<br/>
-Checks the page does not contain the given warning message. 
-<br/><br/>
-
-```gherkin
-  Given I should not see the warning message "deprecated"
-  Given I should not see the warning message containing "deprecated"
-
-```
-
-</details>
-
-<details>
   <summary><code>@Then I should see the error message( containing) :message</code></summary>
 
 <br/>
@@ -1328,6 +1283,21 @@ Checks if the current page contains the given set of error messages.
     | error messages         |
     | Username is required   |
     | Password is required   |
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then I should not see the error message( containing) :message</code></summary>
+
+<br/>
+Checks if the current page does not contain the given error message. 
+<br/><br/>
+
+```gherkin
+  Then I should not see the error message "Access denied"
+  Then I should not see the error message containing "Access"
 
 ```
 
@@ -1381,6 +1351,21 @@ Checks if the current page contains the given set of success messages.
 </details>
 
 <details>
+  <summary><code>@Then I should not see the success message( containing) :message</code></summary>
+
+<br/>
+Checks the page does not contain the given success message. 
+<br/><br/>
+
+```gherkin
+  Then I should not see the success message "saved"
+  Then I should not see the success message containing "saved"
+
+```
+
+</details>
+
+<details>
   <summary><code>@Then I should not see the following success messages:</code></summary>
 
 <br/>
@@ -1422,6 +1407,21 @@ Checks if the current page contains the given set of warning messages.
   Then I should see the following warning messages:
     | warning messages                |
     | This action cannot be undone    |
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then I should not see the warning message( containing) :message</code></summary>
+
+<br/>
+Checks the page does not contain the given warning message. 
+<br/><br/>
+
+```gherkin
+  Then I should not see the warning message "deprecated"
+  Then I should not see the warning message containing "deprecated"
 
 ```
 

--- a/scripts/docs.php
+++ b/scripts/docs.php
@@ -22,11 +22,13 @@
  *
  * Step definition conventions (to be enforced in version 6):
  * - @Given steps ending with ':' must contain the word "following".
+ * - @Given/@When steps must NOT contain the word "should" (reserved for @Then).
  * - @When steps must contain "I " (first person).
  * - @Then steps must contain the word "should".
  * - @Then steps must contain "the", "a", or "no".
  * - @Then method names must contain "Assert".
  * - @Then method names must NOT contain "Should".
+ * - @Given/@When method names must NOT contain "Assert" (reserved for @Then).
  * - All steps must have an @code/@endcode example in the docblock.
  * - Each method should define only one step annotation.
  * - Steps should use turnip syntax instead of unnecessary regex.
@@ -718,6 +720,10 @@ function validate(array $info, string $base_path = ''): array {
         $step_wording['pass'] = FALSE;
         $step_wording['messages'][] = 'Missing "I " in the step';
       }
+      if ((str_starts_with($step, '@Given') || str_starts_with($step, '@When')) && str_contains($step, ' should ')) {
+        $step_wording['pass'] = FALSE;
+        $step_wording['messages'][] = 'Contains "should" in the step (reserved for @Then)';
+      }
       if (str_starts_with($step, '@Then')) {
         if (!str_contains($step, ' should ')) {
           $step_wording['pass'] = FALSE;
@@ -740,6 +746,10 @@ function validate(array $info, string $base_path = ''): array {
           $method_naming['pass'] = FALSE;
           $method_naming['messages'][] = 'Contains "Should" in the method name';
         }
+      }
+      if ((str_starts_with($step, '@Given') || str_starts_with($step, '@When')) && stripos((string) $method['name'], 'assert') !== FALSE) {
+        $method_naming['pass'] = FALSE;
+        $method_naming['messages'][] = 'Contains "Assert" in the method name (reserved for @Then)';
       }
 
       // Single step check.

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -41,7 +41,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
   }
 
   /**
-   * Assert the user is anonymous.
+   * Log the current user out so the session is anonymous.
    *
    * @code
    * Given I am an anonymous user
@@ -53,7 +53,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
   }
 
   /**
-   * Assert the user is not logged in.
+   * Log the current user out.
    *
    * @code
    * Given I am not logged in
@@ -85,7 +85,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @endcode
    */
   #[Given('I am logged in as a user with the :role role(s)')]
-  public function assertAuthenticatedByRole(string $role): void {
+  public function iAmLoggedInAsUserWithRole(string $role): void {
     $this->createAndLoginUserWithRole($role);
   }
 
@@ -97,7 +97,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @endcode
    */
   #[Given('I am logged in as a/an :role')]
-  public function assertAuthenticatedByRoleShort(string $role): void {
+  public function iAmLoggedInAsRole(string $role): void {
     $this->createAndLoginUserWithRole($role);
   }
 
@@ -111,7 +111,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @endcode
    */
   #[Given('I am logged in as a user with the :role role(s) and I have the following fields:')]
-  public function assertAuthenticatedByRoleWithGivenFields(string $role, TableNode $fields): void {
+  public function iAmLoggedInAsUserWithRoleAndFields(string $role, TableNode $fields): void {
     $this->createAndLoginUserWithRole($role, $fields->getRowsHash());
   }
 
@@ -177,7 +177,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @endcode
    */
   #[Given('I am logged in as :name')]
-  public function assertLoggedInByName(string $name): void {
+  public function iAmLoggedInAs(string $name): void {
     $this->login($this->getUserManager()->getUser($name));
   }
 
@@ -190,7 +190,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @endcode
    */
   #[Given('I am logged in as a user with the :permissions permission(s)')]
-  public function assertLoggedInWithPermissions(string $permissions): void {
+  public function iAmLoggedInAsUserWithPermissions(string $permissions): void {
     $driver = $this->getDriver();
 
     if (!$driver instanceof RoleCapabilityInterface || !$driver instanceof UserCapabilityInterface) {
@@ -312,7 +312,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @endcode
    */
   #[Given('I click :link in the :rowText row')]
-  public function assertClickInTableRow(string $link, string $rowText): void {
+  public function iClickInTableRow(string $link, string $rowText): void {
     $page = $this->getSession()->getPage();
     if ($link_element = $this->getTableRow($page, $rowText)->findLink($link)) {
       // Click the link and return.
@@ -334,7 +334,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @endcode
    */
   #[Given('I press :button in the :rowText row')]
-  public function assertPressInTableRow(string $button, string $rowText): void {
+  public function iPressInTableRow(string $button, string $rowText): void {
     $page = $this->getSession()->getPage();
     if ($button_element = $this->getTableRow($page, $rowText)->findButton($button)) {
       // Press the button and return.
@@ -352,7 +352,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @endcode
    */
   #[Given('the cache has been cleared')]
-  public function assertCacheClear(): void {
+  public function clearCache(): void {
     $driver = $this->getDriver();
 
     if (!$driver instanceof CacheCapabilityInterface) {
@@ -370,7 +370,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @endcode
    */
   #[Given('I run cron')]
-  public function assertCron(): void {
+  public function iRunCron(): void {
     $driver = $this->getDriver();
 
     if (!$driver instanceof CronCapabilityInterface) {
@@ -479,7 +479,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @endcode
    */
   #[Given('I am viewing a/an :type with the following fields:')]
-  public function assertViewingNode(string $type, TableNode $fields): void {
+  public function iAmViewingNodeWithFields(string $type, TableNode $fields): void {
     $this->createAndVisitNodeFromTable($type, $fields);
   }
 
@@ -493,7 +493,7 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
    * @endcode
    */
   #[Given('I am viewing a/an :type content with the following fields:')]
-  public function assertViewingNodeContent(string $type, TableNode $fields): void {
+  public function iAmViewingNodeContentWithFields(string $type, TableNode $fields): void {
     $this->createAndVisitNodeFromTable($type, $fields);
   }
 

--- a/src/Drupal/DrupalExtension/Context/DrushContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrushContext.php
@@ -49,7 +49,7 @@ class DrushContext extends RawDrupalContext implements TranslatableContext {
    * @endcode
    */
   #[Given('I run drush :command')]
-  public function assertDrushCommand(string $command): void {
+  public function iRunDrush(string $command): void {
     if (!$this->drushOutput = $this->getDriver('drush')->$command()) {
       $this->drushOutput = TRUE;
     }
@@ -63,7 +63,7 @@ class DrushContext extends RawDrupalContext implements TranslatableContext {
    * @endcode
    */
   #[Given('I run drush :command :arguments')]
-  public function assertDrushCommandWithArgument(string $command, string $arguments): void {
+  public function iRunDrushWithArguments(string $command, string $arguments): void {
     $this->drushOutput = $this->getDriver('drush')->$command($this->fixStepArgument($arguments));
     if ($this->drushOutput === NULL) {
       $this->drushOutput = TRUE;

--- a/src/Drupal/DrupalExtension/Context/MessageContext.php
+++ b/src/Drupal/DrupalExtension/Context/MessageContext.php
@@ -89,12 +89,12 @@ class MessageContext extends RawMinkContext implements TranslatableContext, Para
    *   The text to be checked.
    *
    * @code
-   *   Given I should not see the error message "Access denied"
-   *   Given I should not see the error message containing "Access"
+   *   Then I should not see the error message "Access denied"
+   *   Then I should not see the error message containing "Access"
    * @endcode
    */
-  #[Given('I should not see the error message( containing) :message')]
-  public function assertNotErrorVisible(string $message): void {
+  #[Then('I should not see the error message( containing) :message')]
+  public function errorMessageAssertIsNotVisible(string $message): void {
     $this->assertNot(
           $message,
           'error',
@@ -121,7 +121,7 @@ class MessageContext extends RawMinkContext implements TranslatableContext, Para
     foreach ($messages->getHash() as $value) {
       $value = array_change_key_case($value);
       $message = trim($value['error messages']);
-      $this->assertNotErrorVisible($message);
+      $this->errorMessageAssertIsNotVisible($message);
     }
   }
 
@@ -176,12 +176,12 @@ class MessageContext extends RawMinkContext implements TranslatableContext, Para
    *   The text to be checked.
    *
    * @code
-   *   Given I should not see the success message "saved"
-   *   Given I should not see the success message containing "saved"
+   *   Then I should not see the success message "saved"
+   *   Then I should not see the success message containing "saved"
    * @endcode
    */
-  #[Given('I should not see the success message( containing) :message')]
-  public function assertNotSuccessMessage(string $message): void {
+  #[Then('I should not see the success message( containing) :message')]
+  public function successMessageAssertIsNotVisible(string $message): void {
     $this->assertNot(
           $message,
           'success',
@@ -208,7 +208,7 @@ class MessageContext extends RawMinkContext implements TranslatableContext, Para
     foreach ($messages->getHash() as $value) {
       $value = array_change_key_case($value);
       $message = trim($value['success messages']);
-      $this->assertNotSuccessMessage($message);
+      $this->successMessageAssertIsNotVisible($message);
     }
   }
 
@@ -263,12 +263,12 @@ class MessageContext extends RawMinkContext implements TranslatableContext, Para
    *   The text to be checked.
    *
    * @code
-   *   Given I should not see the warning message "deprecated"
-   *   Given I should not see the warning message containing "deprecated"
+   *   Then I should not see the warning message "deprecated"
+   *   Then I should not see the warning message containing "deprecated"
    * @endcode
    */
-  #[Given('I should not see the warning message( containing) :message')]
-  public function assertNotWarningMessage(string $message): void {
+  #[Then('I should not see the warning message( containing) :message')]
+  public function warningMessageAssertIsNotVisible(string $message): void {
     $this->assertNot(
           $message,
           'warning',
@@ -295,7 +295,7 @@ class MessageContext extends RawMinkContext implements TranslatableContext, Para
     foreach ($messages->getHash() as $value) {
       $value = array_change_key_case($value);
       $message = trim($value['warning messages']);
-      $this->assertNotWarningMessage($message);
+      $this->warningMessageAssertIsNotVisible($message);
     }
   }
 

--- a/src/Drupal/DrupalExtension/Context/MessageContext.php
+++ b/src/Drupal/DrupalExtension/Context/MessageContext.php
@@ -8,7 +8,6 @@ use Behat\Behat\Context\TranslatableContext;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Behat\Step\Given;
 use Behat\Step\Then;
 use Drupal\DrupalExtension\DeprecationInterface;
 use Drupal\DrupalExtension\DeprecationTrait;

--- a/tests/behat/features/d10.feature
+++ b/tests/behat/features/d10.feature
@@ -30,7 +30,7 @@ Feature: DrupalContext
 
   # This tests that a user that is created in one particular Context class (in
   # this case FeatureContext::assertLoggedInByUsernameAndPassword()) can be
-  # accessed in another Context (DrupalContext::assertLoggedInByName()).
+  # accessed in another Context (DrupalContext::iAmLoggedInAs()).
   @test-drupal @api
   Scenario: Logging in as a user without an e-mail address.
     Given I am logged in as a user with name "Carrot Ironfoundersson" and password "citywatch1234"

--- a/tests/behat/features/i18n/es/d10.feature
+++ b/tests/behat/features/i18n/es/d10.feature
@@ -37,7 +37,7 @@ Característica: DrupalContext
 
   # lo siguiente comprueba que un usuario creado por una clase Conexto (en este
   # caso FeatureContext::assertLoggedInByUsernameAndPassword()) puede ser utilizado
-  # por otro Contexto (DrupalContext::assertLoggedInByName()).
+  # por otro Contexto (DrupalContext::iAmLoggedInAs()).
   @test-drupal @api
   Escenario: Conectarse como usuario sin dirección de correo
     # notar que el siguiente paso no está traducido: está definido en FeatureContext (no en DrupalContext)

--- a/tests/phpunit/fixtures/docs/MisnamedAssertContext.php
+++ b/tests/phpunit/fixtures/docs/MisnamedAssertContext.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Tests\Fixtures;
+
+use Behat\Step\Given;
+use Behat\Step\When;
+
+/**
+ * Context exercising the inverse 'Assert'/'should' validation checks.
+ *
+ * Each public step here intentionally violates one of the rules added in
+ * 6.0: '@Given'/'@When' methods may not contain "Assert" in the method
+ * name, and '@Given'/'@When' step text may not contain "should". Used by
+ * the full extract_info → validate pipeline to confirm the validator
+ * flags violations when they are encoded as real PHP attributes.
+ */
+class MisnamedAssertContext {
+
+  /**
+   * Method name contains 'Assert' on a Given step (action, not assertion).
+   *
+   * @code
+   * Given I create the thing
+   * @endcode
+   */
+  #[Given('I create the thing')]
+  public function assertGivenAction(): void {
+  }
+
+  /**
+   * Method name contains 'Assert' on a When step (action, not assertion).
+   *
+   * @code
+   * When I trigger the thing
+   * @endcode
+   */
+  #[When('I trigger the thing')]
+  public function assertWhenAction(): void {
+  }
+
+  /**
+   * Given step text contains 'should' (reserved for Then).
+   *
+   * @code
+   * Given the page should be ready
+   * @endcode
+   */
+  #[Given('the page should be ready')]
+  public function pageIsReady(): void {
+  }
+
+  /**
+   * When step text contains 'should' (reserved for Then).
+   *
+   * @code
+   * When I think the request should succeed
+   * @endcode
+   */
+  #[When('I think the request should succeed')]
+  public function requestSucceeds(): void {
+  }
+
+}

--- a/tests/phpunit/src/DocsTest.php
+++ b/tests/phpunit/src/DocsTest.php
@@ -1853,6 +1853,45 @@ EOD,
   }
 
   /**
+   * Tests the extract_info → validate pipeline with the inverse checks.
+   *
+   * Builds the info structure from a real PHP fixture (via reflection on
+   * its '#[Given]' / '#[When]' attributes) and feeds it into validate(),
+   * confirming the validator flags '@Given'/'@When' methods named with
+   * 'Assert' and step text containing 'should'.
+   */
+  public function testValidateInverseChecksThroughExtractInfo(): void {
+    $base_path = static::$tmp;
+    $context_dir = $base_path . DIRECTORY_SEPARATOR . 'src';
+    if (!is_dir($context_dir)) {
+      mkdir($context_dir, 0777, TRUE);
+    }
+
+    $class_name = 'MisnamedAssertContext';
+    $fixtures_dir = __DIR__ . '/../fixtures/docs';
+    copy($fixtures_dir . DIRECTORY_SEPARATOR . $class_name . '.php', $context_dir . DIRECTORY_SEPARATOR . $class_name . '.php');
+
+    $info = extract_info($context_dir, [], $base_path, 'Drupal\\DrupalExtension\\Tests\\Fixtures');
+    $results = validate($info, $base_path);
+
+    $methods = $results[$class_name]['methods'];
+
+    $this->assertFalse($methods['assertGivenAction']['method_naming']['pass']);
+    $this->assertSame(['Contains "Assert" in the method name (reserved for @Then)'], $methods['assertGivenAction']['method_naming']['messages']);
+
+    $this->assertFalse($methods['assertWhenAction']['method_naming']['pass']);
+    $this->assertSame(['Contains "Assert" in the method name (reserved for @Then)'], $methods['assertWhenAction']['method_naming']['messages']);
+
+    $this->assertFalse($methods['pageIsReady']['step_wording']['pass']);
+    $this->assertSame(['Contains "should" in the step (reserved for @Then)'], $methods['pageIsReady']['step_wording']['messages']);
+
+    $this->assertFalse($methods['requestSucceeds']['step_wording']['pass']);
+    $this->assertSame(['Contains "should" in the step (reserved for @Then)'], $methods['requestSucceeds']['step_wording']['messages']);
+
+    $this->assertTrue(has_validation_errors($results));
+  }
+
+  /**
    * Test extract_info excludes classes without step definitions.
    */
   public function testExtractInfoNoStepAnnotations(): void {

--- a/tests/phpunit/src/DocsTest.php
+++ b/tests/phpunit/src/DocsTest.php
@@ -1113,6 +1113,101 @@ EOD,
       TRUE,
       [],
     ];
+    yield 'given with assert in method name' => [
+      [
+        'TestContext' => [
+          'name' => 'TestContext',
+          'methods' => [
+            [
+              'name' => 'assertSomething',
+              'steps' => ['@Given I do something'],
+              'description' => 'Desc',
+              'example' => 'Example',
+            ],
+          ],
+        ],
+      ],
+      'assertSomething',
+      'method_naming',
+      FALSE,
+      ['Contains "Assert" in the method name (reserved for @Then)'],
+    ];
+    yield 'when with assert in method name' => [
+      [
+        'TestContext' => [
+          'name' => 'TestContext',
+          'methods' => [
+            [
+              'name' => 'assertWhenSomething',
+              'steps' => ['@When I do something'],
+              'description' => 'Desc',
+              'example' => 'Example',
+            ],
+          ],
+        ],
+      ],
+      'assertWhenSomething',
+      'method_naming',
+      FALSE,
+      ['Contains "Assert" in the method name (reserved for @Then)'],
+    ];
+    yield 'given with mid-name Assert' => [
+      [
+        'TestContext' => [
+          'name' => 'TestContext',
+          'methods' => [
+            [
+              'name' => 'doSomethingAssertingThing',
+              'steps' => ['@Given I do something'],
+              'description' => 'Desc',
+              'example' => 'Example',
+            ],
+          ],
+        ],
+      ],
+      'doSomethingAssertingThing',
+      'method_naming',
+      FALSE,
+      ['Contains "Assert" in the method name (reserved for @Then)'],
+    ];
+    yield 'given with should in step' => [
+      [
+        'TestContext' => [
+          'name' => 'TestContext',
+          'methods' => [
+            [
+              'name' => 'iDoSomething',
+              'steps' => ['@Given I should not see the error'],
+              'description' => 'Desc',
+              'example' => 'Example',
+            ],
+          ],
+        ],
+      ],
+      'iDoSomething',
+      'step_wording',
+      FALSE,
+      ['Contains "should" in the step (reserved for @Then)'],
+    ];
+    yield 'when with should in step' => [
+      [
+        'TestContext' => [
+          'name' => 'TestContext',
+          'methods' => [
+            [
+              'name' => 'iDoSomething',
+              'steps' => ['@When I think something should happen'],
+              'description' => 'Desc',
+              'example' => 'Example',
+            ],
+          ],
+        ],
+      ],
+      'iDoSomething',
+      'step_wording',
+      FALSE,
+      ['Contains "should" in the step (reserved for @Then)'],
+    ];
   }
 
   #[DataProvider('dataProviderRegexToTurnip')]


### PR DESCRIPTION
## Summary

The `scripts/docs.php` validator enforced naming conventions for `@Then` step methods (must contain "Assert") but had no inverse checks: `@Given`/`@When` methods named `assert*` silently passed even though those steps perform actions, not assertions. This PR tightens the validator in both directions, renames every mislabelled method across `DrupalContext`, `DrushContext`, and `MessageContext`, re-annotates three negative-message steps from `@Given` to `@Then`, and adds tests and documentation to cover all changes.

## Changes

### Validator

- Added inverse check: `@Given`/`@When` method names must NOT contain "Assert" (reserved for `@Then`).
- Added inverse check: `@Given`/`@When` step text must NOT contain "should" (reserved for `@Then`).
- Updated the convention list at the top of `scripts/docs.php` to document both new rules.

### `DrupalContext`

- Renamed 11 `assert*` action methods to action-style names (e.g. `assertAuthenticatedByRole` → `iAmLoggedInAsUserWithRole`, `assertCron` → `iRunCron`, `assertCacheClear` → `clearCache`). Step text is unchanged.
- Fixed two misleading docblock descriptions on `iAmAnonymous` / `iAmNotLoggedIn` that said "Assert the user is..." when both methods simply log the user out.

### `DrushContext`

- Renamed `assertDrushCommand` → `iRunDrush`.
- Renamed `assertDrushCommandWithArgument` → `iRunDrushWithArguments`.

### `MessageContext`

- Re-annotated `assertNotErrorVisible`, `assertNotSuccessMessage`, and `assertNotWarningMessage` from `@Given` to `@Then` - those steps perform assertions and already say "should not see" in the step text.
- Renamed the three methods to match the existing `<noun>AssertIsVisible` pattern used by the positive-message counterparts: `errorMessageAssertIsNotVisible`, `successMessageAssertIsNotVisible`, `warningMessageAssertIsNotVisible`.
- Updated the three internal `assertNotXxx()` calls within `MessageContext` to use the new method names.

### Tests

- Added 5 inline `dataProvider` cases in `DocsTest::dataProviderValidate` covering both new inverse checks (`@Given`/`@When` with "Assert" in the method name, `@Given`/`@When` step text containing "should").
- Added `MisnamedAssertContext` PHP fixture (real `#[Given]`/`#[When]` attributes that violate the new rules).
- Added `testValidateInverseChecksThroughExtractInfo()` - a pipeline test that runs `extract_info` via PHP reflection on the fixture then feeds the result into `validate()`, confirming the validator catches the violations end-to-end.

### Documentation

- Regenerated `STEPS.md`: the three negative-message steps moved from the `@Given` section to `@Then`, and the two corrected docblocks updated their summaries.
- Added step re-classification entries and a full method-rename table to `MIGRATION.md`.
- Updated two inline comments in `tests/behat/features/d10.feature` and `tests/behat/features/i18n/es/d10.feature` that referenced the old `assertLoggedInByName` method name.

## Method renames

| Context | 5.x name | 6.0 name |
| --- | --- | --- |
| `DrupalContext` | `assertAuthenticatedByRole` | `iAmLoggedInAsUserWithRole` |
| `DrupalContext` | `assertAuthenticatedByRoleShort` | `iAmLoggedInAsRole` |
| `DrupalContext` | `assertAuthenticatedByRoleWithGivenFields` | `iAmLoggedInAsUserWithRoleAndFields` |
| `DrupalContext` | `assertLoggedInByName` | `iAmLoggedInAs` |
| `DrupalContext` | `assertLoggedInWithPermissions` | `iAmLoggedInAsUserWithPermissions` |
| `DrupalContext` | `assertClickInTableRow` | `iClickInTableRow` |
| `DrupalContext` | `assertPressInTableRow` | `iPressInTableRow` |
| `DrupalContext` | `assertCacheClear` | `clearCache` |
| `DrupalContext` | `assertCron` | `iRunCron` |
| `DrupalContext` | `assertViewingNode` | `iAmViewingNodeWithFields` |
| `DrupalContext` | `assertViewingNodeContent` | `iAmViewingNodeContentWithFields` |
| `DrushContext` | `assertDrushCommand` | `iRunDrush` |
| `DrushContext` | `assertDrushCommandWithArgument` | `iRunDrushWithArguments` |
| `MessageContext` | `assertNotErrorVisible` | `errorMessageAssertIsNotVisible` |
| `MessageContext` | `assertNotSuccessMessage` | `successMessageAssertIsNotVisible` |
| `MessageContext` | `assertNotWarningMessage` | `warningMessageAssertIsNotVisible` |

## Step re-classification

| 5.x keyword | 6.0 keyword | Step text |
| --- | --- | --- |
| `@Given` | `@Then` | `I should not see the error message( containing) :message` |
| `@Given` | `@Then` | `I should not see the success message( containing) :message` |
| `@Given` | `@Then` | `I should not see the warning message( containing) :message` |

## Before / After

Validator rule coverage before and after this PR.

```
Before
┌──────────────────────────────────────────────────────────────────┐
│                    Validator rule matrix                         │
├────────────────┬────────────────────────────────────────────────┤
│ Step keyword   │ Naming rule enforced                           │
├────────────────┼────────────────────────────────────────────────┤
│ @Then          │ method name MUST contain "Assert"              │
│ @Then          │ method name MUST NOT contain "Should"          │
│ @Then          │ step text MUST contain "should"                │
│ @Given / @When │ (no constraint on "Assert" in method name)     │
│ @Given / @When │ (no constraint on "should" in step text)       │
└────────────────┴────────────────────────────────────────────────┘

After
┌──────────────────────────────────────────────────────────────────┐
│                    Validator rule matrix                         │
├────────────────┬────────────────────────────────────────────────┤
│ Step keyword   │ Naming rule enforced                           │
├────────────────┼────────────────────────────────────────────────┤
│ @Then          │ method name MUST contain "Assert"              │
│ @Then          │ method name MUST NOT contain "Should"          │
│ @Then          │ step text MUST contain "should"                │
│ @Given / @When │ method name MUST NOT contain "Assert"  ← NEW  │
│ @Given / @When │ step text MUST NOT contain "should"    ← NEW  │
└────────────────┴────────────────────────────────────────────────┘

"Assert" is now bidirectional — required in @Then, forbidden in @Given/@When.
"should" is now bidirectional — required in @Then step text, forbidden in @Given/@When step text.
```

## Test results

- PHPUnit: 391/391 pass
- Behat (blackbox profile): 109/109 scenarios pass
- Behat (drupal profile): 160/160 scenarios pass
