### PR TITLE
[#479] Added verbose diagnostic output to AJAX timeout exception.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/Traits/AjaxTrait.php
+++ b/src/Drupal/DrupalExtension/Context/Traits/AjaxTrait.php
@@ -197,7 +197,7 @@ JS;
       $lines[] = '';
 
       if (isset($diagnostics['url']) && is_string($diagnostics['url'])) {
-        $lines[] = 'URL: ' . $diagnostics['url'];
+        $lines[] = 'URL: ' . self::redactUrl($diagnostics['url']);
       }
 
       $lines[] = 'jQuery active requests: ' . self::formatScalar($diagnostics['jquery_active'] ?? NULL);
@@ -213,9 +213,15 @@ JS;
 
         $parts = [];
         foreach (['selector', 'event', 'url', 'index'] as $field) {
-          if (isset($instance[$field])) {
-            $parts[] = sprintf("%s: '%s'", $field, $instance[$field]);
+          if (!isset($instance[$field])) {
+            continue;
           }
+
+          $value = (string) $instance[$field];
+          if ($field === 'url') {
+            $value = self::redactUrl($value);
+          }
+          $parts[] = sprintf("%s: '%s'", $field, $value);
         }
         $lines[] = '  - ' . (count($parts) > 0 ? implode(', ', $parts) : '(no details)');
       }
@@ -245,6 +251,18 @@ JS;
     }
 
     return (string) $value;
+  }
+
+  /**
+   * Strips query string and fragment from a URL.
+   *
+   * Diagnostic messages can land in CI logs and artifacts where they may be
+   * publicly accessible, so query strings (potentially containing CSRF
+   * tokens, signed-URL signatures, or session identifiers) and fragments
+   * are removed before the URL is rendered.
+   */
+  private static function redactUrl(string $url): string {
+    return preg_replace('/[?#].*$/', '', $url) ?? $url;
   }
 
 }

--- a/src/Drupal/DrupalExtension/Context/Traits/AjaxTrait.php
+++ b/src/Drupal/DrupalExtension/Context/Traits/AjaxTrait.php
@@ -6,6 +6,7 @@ namespace Drupal\DrupalExtension\Context\Traits;
 
 use Behat\Behat\Hook\Scope\AfterStepScope;
 use Behat\Behat\Hook\Scope\BeforeStepScope;
+use Behat\Behat\Hook\Scope\StepScope;
 use Behat\Hook\AfterStep;
 use Behat\Hook\BeforeStep;
 use Behat\Step\Given;
@@ -82,16 +83,12 @@ trait AjaxTrait {
       function isAjaxing(instance) {
         return instance && instance.ajaxing === true;
       }
-      var d7_not_ajaxing = true;
-      if (typeof Drupal !== 'undefined' && typeof Drupal.ajax !== 'undefined' && typeof Drupal.ajax.instances === 'undefined') {
-        for(var i in Drupal.ajax) { if (isAjaxing(Drupal.ajax[i])) { d7_not_ajaxing = false; } }
-      }
-      var d8_not_ajaxing = (typeof Drupal === 'undefined' || typeof Drupal.ajax === 'undefined' || typeof Drupal.ajax.instances === 'undefined' || !Drupal.ajax.instances.some(isAjaxing))
+      var drupal_not_ajaxing = (typeof Drupal === 'undefined' || typeof Drupal.ajax === 'undefined' || typeof Drupal.ajax.instances === 'undefined' || !Drupal.ajax.instances.some(isAjaxing));
       return (
         // Assert no AJAX request is running (via jQuery or Drupal) and no
         // animation is running.
         (typeof jQuery === 'undefined' || jQuery.hasOwnProperty('active') === false || (jQuery.active <= 0 && jQuery(':animated').length === 0)) &&
-        d7_not_ajaxing && d8_not_ajaxing
+        drupal_not_ajaxing
       );
     }());
 JS;
@@ -103,21 +100,151 @@ JS;
         throw new \RuntimeException('No AJAX timeout has been defined. Please verify that "Drupal\DrupalExtension" is configured in behat.yml.');
       }
 
-      if ($event) {
-        /** @var \Behat\Behat\Hook\Scope\BeforeStepScope $event */
-        $event_data = ' ' . json_encode([
-          'name' => $event->getName(),
-          'feature' => $event->getFeature()->getTitle(),
-          'step' => $event->getStep()->getText(),
-          'suite' => $event->getSuite()->getName(),
-        ]);
+      $diagnostics = $this->captureAjaxDiagnostics();
+      $event_data = $event instanceof StepScope ? [
+        'hook' => $event->getName(),
+        'feature' => $event->getFeature()->getTitle(),
+        'step' => $event->getStep()->getText(),
+        'suite' => $event->getSuite()->getName(),
+      ] : NULL;
+
+      throw new \RuntimeException(self::formatTimeoutMessage((int) $ajax_timeout, $diagnostics, $event_data));
+    }
+  }
+
+  /**
+   * Probes the browser for diagnostic state when an AJAX wait times out.
+   *
+   * Runs after 'wait()' has already returned false, so the cost of an extra
+   * round-trip only applies on the failure path. Returning NULL is fine - the
+   * caller falls back to the event-only message.
+   *
+   * @return array<string, mixed>|null
+   *   Decoded diagnostic data, or NULL if the driver cannot evaluate JS or
+   *   the probe returned malformed output.
+   */
+  protected function captureAjaxDiagnostics(): ?array {
+    $script = <<<JS_WRAP
+    (function() {
+      function collectInstances() {
+        var out = [];
+        if (typeof Drupal === 'undefined' || typeof Drupal.ajax === 'undefined' || typeof Drupal.ajax.instances === 'undefined') {
+          return out;
+        }
+        Drupal.ajax.instances.forEach(function(instance, idx) {
+          if (!instance || instance.ajaxing !== true) {
+            return;
+          }
+          var info = { index: idx };
+          if (instance.url) {
+            info.url = instance.url;
+          }
+          if (instance.element_settings) {
+            if (instance.element_settings.selector) {
+              info.selector = instance.element_settings.selector;
+            }
+            if (instance.element_settings.event) {
+              info.event = instance.element_settings.event;
+            }
+          }
+          out.push(info);
+        });
+        return out;
       }
-      else {
-        $event_data = '';
+      return JSON.stringify({
+        url: window.location.href,
+        jquery_active: (typeof jQuery !== 'undefined' && typeof jQuery.active !== 'undefined') ? jQuery.active : null,
+        jquery_animated: (typeof jQuery !== 'undefined') ? jQuery(':animated').length : null,
+        drupal_ajax_instances: collectInstances()
+      });
+    }())
+    JS_WRAP;
+
+    try {
+      $raw = $this->getSession()->evaluateScript($script);
+    }
+    catch (\Throwable) {
+      return NULL;
+    }
+
+    if (is_string($raw)) {
+      $decoded = json_decode($raw, TRUE);
+
+      return is_array($decoded) ? $decoded : NULL;
+    }
+
+    return is_array($raw) ? $raw : NULL;
+  }
+
+  /**
+   * Formats a verbose timeout exception message.
+   *
+   * Pure helper - no instance state - so the formatting can be unit tested
+   * with synthetic input rather than a live browser session.
+   *
+   * @param int $ajax_timeout
+   *   The configured timeout in seconds.
+   * @param array<string, mixed>|null $diagnostics
+   *   Browser state captured at time of failure, or NULL when unavailable.
+   * @param array<string, string>|null $event_data
+   *   Step scope data when called from a hook, otherwise NULL. Expected keys:
+   *   'hook', 'feature', 'step', 'suite'.
+   */
+  protected static function formatTimeoutMessage(int $ajax_timeout, ?array $diagnostics, ?array $event_data): string {
+    $lines = [sprintf('Unable to complete AJAX request after %d second(s).', $ajax_timeout)];
+
+    if ($diagnostics !== NULL) {
+      $lines[] = '';
+
+      if (isset($diagnostics['url']) && is_string($diagnostics['url'])) {
+        $lines[] = 'URL: ' . $diagnostics['url'];
       }
 
-      throw new \RuntimeException('Unable to complete AJAX request.' . $event_data);
+      $lines[] = 'jQuery active requests: ' . self::formatScalar($diagnostics['jquery_active'] ?? NULL);
+      $lines[] = 'jQuery animated elements: ' . self::formatScalar($diagnostics['jquery_animated'] ?? NULL);
+
+      $instances = is_array($diagnostics['drupal_ajax_instances'] ?? NULL) ? $diagnostics['drupal_ajax_instances'] : [];
+      $lines[] = sprintf('Drupal AJAX instances active: %d', count($instances));
+
+      foreach ($instances as $instance) {
+        if (!is_array($instance)) {
+          continue;
+        }
+
+        $parts = [];
+        foreach (['selector', 'event', 'url', 'index'] as $field) {
+          if (isset($instance[$field])) {
+            $parts[] = sprintf("%s: '%s'", $field, $instance[$field]);
+          }
+        }
+        $lines[] = '  - ' . (count($parts) > 0 ? implode(', ', $parts) : '(no details)');
+      }
     }
+
+    if ($event_data !== NULL) {
+      $lines[] = '';
+      $lines[] = 'Hook: ' . ($event_data['hook'] ?? '');
+      $lines[] = 'Feature: ' . ($event_data['feature'] ?? '');
+      $lines[] = 'Step: ' . ($event_data['step'] ?? '');
+      $lines[] = 'Suite: ' . ($event_data['suite'] ?? '');
+    }
+
+    return implode("\n", $lines);
+  }
+
+  /**
+   * Renders a scalar diagnostic value for the message, NULL = 'unavailable'.
+   */
+  private static function formatScalar(mixed $value): string {
+    if ($value === NULL) {
+      return 'unavailable';
+    }
+
+    if (is_bool($value)) {
+      return $value ? 'true' : 'false';
+    }
+
+    return (string) $value;
   }
 
 }

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -9,6 +9,7 @@
 
 declare(strict_types=1);
 
+use Behat\Behat\Context\Environment\InitializedContextEnvironment;
 use Behat\Step\When;
 use Behat\Step\Given;
 use Behat\Transformation\Transform;
@@ -25,6 +26,7 @@ use Drupal\Driver\Core\Field\AbstractHandler;
 use Drupal\Driver\DrupalDriver;
 use Drupal\Driver\Entity\EntityStub;
 use Drupal\Driver\Entity\EntityStubInterface;
+use Drupal\DrupalExtension\Context\MinkContext;
 use Drupal\DrupalExtension\Hook\Attribute\AfterNodeCreate;
 use Drupal\DrupalExtension\Hook\Attribute\AfterTermCreate;
 use Drupal\DrupalExtension\Hook\Attribute\AfterUserCreate;
@@ -51,6 +53,15 @@ class FeatureContext extends RawDrupalContext {
   protected string $previousUserName = '';
 
   /**
+   * Captured MinkContext used by 'testAjaxWaitTimesOutVerbose()'.
+   *
+   * 'iWaitForAjaxToFinish()' lives on MinkContext (via 'AjaxTrait'); this
+   * reference lets the verbose-timeout assertion call into it without
+   * duplicating the trait's wait/capture/format logic.
+   */
+  protected ?MinkContext $minkContextForAjaxTest = NULL;
+
+  /**
    * Stop Mink sessions before scenarios that will spawn sub-processes.
    *
    * When a @javascript scenario runs in the parent process, Mink keeps the
@@ -69,6 +80,58 @@ class FeatureContext extends RawDrupalContext {
     if ($has_trait_tag) {
       $this->getMink()->stopSessions();
     }
+  }
+
+  /**
+   * Captures the MinkContext from the suite environment per scenario.
+   */
+  #[BeforeScenario]
+  public function testCaptureMinkContextForAjaxTest(BeforeScenarioScope $scope): void {
+    $environment = $scope->getEnvironment();
+    if ($environment instanceof InitializedContextEnvironment && $environment->hasContextClass(MinkContext::class)) {
+      $this->minkContextForAjaxTest = $environment->getContext(MinkContext::class);
+    }
+  }
+
+  /**
+   * Asserts that 'iWaitForAjaxToFinish()' raises a verbose timeout exception.
+   *
+   * The companion fixture 'fixtures/blackbox/ajax_hang.html' pre-loads a
+   * permanently 'ajaxing' Drupal AJAX instance. This step delegates to the
+   * registered MinkContext so the wait/capture/format pipeline runs end-to-end
+   * against a real browser session, then asserts the resulting exception
+   * message contains the diagnostic substrings produced by 'AjaxTrait'.
+   */
+  #[Then('the AJAX wait should time out with verbose diagnostic info')]
+  public function testAjaxWaitTimesOutVerbose(): void {
+    if (!$this->minkContextForAjaxTest instanceof MinkContext) {
+      throw new \RuntimeException('MinkContext was not registered for the active scenario.');
+    }
+
+    try {
+      $this->minkContextForAjaxTest->iWaitForAjaxToFinish();
+    }
+    catch (\RuntimeException $e) {
+      $message = $e->getMessage();
+      $required = [
+        'Unable to complete AJAX request after',
+        'URL: http://blackbox/ajax_hang.html',
+        'Drupal AJAX instances active: 1',
+        "url: '/never-completes'",
+        "selector: '#fake-button'",
+        "event: 'click'",
+      ];
+
+      foreach ($required as $needle) {
+        if (!str_contains($message, $needle)) {
+          throw new \RuntimeException(sprintf("Expected exception message to contain '%s'.\nActual:\n%s", $needle, $message), $e->getCode(), $e);
+        }
+      }
+
+      return;
+    }
+
+    throw new \RuntimeException("Expected 'iWaitForAjaxToFinish()' to time out, but it succeeded.");
   }
 
   /**

--- a/tests/behat/features/ajax.feature
+++ b/tests/behat/features/ajax.feature
@@ -1,0 +1,18 @@
+Feature: AJAX wait diagnostics
+
+  When 'iWaitForAjaxToFinish()' fails to clear the wait condition before the
+  configured 'ajax_timeout', the resulting RuntimeException must include
+  diagnostic state captured from the live browser - the page URL, jQuery
+  counters, and a list of active 'Drupal.ajax.instances' - so failures in
+  CI logs are actionable. The fixture in 'fixtures/blackbox/ajax_hang.html'
+  pre-loads a permanently 'ajaxing' Drupal AJAX instance, guaranteeing the
+  timeout fires.
+
+  This scenario runs the wait directly against a real browser session
+  rather than via the BehatCli subprocess pattern, because @javascript
+  inside a sub-process is a known-hanging combination.
+
+  @test-blackbox @javascript
+  Scenario: Wait for AJAX times out with verbose diagnostic output
+    Given I visit "/ajax_hang.html"
+    Then the AJAX wait should time out with verbose diagnostic info

--- a/tests/behat/fixtures/blackbox/ajax_hang.html
+++ b/tests/behat/fixtures/blackbox/ajax_hang.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>AJAX hang fixture</title>
+  </head>
+  <body>
+    <h1>AJAX hang fixture</h1>
+    <p>
+      Simulates a permanently active Drupal AJAX instance so that
+      'iWaitForAjaxToFinish()' always times out, exercising the verbose
+      diagnostic path of the timeout exception.
+    </p>
+    <script>
+      window.Drupal = window.Drupal || {};
+      window.Drupal.ajax = window.Drupal.ajax || {};
+      window.Drupal.ajax.instances = [{
+        ajaxing: true,
+        url: '/never-completes',
+        element_settings: {
+          selector: '#fake-button',
+          event: 'click'
+        }
+      }];
+    </script>
+  </body>
+</html>

--- a/tests/phpunit/src/Context/Traits/AjaxTraitTest.php
+++ b/tests/phpunit/src/Context/Traits/AjaxTraitTest.php
@@ -203,6 +203,37 @@ class AjaxTraitTest extends TestCase {
       NULL,
       "Unable to complete AJAX request after 5 second(s).\n\nURL: http://example.com/\njQuery active requests: 0\njQuery animated elements: 0\nDrupal AJAX instances active: 0",
     ];
+
+    yield 'page URL with query string and fragment is redacted' => [
+      5,
+      [
+        'url' => 'http://example.com/login?token=abc123&destination=/admin#section',
+        'jquery_active' => 0,
+        'jquery_animated' => 0,
+        'drupal_ajax_instances' => [],
+      ],
+      NULL,
+      "Unable to complete AJAX request after 5 second(s).\n\nURL: http://example.com/login\njQuery active requests: 0\njQuery animated elements: 0\nDrupal AJAX instances active: 0",
+    ];
+
+    yield 'instance URL with query string is redacted, other fields untouched' => [
+      5,
+      [
+        'url' => 'http://example.com/',
+        'jquery_active' => 0,
+        'jquery_animated' => 0,
+        'drupal_ajax_instances' => [
+          [
+            'index' => 0,
+            'selector' => '#edit-submit?keep-this',
+            'event' => 'mousedown',
+            'url' => '/system/ajax?token=abc&form_id=user_login',
+          ],
+        ],
+      ],
+      NULL,
+      "Unable to complete AJAX request after 5 second(s).\n\nURL: http://example.com/\njQuery active requests: 0\njQuery animated elements: 0\nDrupal AJAX instances active: 1\n  - selector: '#edit-submit?keep-this', event: 'mousedown', url: '/system/ajax', index: '0'",
+    ];
   }
 
 }

--- a/tests/phpunit/src/Context/Traits/AjaxTraitTest.php
+++ b/tests/phpunit/src/Context/Traits/AjaxTraitTest.php
@@ -1,0 +1,245 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Tests;
+
+use Behat\Mink\Session;
+use Drupal\DrupalExtension\Context\Traits\AjaxTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the verbose timeout-message formatter on AjaxTrait.
+ *
+ * The instance methods of the trait drive a live Mink session, but the
+ * 'formatTimeoutMessage()' helper is a pure function and is the bit users
+ * read when an AJAX wait fails. It is exercised here through a test consumer
+ * so that the message format is locked down without needing a real browser.
+ */
+#[CoversClass(AjaxTrait::class)]
+class AjaxTraitTest extends TestCase {
+
+  /**
+   * Asserts the rendered exception message for a given input shape.
+   *
+   * @param int $timeout
+   *   The configured AJAX timeout in seconds.
+   * @param array<string, mixed>|null $diagnostics
+   *   The diagnostic payload, or NULL when the browser probe was skipped.
+   * @param array<string, string>|null $event_data
+   *   The Behat scope payload, or NULL when called outside a hook.
+   * @param string $expected
+   *   The expected verbatim message.
+   */
+  #[DataProvider('dataProviderFormatTimeoutMessage')]
+  public function testFormatTimeoutMessage(int $timeout, ?array $diagnostics, ?array $event_data, string $expected): void {
+    $actual = TestableAjaxConsumer::callFormatTimeoutMessage($timeout, $diagnostics, $event_data);
+    $this->assertSame($expected, $actual);
+  }
+
+  /**
+   * Provides data for testFormatTimeoutMessage().
+   *
+   * @return \Iterator<string, array{int, array<string, mixed>|null, array<string, string>|null, string}>
+   *   Test cases keyed by description.
+   */
+  public static function dataProviderFormatTimeoutMessage(): \Iterator {
+    yield 'timeout only, no diagnostics, no event' => [
+      5,
+      NULL,
+      NULL,
+      'Unable to complete AJAX request after 5 second(s).',
+    ];
+
+    yield 'timeout plus event only - simulates pre-#479 behaviour' => [
+      10,
+      NULL,
+      [
+        'hook' => 'step.before',
+        'feature' => 'My Feature',
+        'step' => 'I click the button',
+        'suite' => 'default',
+      ],
+      "Unable to complete AJAX request after 10 second(s).\n\nHook: step.before\nFeature: My Feature\nStep: I click the button\nSuite: default",
+    ];
+
+    yield 'timeout plus full diagnostics with one Drupal AJAX instance' => [
+      5,
+      [
+        'url' => 'http://example.com/node/add',
+        'jquery_active' => 2,
+        'jquery_animated' => 0,
+        'drupal_ajax_instances' => [
+          [
+            'index' => 0,
+            'selector' => '#edit-submit',
+            'event' => 'mousedown',
+            'url' => '/system/ajax',
+          ],
+        ],
+      ],
+      NULL,
+      "Unable to complete AJAX request after 5 second(s).\n\nURL: http://example.com/node/add\njQuery active requests: 2\njQuery animated elements: 0\nDrupal AJAX instances active: 1\n  - selector: '#edit-submit', event: 'mousedown', url: '/system/ajax', index: '0'",
+    ];
+
+    yield 'diagnostics plus event combined into one message' => [
+      5,
+      [
+        'url' => 'http://example.com/node/add',
+        'jquery_active' => 1,
+        'jquery_animated' => 0,
+        'drupal_ajax_instances' => [],
+      ],
+      [
+        'hook' => 'step.after',
+        'feature' => 'Conference',
+        'step' => 'I press "Save"',
+        'suite' => 'default',
+      ],
+      "Unable to complete AJAX request after 5 second(s).\n\nURL: http://example.com/node/add\njQuery active requests: 1\njQuery animated elements: 0\nDrupal AJAX instances active: 0\n\nHook: step.after\nFeature: Conference\nStep: I press \"Save\"\nSuite: default",
+    ];
+
+    yield 'jquery_active 0 renders as 0, not unavailable' => [
+      5,
+      [
+        'url' => 'http://example.com/',
+        'jquery_active' => 0,
+        'jquery_animated' => 0,
+        'drupal_ajax_instances' => [],
+      ],
+      NULL,
+      "Unable to complete AJAX request after 5 second(s).\n\nURL: http://example.com/\njQuery active requests: 0\njQuery animated elements: 0\nDrupal AJAX instances active: 0",
+    ];
+
+    yield 'jQuery undefined renders the scalars as unavailable' => [
+      5,
+      [
+        'url' => 'http://example.com/',
+        'jquery_active' => NULL,
+        'jquery_animated' => NULL,
+        'drupal_ajax_instances' => [],
+      ],
+      NULL,
+      "Unable to complete AJAX request after 5 second(s).\n\nURL: http://example.com/\njQuery active requests: unavailable\njQuery animated elements: unavailable\nDrupal AJAX instances active: 0",
+    ];
+
+    yield 'multiple Drupal AJAX instances each get their own bullet' => [
+      5,
+      [
+        'url' => 'http://example.com/',
+        'jquery_active' => 0,
+        'jquery_animated' => 0,
+        'drupal_ajax_instances' => [
+          ['index' => 0, 'selector' => '#a', 'event' => 'click', 'url' => '/a'],
+          ['index' => 1, 'selector' => '#b', 'event' => 'change', 'url' => '/b'],
+        ],
+      ],
+      NULL,
+      "Unable to complete AJAX request after 5 second(s).\n\nURL: http://example.com/\njQuery active requests: 0\njQuery animated elements: 0\nDrupal AJAX instances active: 2\n  - selector: '#a', event: 'click', url: '/a', index: '0'\n  - selector: '#b', event: 'change', url: '/b', index: '1'",
+    ];
+
+    yield 'instance with no recognised fields falls back to no details' => [
+      5,
+      [
+        'url' => 'http://example.com/',
+        'jquery_active' => 0,
+        'jquery_animated' => 0,
+        'drupal_ajax_instances' => [
+          ['something_else' => 'ignored'],
+        ],
+      ],
+      NULL,
+      "Unable to complete AJAX request after 5 second(s).\n\nURL: http://example.com/\njQuery active requests: 0\njQuery animated elements: 0\nDrupal AJAX instances active: 1\n  - (no details)",
+    ];
+
+    yield 'malformed instance entry is skipped without crashing' => [
+      5,
+      [
+        'url' => 'http://example.com/',
+        'jquery_active' => 0,
+        'jquery_animated' => 0,
+        'drupal_ajax_instances' => [
+          'not-an-array',
+          ['selector' => '#valid'],
+        ],
+      ],
+      NULL,
+      "Unable to complete AJAX request after 5 second(s).\n\nURL: http://example.com/\njQuery active requests: 0\njQuery animated elements: 0\nDrupal AJAX instances active: 2\n  - selector: '#valid'",
+    ];
+
+    yield 'missing url key omits the URL line entirely' => [
+      5,
+      [
+        'jquery_active' => 0,
+        'jquery_animated' => 0,
+        'drupal_ajax_instances' => [],
+      ],
+      NULL,
+      "Unable to complete AJAX request after 5 second(s).\n\njQuery active requests: 0\njQuery animated elements: 0\nDrupal AJAX instances active: 0",
+    ];
+
+    yield 'non-string url is skipped, scalars still rendered' => [
+      5,
+      [
+        'url' => ['not', 'a', 'string'],
+        'jquery_active' => 0,
+        'jquery_animated' => 0,
+        'drupal_ajax_instances' => [],
+      ],
+      NULL,
+      "Unable to complete AJAX request after 5 second(s).\n\njQuery active requests: 0\njQuery animated elements: 0\nDrupal AJAX instances active: 0",
+    ];
+
+    yield 'non-array drupal_ajax_instances is treated as empty' => [
+      5,
+      [
+        'url' => 'http://example.com/',
+        'jquery_active' => 0,
+        'jquery_animated' => 0,
+        'drupal_ajax_instances' => 'not-an-array',
+      ],
+      NULL,
+      "Unable to complete AJAX request after 5 second(s).\n\nURL: http://example.com/\njQuery active requests: 0\njQuery animated elements: 0\nDrupal AJAX instances active: 0",
+    ];
+  }
+
+}
+
+/**
+ * Test consumer that exposes the trait's protected static formatter.
+ *
+ * Mirrors the 'TestableDeprecationConsumer' pattern from
+ * 'DeprecationTraitTest' so the public API of the trait is not changed.
+ * The 'getSession()' stub keeps PHPStan satisfied - the consumer class
+ * is only ever used to call the static formatter, never the instance
+ * methods that need a real Mink session.
+ */
+// phpcs:ignore Drupal.Classes.ClassFileName.NoMatch
+class TestableAjaxConsumer {
+
+  use AjaxTrait;
+
+  /**
+   * Public bridge to the protected static formatter.
+   *
+   * @param int $timeout
+   *   The configured AJAX timeout in seconds.
+   * @param array<string, mixed>|null $diagnostics
+   *   The diagnostic payload, or NULL when the browser probe was skipped.
+   * @param array<string, string>|null $event_data
+   *   The Behat scope payload, or NULL when called outside a hook.
+   */
+  public static function callFormatTimeoutMessage(int $timeout, ?array $diagnostics, ?array $event_data): string {
+    return self::formatTimeoutMessage($timeout, $diagnostics, $event_data);
+  }
+
+  /**
+   * Stub keeping PHPStan happy - the formatter never calls this.
+   */
+  protected function getSession(): Session {
+    throw new \LogicException('TestableAjaxConsumer::getSession() should not be called - this fixture is for static formatter tests only.');
+  }
+
+}


### PR DESCRIPTION
Closes #479

## Summary

`iWaitForAjaxToFinish()` used to throw a single-line exception when AJAX timed out - just the word "Unable to complete AJAX request." optionally followed by a JSON blob of Behat step metadata. That gave no clue about *why* the browser was still busy. This PR captures live browser state (current URL, `jQuery.active` count, animated-element count, and each active `Drupal.ajax.instances` entry with its selector, event, and URL) at the moment of timeout and includes it in a structured, human-readable multi-line message. A try/catch guards the extra JS evaluation so the step still fails cleanly when the driver is unavailable or the browser has died.

The Drupal 7 code path (the `for...in Drupal.ajax` branch) has been removed from both the existing wait condition and the new diagnostic capture - the project requires Drupal 8+ only.

## Changes

**`src/Drupal/DrupalExtension/Context/Traits/AjaxTrait.php`**
- Removed dead Drupal 7 `for...in Drupal.ajax` loop from the wait-condition JS.
- Added `captureAjaxDiagnostics()` - runs a second JS snippet on the failure path to collect URL, `jQuery.active`, animated-element count, and active `Drupal.ajax.instances` entries. Returns `NULL` if the driver throws or returns malformed output.
- Added `formatTimeoutMessage()` - a pure static helper that assembles the multi-line exception message from the timeout value, diagnostics array, and optional step-scope data. Pure so it can be unit tested without a real browser.
- Added `formatScalar()` - renders a diagnostic scalar value, mapping `NULL` to `'unavailable'`.
- The existing step-scope data (`name`, `feature`, `step`, `suite`) is preserved but renamed/restructured into the new message format under a `Hook:` heading.

**`tests/phpunit/src/Context/Traits/AjaxTraitTest.php`** (new)
- 12 data-provider test cases for `formatTimeoutMessage()` via a `TestableAjaxConsumer` shim (same pattern as `DeprecationTraitTest`).
- Cases cover: timeout-only, event-only, full diagnostics with one instance, diagnostics + event combined, `jquery_active` 0 vs `NULL`, multiple instances, instance with no known fields, malformed instance entry, missing URL key, non-string URL, non-array `drupal_ajax_instances`.

## Before / After

```
BEFORE (single line, no browser context):
+-----------------------------------------------------------------+
| RuntimeException:                                               |
| Unable to complete AJAX request. {"name":"step.before",        |
| "feature":"My Feature","step":"I click button","suite":"dflt"} |
+-----------------------------------------------------------------+

AFTER (multi-line, full browser context):
+-----------------------------------------------------------------+
| RuntimeException:                                               |
| Unable to complete AJAX request after 5 second(s).             |
|                                                                 |
| URL: http://example.com/node/add                               |
| jQuery active requests: 2                                       |
| jQuery animated elements: 0                                     |
| Drupal AJAX instances active: 1                                 |
|   - selector: '#edit-submit', event: 'mousedown',              |
|     url: '/system/ajax', index: '0'                            |
|                                                                 |
| Hook: step.before                                               |
| Feature: My Feature                                             |
| Step: I click button                                            |
| Suite: default                                                  |
+-----------------------------------------------------------------+
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced AJAX timeout error messages with comprehensive diagnostic information including current URL, jQuery request counts, and active operations, enabling faster troubleshooting of timeout issues.

* **Tests**
  * Added comprehensive test coverage for AJAX timeout message formatting, validating correct behavior across diverse scenarios including edge cases with missing or malformed diagnostic data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->