### PR TITLE
[#730] Migrated local stack to Pygmy and Lagoon images.

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -18,21 +18,18 @@ commands:
       ahoy composer require --no-interaction --dev --no-update drupal/core:^${DRUPAL_VERSION:-11} drupal/core-composer-scaffold:^${DRUPAL_VERSION:-11}
       if [ "${DRUPAL_VERSION:-11}" != "11" ]; then ahoy composer remove --no-interaction --dev --no-update phpunit/phpunit; fi
       ahoy composer install
-      ahoy cli cp -r tests/behat/fixtures/drupal/modules/behat_test build/web/modules
-      ahoy cli cp -r tests/behat/fixtures/drupal/drush build/drush
 
   info:
     usage: Print information about this project.
     cmd: |
       echo "  Drupal version           : " ${DRUPAL_VERSION:-11}
       echo "  PHP version              : " ${PHP_VERSION:-8.3}
-      echo "  Site local URL           : " http://localhost:${DRUPAL_HOST_PORT:-8888}
-      echo "  Blackbox local URL       : " http://localhost:${BLACKBOX_HOST_PORT:-8889}
+      echo "  Site local URL           : " ${LOCALDEV_URL:-http://drupalextension.docker.amazee.io}
       echo "  Path to project          : " /app
       echo "  Path to web root         : " /app/build/web
-      echo "  DB port on host          : " $(docker compose port database 3306 2>/dev/null | cut -d : -f 2)
+      echo "  DB port on host          : " $(docker compose port mariadb 3306 2>/dev/null | cut -d : -f 2)
       echo "  Selenium VNC URL on host :  http://localhost:$(docker compose port chrome 7900 2>/dev/null | cut -d : -f 2)/?autoconnect=1&password=secret"
-      echo "  Xdebug                   : " $(docker compose exec -T php php -v 2>/dev/null | grep -q Xdebug && echo "enabled (disable with ahoy up)" || echo "disabled (enable with ahoy debug)")
+      echo "  Xdebug                   : " $(ahoy cli php -v 2>/dev/null | grep -q Xdebug && echo "enabled (disable with 'ahoy up')" || echo "disabled (enable with 'ahoy debug')")
       if [ -n "$1" ]; then
         echo "  One-time login           : " $(ahoy login -- --no-browser)
       fi
@@ -41,7 +38,7 @@ commands:
     usage: Open DB in Sequel Ace.
     cmd: |
       uname -a | grep -i -q darwin && mdfind -name 'Sequel Ace'|grep -q "Ace" && \
-      HOST_DB_PORT="$(docker compose port database 3306 2>/dev/null | cut -d : -f 2)" && \
+      HOST_DB_PORT="$(docker compose port mariadb 3306 2>/dev/null | cut -d : -f 2)" && \
       open "mysql://drupal:drupal@127.0.0.1:${HOST_DB_PORT}/drupal" -a "Sequel Ace" \
       || echo "Not a supported OS or Sequel Ace is not installed."
 
@@ -75,23 +72,23 @@ commands:
 
   pull:
     usage: Pull latest docker images.
-    cmd: if [ ! -z "$(docker image ls -q)" ]; then docker image ls --format \"{{.Repository}}:{{.Tag}}\" | grep wodby/ | grep -v none | xargs -n1 docker pull | cat; fi
+    cmd: if [ ! -z "$(docker image ls -q)" ]; then docker image ls --format \"{{.Repository}}:{{.Tag}}\" | grep uselagoon/ | grep -v none | xargs -n1 docker pull | cat; fi
 
   cli:
-    usage: Start a shell inside PHP container or run a command.
-    cmd: if \[ "${#}" -ne 0 \]; then docker compose exec -e BEHAT_CLI_DEBUG=${BEHAT_CLI_DEBUG:-0} php bash -c "$*"; else docker compose exec php bash; fi
+    usage: Start a shell inside CLI container or run a command.
+    cmd: if \[ "${#}" -ne 0 \]; then docker compose exec -e BEHAT_CLI_DEBUG=${BEHAT_CLI_DEBUG:-0} -T cli bash -c "$*"; else docker compose exec cli bash; fi
 
   composer:
-    usage: Run Composer commands in the PHP service container.
-    cmd: docker compose exec -T php composer "$@"
+    usage: Run Composer commands in the CLI container.
+    cmd: docker compose exec -T cli composer "$@"
 
   drush:
-    usage: Run Drush commands in the PHP service container.
-    cmd: ahoy cli "./vendor/bin/drush --root=build/web $*"
+    usage: Run Drush commands in the CLI container.
+    cmd: docker compose exec -T cli /app/vendor/bin/drush --root=/app/build/web --uri=${LOCALDEV_URL:-http://drupalextension.docker.amazee.io} "$@"
 
   debug:
     usage: Enable PHP Xdebug.
-    cmd: PHP_EXTENSIONS_DISABLE=xhprof,spx PHP_XDEBUG_MODE=debug docker compose up -d --force-recreate php && ahoy cli php -v | grep -q Xdebug && echo "Enabled debug configuration. Use 'ahoy up -- --force-recreate' to disable."
+    cmd: ahoy cli php -v | grep -q Xdebug || XDEBUG_ENABLE=true docker compose up -d --force-recreate cli php && ahoy cli php -v | grep -q Xdebug && echo "Enabled debug configuration. Use 'ahoy up -- --force-recreate' to disable."
 
   # ----------------------------------------------------------------------------
   # Application commands.
@@ -99,15 +96,11 @@ commands:
 
   login:
     usage: Login to a website.
-    cmd: ahoy drush --uri="http://localhost:${DRUPAL_HOST_PORT:-8888}" uli "$@"
+    cmd: ahoy drush uli "$@"
 
   provision:
     usage: Provision a fixture test site.
-    cmd: |
-      ahoy drush sql-drop --yes 2>/dev/null || true
-      ahoy drush --yes site-install --db-url=mysql://drupal:drupal@database/drupal --debug
-      ahoy drush --yes en behat_test
-      ahoy drush --yes deploy:hook
+    cmd: ahoy cli ./scripts/provision.sh
 
   clean:
     usage: Remove containers and all build files.

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -197,10 +197,6 @@ commands:
     usage: Run Drupal API Behat tests.
     cmd: ahoy cli "vendor/bin/behat --profile=drupal --strict --no-coverage $@"
 
-  test-bdd-drupal-https:
-    usage: Run HTTPS Behat tests.
-    cmd: ahoy cli "vendor/bin/behat --profile=drupal_https --strict --no-coverage $@"
-
   test-coverage:
     usage: Run all tests with coverage and merge reports.
     cmd: |

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -28,8 +28,8 @@ commands:
       echo "  PHP version              : " ${PHP_VERSION:-8.3}
       echo "  Site local URL           : " http://localhost:${DRUPAL_HOST_PORT:-8888}
       echo "  Blackbox local URL       : " http://localhost:${BLACKBOX_HOST_PORT:-8889}
-      echo "  Path to project          : " /var/www/html
-      echo "  Path to web root         : " /var/www/html/build/web
+      echo "  Path to project          : " /app
+      echo "  Path to web root         : " /app/build/web
       echo "  DB port on host          : " $(docker compose port database 3306 2>/dev/null | cut -d : -f 2)
       echo "  Selenium VNC URL on host :  http://localhost:$(docker compose port chrome 7900 2>/dev/null | cut -d : -f 2)/?autoconnect=1&password=secret"
       echo "  Xdebug                   : " $(docker compose exec -T php php -v 2>/dev/null | grep -q Xdebug && echo "enabled (disable with ahoy up)" || echo "disabled (enable with ahoy debug)")
@@ -217,10 +217,10 @@ commands:
       ahoy cli "php -d pcov.enabled=1 -d pcov.directory=. vendor/bin/phpunit -c phpunit.xml"
 
       ahoy title "Running Behat with coverage: blackbox"
-      ahoy cli "php -d pcov.enabled=1 -d pcov.directory=/var/www/html/src vendor/bin/behat --strict --allow-no-tests"
+      ahoy cli "php -d pcov.enabled=1 -d pcov.directory=/app/src vendor/bin/behat --strict --allow-no-tests"
 
       ahoy title "Running Behat with coverage: drupal"
-      ahoy cli "php -d pcov.enabled=1 -d pcov.directory=/var/www/html/src vendor/bin/behat --profile=drupal --strict --allow-no-tests"
+      ahoy cli "php -d pcov.enabled=1 -d pcov.directory=/app/src vendor/bin/behat --profile=drupal --strict --allow-no-tests"
 
       ahoy cli "php scripts/merge-coverage.php"
 
@@ -243,10 +243,10 @@ commands:
       STRICT=""; if [ -z "$1" ]; then STRICT="--strict"; fi
 
       ahoy title "Running Behat with coverage: blackbox"
-      ahoy cli "php -d pcov.enabled=1 -d pcov.directory=/var/www/html/src vendor/bin/behat $STRICT --allow-no-tests $@"
+      ahoy cli "php -d pcov.enabled=1 -d pcov.directory=/app/src vendor/bin/behat $STRICT --allow-no-tests $@"
 
       ahoy title "Running Behat with coverage: drupal"
-      ahoy cli "php -d pcov.enabled=1 -d pcov.directory=/var/www/html/src vendor/bin/behat --profile=drupal $STRICT --allow-no-tests $@"
+      ahoy cli "php -d pcov.enabled=1 -d pcov.directory=/app/src vendor/bin/behat --profile=drupal $STRICT --allow-no-tests $@"
 
       ahoy cli "php scripts/merge-coverage.php"
 

--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -24,7 +24,7 @@ commands:
     cmd: |
       echo "  Drupal version           : " ${DRUPAL_VERSION:-11}
       echo "  PHP version              : " ${PHP_VERSION:-8.3}
-      echo "  Site local URL           : " ${LOCALDEV_URL:-http://drupalextension.docker.amazee.io}
+      echo "  Site local URL           : " ${LOCALDEV_URL:-http://${COMPOSE_PROJECT_NAME:-$(basename "$PWD")}.docker.amazee.io}
       echo "  Path to project          : " /app
       echo "  Path to web root         : " /app/build/web
       echo "  DB port on host          : " $(docker compose port mariadb 3306 2>/dev/null | cut -d : -f 2)
@@ -84,7 +84,7 @@ commands:
 
   drush:
     usage: Run Drush commands in the CLI container.
-    cmd: docker compose exec -T cli /app/vendor/bin/drush --root=/app/build/web --uri=${LOCALDEV_URL:-http://drupalextension.docker.amazee.io} "$@"
+    cmd: docker compose exec -T cli /app/vendor/bin/drush --root=/app/build/web --uri=${LOCALDEV_URL:-http://${COMPOSE_PROJECT_NAME:-$(basename "$PWD")}.docker.amazee.io} "$@"
 
   debug:
     usage: Enable PHP Xdebug.

--- a/.docker/cli.dockerfile
+++ b/.docker/cli.dockerfile
@@ -1,0 +1,7 @@
+# hadolint global ignore=DL3018
+ARG PHP_VERSION=8.3
+FROM uselagoon/php-${PHP_VERSION}-cli-drupal:26.2.0
+
+RUN apk add --no-cache $PHPIZE_DEPS \
+    && pecl install pcov \
+    && docker-php-ext-enable pcov

--- a/.docker/cli.dockerfile
+++ b/.docker/cli.dockerfile
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3018
 ARG PHP_VERSION=8.3
-FROM uselagoon/php-${PHP_VERSION}-cli-drupal:26.2.0
+FROM uselagoon/php-${PHP_VERSION}-cli-drupal:latest
 
 RUN apk add --no-cache $PHPIZE_DEPS \
     && pecl install pcov \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Load docs validation logs
         if: github.event_name == 'pull_request' && !cancelled()
         run: |
+          mkdir -p .logs/docs
           docker compose cp cli:/app/.logs/docs/. .logs/docs/
           { echo "DOCS_SUMMARY<<EOF"; cat .logs/docs/validation-summary.txt; echo "EOF"; } >> "$GITHUB_ENV"
           { echo "DOCS_DETAILS<<EOF"; cat .logs/docs/validation-details.txt; echo "EOF"; } >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,41 +21,55 @@ jobs:
     env:
       PHP_VERSION: '8.4'
       DRUPAL_VERSION: '11'
-      DOCKER_USER_ID: '1001'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Start Docker containers
-        run: docker compose up -d
+      - name: Cache Composer downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-
 
-      - name: Configure git safe directory
-        run: docker compose exec -T php git config --global --add safe.directory /app
+      - name: Process the codebase to run in CI
+        run: |
+          sed -i -e "/###/d" docker-compose.yml
+          sed -i -e "s/##//" docker-compose.yml
+
+      - name: Build stack
+        run: |
+          docker compose up -d --build
+          docker cp -L . "$(docker compose ps -q cli)":/app/
 
       - name: Install Composer dependencies
-        run: docker compose exec -T php composer install
+        run: |
+          docker compose exec -T cli bash -c "
+            if [ -n \"${GITHUB_TOKEN:-}\" ]; then export COMPOSER_AUTH='{\"github-oauth\": {\"github.com\": \"${GITHUB_TOKEN-}\"}}'; fi && \
+            COMPOSER_MEMORY_LIMIT=-1 composer --ansi install --prefer-dist"
 
       - name: Validate composer.json
-        run: docker compose exec -T php composer validate --no-interaction
+        run: docker compose exec -T cli composer validate --no-interaction
 
       - name: Check composer.json is normalized
-        run: docker compose exec -T php composer normalize --dry-run
+        run: docker compose exec -T cli composer normalize --dry-run
 
       - name: Run linting
         run: |
-          docker compose exec -T php vendor/bin/parallel-lint src scripts tests
-          docker compose exec -T php vendor/bin/phpcs
-          docker compose exec -T php vendor/bin/phpstan
-          docker compose exec -T php vendor/bin/rector process --dry-run
-          docker compose exec -T php vendor/bin/gherkinlint lint tests/behat/features
+          docker compose exec -T cli vendor/bin/parallel-lint src scripts tests
+          docker compose exec -T cli vendor/bin/phpcs
+          docker compose exec -T cli vendor/bin/phpstan
+          docker compose exec -T cli vendor/bin/rector process --dry-run
+          docker compose exec -T cli vendor/bin/gherkinlint lint tests/behat/features
 
       - name: Lint documentation
-        run: docker compose exec -T php php scripts/docs.php --fail-on-change --log-dir=.logs/docs
+        run: docker compose exec -T cli php scripts/docs.php --fail-on-change --log-dir=.logs/docs
 
       - name: Load docs validation logs
         if: github.event_name == 'pull_request' && !cancelled()
         run: |
+          docker compose cp cli:/app/.logs/docs/. .logs/docs/
           { echo "DOCS_SUMMARY<<EOF"; cat .logs/docs/validation-summary.txt; echo "EOF"; } >> "$GITHUB_ENV"
           { echo "DOCS_DETAILS<<EOF"; cat .logs/docs/validation-details.txt; echo "EOF"; } >> "$GITHUB_ENV"
 
@@ -123,67 +137,73 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php_version }}
       DRUPAL_VERSION: ${{ matrix.drupal_version }}
-      DOCKER_USER_ID: '1001'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Start Docker containers
-        run: docker compose up -d
+      - name: Cache Composer downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-
 
-      - name: Configure git safe directory
-        run: docker compose exec -T php git config --global --add safe.directory /app
+      - name: Process the codebase to run in CI
+        run: |
+          sed -i -e "/###/d" docker-compose.yml
+          sed -i -e "s/##//" docker-compose.yml
+
+      - name: Build stack
+        run: |
+          docker compose up -d --build
+          docker cp -L . "$(docker compose ps -q cli)":/app/
 
       - name: Add Drupal core dependency
-        run: docker compose exec -u ${DOCKER_USER_ID} -T php composer require --no-interaction --dev --no-update drupal/core:^${DRUPAL_VERSION} drupal/core-composer-scaffold:^${DRUPAL_VERSION}
+        run: docker compose exec -T cli composer require --no-interaction --dev --no-update drupal/core:^${DRUPAL_VERSION} drupal/core-composer-scaffold:^${DRUPAL_VERSION}
 
       - name: Remove PHPUnit 11 for Drupal 10
         if: ${{ !matrix.coverage }}
-        run: docker compose exec -u ${DOCKER_USER_ID} -T php composer remove --no-interaction --dev --no-update phpunit/phpunit
+        run: docker compose exec -T cli composer remove --no-interaction --dev --no-update phpunit/phpunit
 
       - name: Install Composer dependencies
         run: |
           if [[ "${{ matrix.deps }}" == "lowest" ]]; then
-            docker compose exec -T php composer update --prefer-lowest --prefer-stable
+            docker compose exec -T cli composer update --prefer-lowest --prefer-stable
           else
-            docker compose exec -T php composer install
+            docker compose exec -T cli composer install
           fi
 
-      - name: Copy Drush configuration
-        run: docker compose exec -T php cp -r tests/behat/fixtures/drupal/drush build/drush
+      - name: Provision Drupal site
+        run: docker compose exec -T cli bash scripts/provision.sh
 
       - name: Run PHPUnit tests
         if: ${{ matrix.coverage }}
-        run: docker compose exec -T php php -d pcov.enabled=1 -d pcov.directory=. vendor/bin/phpunit -c phpunit.xml
-
-      - name: Provision Drupal site
-        run: docker compose exec -T php ./vendor/bin/drush --yes --root=build/web site-install --db-url=mysql://drupal:drupal@database/drupal --debug
-
-      - name: Copy test fixtures
-        run: docker compose exec -T php cp -r tests/behat/fixtures/drupal/modules/behat_test build/web/modules
-
-      - name: Adjust Drupal configurations
-        run: |
-          docker compose exec -T php ./vendor/bin/drush --yes --root=build/web en behat_test
-          docker compose exec -T php ./vendor/bin/drush --yes --root=build/web deploy:hook
+        run: docker compose exec -T cli php -d pcov.enabled=1 -d pcov.directory=. vendor/bin/phpunit -c phpunit.xml
 
       - name: Run Behat tests with coverage
         if: ${{ matrix.coverage }}
         run: |
-          docker compose exec -T php php -d pcov.enabled=1 -d pcov.directory=/app/src vendor/bin/behat --strict
-          docker compose exec -T php php -d pcov.enabled=1 -d pcov.directory=/app/src vendor/bin/behat --profile=drupal --strict
+          docker compose exec -T cli php -d pcov.enabled=1 -d pcov.directory=/app/src vendor/bin/behat --strict
+          docker compose exec -T cli php -d pcov.enabled=1 -d pcov.directory=/app/src vendor/bin/behat --profile=drupal --strict
 
       - name: Run Behat tests
         if: ${{ !matrix.coverage }}
         run: |
-          docker compose exec -T php vendor/bin/behat --strict --no-coverage
-          docker compose exec -T php vendor/bin/behat --profile=drupal --strict --no-coverage
-          docker compose exec -T php vendor/bin/behat --profile=drupal_https --strict --no-coverage
+          docker compose exec -T cli vendor/bin/behat --strict --no-coverage
+          docker compose exec -T cli vendor/bin/behat --profile=drupal --strict --no-coverage
 
       - name: Merge all coverage
         if: ${{ matrix.coverage }}
-        run: docker compose exec -T php php scripts/merge-coverage.php
+        run: docker compose exec -T cli php scripts/merge-coverage.php
+
+      - name: Copy logs out of container
+        if: always()
+        run: |
+          mkdir -p .logs
+          if docker compose ps --services --filter "status=running" | grep -q cli && docker compose exec -T cli test -d /app/.logs; then
+            docker compose cp cli:/app/.logs/. .logs/
+          fi
 
       - name: Extract total coverage
         if: ${{ matrix.coverage }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: docker compose up -d
 
       - name: Configure git safe directory
-        run: docker compose exec -T php git config --global --add safe.directory /var/www/html
+        run: docker compose exec -T php git config --global --add safe.directory /app
 
       - name: Install Composer dependencies
         run: docker compose exec -T php composer install
@@ -133,7 +133,7 @@ jobs:
         run: docker compose up -d
 
       - name: Configure git safe directory
-        run: docker compose exec -T php git config --global --add safe.directory /var/www/html
+        run: docker compose exec -T php git config --global --add safe.directory /app
 
       - name: Add Drupal core dependency
         run: docker compose exec -u ${DOCKER_USER_ID} -T php composer require --no-interaction --dev --no-update drupal/core:^${DRUPAL_VERSION} drupal/core-composer-scaffold:^${DRUPAL_VERSION}
@@ -171,8 +171,8 @@ jobs:
       - name: Run Behat tests with coverage
         if: ${{ matrix.coverage }}
         run: |
-          docker compose exec -T php php -d pcov.enabled=1 -d pcov.directory=/var/www/html/src vendor/bin/behat --strict
-          docker compose exec -T php php -d pcov.enabled=1 -d pcov.directory=/var/www/html/src vendor/bin/behat --profile=drupal --strict
+          docker compose exec -T php php -d pcov.enabled=1 -d pcov.directory=/app/src vendor/bin/behat --strict
+          docker compose exec -T php php -d pcov.enabled=1 -d pcov.directory=/app/src vendor/bin/behat --profile=drupal --strict
 
       - name: Run Behat tests
         if: ${{ !matrix.coverage }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,33 +56,44 @@ The test suites are organized by driver:
   (the blackbox driver). These run against static HTML fixtures.
 - `test-bdd-drupal` — Tests steps that need the Drupal API or
   Drush drivers. These run against a real Drupal installation.
-- `test-bdd-drupal-https` — Tests HTTPS-specific functionality.
 
 ## Setting up the local environment
 
-The local development environment uses Docker Compose to run
-the extension's test suite against a real Drupal installation.
-You can test with different combinations of PHP and Drupal
-versions to match the CI matrix.
+The local development environment uses [Lagoon](https://docs.lagoon.sh)
+container images and [Pygmy](https://github.com/pygmystack/pygmy) to
+serve the test site at a real `*.docker.amazee.io` URL with no
+`/etc/hosts` edits or host port juggling.
 
-You'll need [Docker and Docker Compose](https://docs.docker.com/engine/install/)
-and [Ahoy](https://github.com/ahoy-cli/ahoy) for running
-commands.
+You will need:
 
-The environment consists of several services:
+- [Docker and Docker Compose](https://docs.docker.com/engine/install/)
+- [Pygmy](https://github.com/pygmystack/pygmy)
+  (`brew install pygmy` on macOS, or
+  [`pygmy-go`](https://github.com/pygmystack/pygmy-go) on Linux)
+- [Ahoy](https://github.com/ahoy-cli/ahoy) for running commands
 
-- **php** — PHP-FPM backend that runs Drupal. All test commands
-  execute inside this container.
-- **database** — MariaDB database for the Drupal site.
-- **drupal** — Nginx web server for the Drupal site, used by
-  Behat tests that require a running Drupal installation
-  (`@api` tagged tests).
-- **blackbox** — Nginx web server serving static HTML fixtures,
-  used by Behat tests that do not require Drupal (`@test-blackbox`
-  tagged tests).
+Start Pygmy once and leave it running:
+
+```shell
+pygmy up
+```
+
+The first run may prompt to trust the self-signed certificate so that
+HTTPS routes work without browser warnings. Pygmy listens on host port
+80/443 — stop any local web server holding those ports first.
+
+The stack consists of:
+
+- **cli** — Lagoon `php-cli-drupal` image (built locally with Pcov).
+  All test commands run inside this container.
+- **php** — Lagoon `php-fpm` backend that serves Drupal pages.
+- **nginx** — Lagoon `nginx-drupal` web server. Pygmy routes
+  `http://drupalextension.docker.amazee.io` to this service.
+- **mariadb** — Lagoon `mariadb-drupal` database.
 - **chrome** — Selenium standalone Chromium for browser testing.
-- **proxy** — Traefik reverse proxy for HTTPS/TLS termination
-  in CI.
+- The blackbox HTML fixtures are served by an in-process PHP server
+  that the `BlackboxServerContext` starts inside `cli` for every
+  blackbox scenario; no separate web container is needed.
 
 ### Choosing PHP and Drupal versions
 
@@ -127,16 +138,15 @@ ahoy provision  # Install Drupal and configure. Run this when need to re-install
 
 ### Accessing the sites
 
-Once the environment is running, you can access the sites in
-your browser:
+Once the environment is running, you can reach the site in your
+browser at the Pygmy URL:
 
-- Drupal site: http://localhost:8888
-- Blackbox fixtures: http://localhost:8889
-- Selenium VNC: http://localhost:7900/?autoconnect=1&password=secret
+- Drupal site: http://drupalextension.docker.amazee.io
+- Selenium VNC: `ahoy info` prints the dynamically-assigned port
 
-To use different ports, set `DRUPAL_HOST_PORT` and
-`BLACKBOX_HOST_PORT` environment variables before starting the
-containers.
+If port 80 or 443 is already taken on the host, stop the colliding
+service or set `LOCALDEV_URL` and `PROJECT` to a unique pair before
+running `ahoy up`.
 
 ## Automated testing
 
@@ -149,10 +159,9 @@ ahoy lint-fix               # Fix coding standards
 
 ahoy test                   # Run all tests without coverage
 ahoy test-unit              # Run PHPUnit tests
-ahoy test-bdd               # Run all Behat tests (all profiles)
+ahoy test-bdd               # Run all Behat tests (both profiles)
 ahoy test-bdd-blackbox      # Blackbox tests only
 ahoy test-bdd-drupal        # Drupal API tests only
-ahoy test-bdd-drupal-https  # HTTPS tests only
 
 ahoy test-coverage          # Run all tests with coverage and merge
 ahoy test-unit-coverage     # Run PHPUnit tests with coverage
@@ -169,7 +178,6 @@ from functional tags like `@api` (which enables the Drupal API driver):
 |------------------|-----------------|--------------------------------|
 | `@test-blackbox` | `default`       | Static HTML fixtures           |
 | `@test-drupal`   | `drupal`        | Installed Drupal site with API |
-| `@test-https`    | `drupal_https`  | HTTPS via Traefik proxy        |
 
 Functional tags like `@api`, `@javascript`, and `@smoke` serve a different
 purpose — they enable specific Behat functionality (e.g. the Drupal API driver

--- a/behat.dist.yml
+++ b/behat.dist.yml
@@ -120,12 +120,12 @@ drupal:
       login_field: name
       # Drupal API driver settings.
       drupal:
-        drupal_root: /var/www/html/web
+        drupal_root: /app/web
       # Drush driver settings.
       drush:
         alias: ~
         binary: vendor/bin/drush
-        root: /var/www/html/web
+        root: /app/web
         global_options: ~
       regions:
         Content: '#main .region-content'

--- a/behat.yml
+++ b/behat.yml
@@ -145,15 +145,15 @@ drupal:
   extensions:
     Drupal\MinkExtension:
       base_url: http://drupal
-      files_path: /var/www/html/tests/behat/fixtures/files
+      files_path: /app/tests/behat/fixtures/files
 
     Drupal\DrupalExtension:
       api_driver: "drupal"
       login_wait: 0
       drupal:
-        drupal_root: "/var/www/html/build/web"
+        drupal_root: "/app/build/web"
       drush:
-        root: "/var/www/html/build/web"
+        root: "/app/build/web"
       regions:
         main content: "#main"
       selectors:
@@ -191,4 +191,4 @@ drupal_https:
     Drupal\DrupalExtension:
       api_driver: "drupal"
       drupal:
-        drupal_root: "/var/www/html/build/web"
+        drupal_root: "/app/build/web"

--- a/behat.yml
+++ b/behat.yml
@@ -52,13 +52,19 @@ default:
         - FeatureContext
         - BehatCliContext
         - DrevOps\BehatScreenshotExtension\Context\ScreenshotContext
+        # Serves blackbox HTML fixtures from the 'cli' container itself, so
+        # tests do not depend on a separate web container.
+        - BlackboxServerContext:
+            webroot: '%paths.base%/tests/behat/fixtures/blackbox'
+            host: 0.0.0.0
+            port: 8888
       filters:
         tags: "@test-blackbox&&~@skipped"
 
   extensions:
     Drupal\MinkExtension:
       browserkit_http: ~
-      base_url: http://blackbox
+      base_url: http://cli:8888
       browser_name: chrome
       javascript_session: selenium2
       selenium2:
@@ -144,7 +150,7 @@ drupal:
 
   extensions:
     Drupal\MinkExtension:
-      base_url: http://drupal
+      base_url: http://nginx:8080
       files_path: /app/tests/behat/fixtures/files
 
     Drupal\DrupalExtension:

--- a/behat.yml
+++ b/behat.yml
@@ -25,7 +25,6 @@
 # like @api (which enables the Drupal API driver):
 #   @test-blackbox  — runs in the default (blackbox) profile only
 #   @test-drupal    — runs in the drupal profile only
-#   @test-https     — runs in the drupal_https profile only
 #
 # Each scenario must be explicitly tagged. The drupal profile only picks
 # up scenarios tagged @test-drupal, not "everything that is not @test-blackbox."
@@ -168,33 +167,3 @@ drupal:
           error: '.messages--error'
           success: '.messages--status'
           warning: '.messages--warning'
-
-# HTTPS profile: tests TLS termination via Traefik reverse proxy.
-# Inherits: autoload, paths, Mink selenium2/chrome config, screenshot extension,
-# code coverage extension.
-drupal_https:
-  suites:
-    default:
-      contexts:
-        # Contexts under tests - Mink context.
-        - Drupal\DrupalExtension\Context\MinkContext
-        # Contexts under tests - Drupal contexts.
-        - Drupal\DrupalExtension\Context\DrupalContext
-        # Helper contexts for test execution and reporting.
-        - FeatureContext
-        - BehatCliContext
-        - DrevOps\BehatScreenshotExtension\Context\ScreenshotContext
-      filters:
-        tags: "@test-https&&~@skipped"
-
-  extensions:
-    Drupal\MinkExtension:
-      base_url: https://proxy
-      browserkit_http:
-        guzzle_request_options:
-          verify: false
-
-    Drupal\DrupalExtension:
-      api_driver: "drupal"
-      drupal:
-        drupal_root: "/app/build/web"

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "composer/installers": "^2.3",
         "dantleech/gherkin-lint": "^0.2.3",
         "dflydev/dot-access-data": "^3.0.3",
+        "drevops/behat-phpserver": "^2.3",
         "drevops/behat-screenshot": "^2.2",
         "drevops/phpcs-standard": "^0.7.0",
         "drupal/coder": "^8.3.27",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,137 +1,110 @@
+# Local development stack for the Behat Drupal Extension.
+#
+# Locally this stack is fronted by Pygmy (https://github.com/pygmystack/pygmy)
+# which serves the Lagoon nginx container at the LOCALDEV_URL Host. To run in
+# CI, the host-only lines tagged with '###' are stripped and the named-volume
+# overrides tagged with '##' are uncommented:
+#
+#   sed -i -e "/###/d" docker-compose.yml
+#   sed -i -e "s/##//" docker-compose.yml
+#
+# For reference, see https://github.com/drevops/behat-steps/blob/main/docker-compose.yml.
+x-project:
+  &project ${PROJECT:-drupalextension}
+
+x-url:
+  &url ${LOCALDEV_URL:-http://drupalextension.docker.amazee.io}
+
+x-volumes:
+  &default-volumes
+  volumes:
+    - .:/app:${VOLUME_FLAGS:-delegated} ### Local overrides to mount host filesystem. Automatically removed in CI.
+    ##- app:/app # Override for environment without host mounts. Automatically uncommented in CI.
+
+x-user:
+  &default-user
+  user: '1000'
+
+x-environment:
+  &default-environment
+  PROJECT: *project
+  WEBROOT: build/web
+  LOCALDEV_URL: *url
+  LAGOON_LOCALDEV_URL: *url
+  CI: ${CI:-}
+  XDEBUG_ENABLE: ${XDEBUG_ENABLE:-}
+  DRUPAL_VERSION: ${DRUPAL_VERSION:-11}
+  PHP_VERSION: ${PHP_VERSION:-8.3}
+  GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+  PHP_MEMORY_LIMIT: 2048M
+
 services:
 
-  # PHP-FPM backend that runs Drupal. Behat tests execute inside this container
-  # via `docker compose exec -T php`.
-  php:
-    image: wodby/drupal-php:${PHP_VERSION:-8.3}
+  cli:
+    build:
+      context: .
+      dockerfile: .docker/cli.dockerfile
+      args:
+        PHP_VERSION: ${PHP_VERSION:-8.3}
+    <<: *default-volumes
+    user: root
+    expose:
+      - "8888"
     environment:
-      DB_HOST: database
-      DB_USER: drupal
-      DB_PASSWORD: drupal
-      DB_NAME: drupal
-      DB_DRIVER: mysql
-      PHP_FPM_USER: wodby
-      PHP_FPM_GROUP: wodby
-      PHP_FPM_CLEAR_ENV: "yes"
-      PHP_OPCACHE_PRELOAD_USER: wodby
-      # Override PATH to remove vendor/bin so that bare 'drush' does not
-      # resolve globally — forces tests to exercise the binary resolution.
-      PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-      PHP_EXTENSIONS_DISABLE: "${PHP_EXTENSIONS_DISABLE:-xdebug,xhprof,spx}"
-      PHP_XDEBUG_MODE: "${PHP_XDEBUG_MODE:-off}"
-      PHP_XDEBUG_CLIENT_HOST: host.docker.internal
-      PHP_XDEBUG_IDEKEY: "PHPSTORM"
-      PHP_IDE_CONFIG: "serverName=drupalextension"
-    volumes:
-      - ./:/var/www/html
-    labels:
-      - "traefik.enable=false"
-    depends_on:
-      - database
-      - proxy
+      <<: *default-environment
+    volumes_from: ### Local overrides to mount host SSH keys. Automatically removed in CI.
+      - container:amazeeio-ssh-agent ### Local overrides to mount host SSH keys. Automatically removed in CI.
 
-  # MariaDB database for the Drupal site.
-  database:
-    image: wodby/mariadb:10.6-3.28.3
-    stop_grace_period: 30s
+  php:
+    image: uselagoon/php-${PHP_VERSION:-8.3}-fpm:26.2.0
+    <<: [*default-volumes, *default-user]
     environment:
-      MYSQL_ROOT_PASSWORD: password
-      MYSQL_DATABASE: drupal
-      MYSQL_USER: drupal
-      MYSQL_PASSWORD: drupal
+      <<: *default-environment
+    depends_on:
+      - cli
+
+  nginx:
+    image: uselagoon/nginx-drupal:26.2.0
+    <<: [*default-volumes, *default-user]
+    environment:
+      <<: *default-environment
+    depends_on:
+      - cli
+    networks:
+      - amazeeio-network ### This network is supported by Pygmy and used to route all requests to host machine locally. Removed in CI.
+      - default
+
+  mariadb:
+    image: uselagoon/mariadb-10.6-drupal:26.2.0
+    environment:
+      <<: *default-environment
     ports:
       - "3306"
-    labels:
-      - "traefik.enable=false"
 
-  # Traefik reverse proxy. Only needed for HTTPS/TLS termination, used by the
-  # drupal_https Behat profile (@https scenarios). Routes requests to the drupal
-  # nginx service based on the Host(`proxy`) rule. Used in CI (Linux) where
-  # Docker socket access works. On Docker Desktop for Mac, Traefik may not be
-  # able to access the Docker socket — the 'proxy' network alias on the drupal
-  # service provides a direct fallback for HTTP.
-  proxy:
-    image: traefik:v2.10
-    command:
-      - "--api.insecure=true"
-      - "--providers.docker"
-      - "--entrypoints.http-80.address=:80"
-      - "--entrypoints.http-443.address=:443"
-    ports:
-      - "${PROXY_HTTP_PORT:-80}:80"
-      - "${PROXY_HTTPS_PORT:-443}:443"
-      # The Web UI (enabled by --api.insecure=true)
-      - "${PROXY_DASHBOARD_PORT:-8080}:8080"
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    labels:
-      - "traefik.enable=false"
-
-  # Nginx web server for the Drupal site. The 'proxy' network alias allows
-  # containers to reach Drupal at http://proxy without depending on Traefik.
-  # Host access: http://localhost:8888
-  drupal:
-    image: wodby/nginx
-    depends_on:
-      - php
-    environment:
-      NGINX_STATIC_OPEN_FILE_CACHE: "off"
-      NGINX_ERROR_LOG_LEVEL: debug
-      NGINX_BACKEND_HOST: php
-      NGINX_SERVER_ROOT: /var/www/html/build/web
-      NGINX_VHOST_PRESET: drupal10
-    volumes:
-      - ./:/var/www/html
-    networks:
-      default:
-        aliases:
-          - proxy
-    ports:
-      - "${DRUPAL_HOST_PORT:-8888}:80"
-    labels:
-      - "traefik.http.routers.drupal.rule=Host(`proxy`)"
-      - "traefik.http.routers.drupal.entrypoints=http-80"
-      - "traefik.http.routers.drupal-secure.rule=Host(`proxy`)"
-      - "traefik.http.routers.drupal-secure.tls=true"
-      - "traefik.http.routers.drupal-secure.entrypoints=http-443"
-
-  # Nginx web server serving static HTML fixtures for blackbox Behat tests.
-  # These tests do not require a running Drupal site.
-  # Host access: http://localhost:8889
-  blackbox:
-    image: wodby/nginx
-    environment:
-      NGINX_STATIC_OPEN_FILE_CACHE: "off"
-      NGINX_ERROR_LOG_LEVEL: debug
-      NGINX_SERVER_ROOT: /var/www/html/tests/behat/fixtures/blackbox
-      NGINX_VHOST_PRESET: html
-    volumes:
-      - ./:/var/www/html
-    ports:
-      - "${BLACKBOX_HOST_PORT:-8889}:80"
-    labels:
-      - "traefik.enable=false"
-
-  # Selenium standalone Chromium for browser testing.
-  # Access via noVNC at http://localhost:7900/?autoconnect=1&password=secret
   chrome:
     image: selenium/standalone-chromium:145.0
     ports:
-      - "${CHROME_VNC_PORT:-7900}:7900"
+      - "7900:7900"
     expose:
       - "8888"
     shm_size: '1gb'
-    volumes:
-      - ./:/var/www/html
+    <<: *default-volumes
+    environment:
+      <<: *default-environment
     depends_on:
-      - php
-    labels:
-      - "traefik.enable=false"
+      - cli
 
   # Helper container to wait for services to become available.
   wait_dependencies:
     image: drevops/docker-wait-for-dependencies:26.1.0
     depends_on:
-      - php
-      - database
-    command: database:3306
+      - cli
+      - mariadb
+    command: mariadb:3306
+
+networks:           ### Use external networks locally. Automatically removed in CI.
+  amazeeio-network: ### Automatically removed in CI.
+    external: true  ### Automatically removed in CI.
+
+volumes:
+  app: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ x-project:
   &project ${PROJECT:-drupalextension}
 
 x-url:
-  &url ${LOCALDEV_URL:-http://drupalextension.docker.amazee.io}
+  &url ${LOCALDEV_URL:-http://${COMPOSE_PROJECT_NAME}.docker.amazee.io}
 
 x-volumes:
   &default-volumes
@@ -56,7 +56,7 @@ services:
       - container:amazeeio-ssh-agent ### Local overrides to mount host SSH keys. Automatically removed in CI.
 
   php:
-    image: uselagoon/php-${PHP_VERSION:-8.3}-fpm:26.2.0
+    image: uselagoon/php-${PHP_VERSION:-8.3}-fpm:latest
     <<: [*default-volumes, *default-user]
     environment:
       <<: *default-environment
@@ -64,7 +64,7 @@ services:
       - cli
 
   nginx:
-    image: uselagoon/nginx-drupal:26.2.0
+    image: uselagoon/nginx-drupal:latest
     <<: [*default-volumes, *default-user]
     environment:
       <<: *default-environment
@@ -75,14 +75,14 @@ services:
       - default
 
   mariadb:
-    image: uselagoon/mariadb-10.6-drupal:26.2.0
+    image: uselagoon/mariadb-10.6-drupal:latest
     environment:
       <<: *default-environment
     ports:
       - "3306"
 
   chrome:
-    image: selenium/standalone-chromium:145.0
+    image: selenium/standalone-chromium:latest
     ports:
       - "7900:7900"
     expose:
@@ -96,7 +96,7 @@ services:
 
   # Helper container to wait for services to become available.
   wait_dependencies:
-    image: drevops/docker-wait-for-dependencies:26.1.0
+    image: drevops/docker-wait-for-dependencies:latest
     depends_on:
       - cli
       - mariadb

--- a/scripts/check-coverage.php
+++ b/scripts/check-coverage.php
@@ -10,7 +10,7 @@
  * Where:
  * - ClassName: The name of the class to check (e.g., "DrupalContext")
  * - coverage_file_path: Optional path to the cobertura.xml file.
- *   Defaults to '/var/www/html/.logs/coverage/merged/cobertura.xml'.
+ *   Defaults to '/app/.logs/coverage/merged/cobertura.xml'.
  *
  * Examples:
  * php check-coverage.php DrupalContext
@@ -27,8 +27,8 @@ if (empty($argv[1])) {
 }
 
 $trait_name = $argv[1];
-$default_coverage_file = file_exists('/var/www/html/.logs/coverage/merged/cobertura.xml')
-  ? '/var/www/html/.logs/coverage/merged/cobertura.xml'
+$default_coverage_file = file_exists('/app/.logs/coverage/merged/cobertura.xml')
+  ? '/app/.logs/coverage/merged/cobertura.xml'
   : __DIR__ . '/../.logs/coverage/merged/cobertura.xml';
 $coverage_file = $argv[2] ?? $default_coverage_file;
 

--- a/scripts/merge-coverage.php
+++ b/scripts/merge-coverage.php
@@ -8,7 +8,7 @@
  * php merge-coverage.php [coverage_root_path].
  *
  * Where coverage_root_path is the optional path to the coverage root directory.
- * Defaults to '/var/www/html/.logs/coverage'.
+ * Defaults to '/app/.logs/coverage'.
  *
  * This will merge coverage from:
  * - PHPUnit: {root}/phpunit/phpcov.php
@@ -31,7 +31,7 @@ use SebastianBergmann\CodeCoverage\Report\Thresholds;
 require_once __DIR__ . '/../vendor/autoload.php';
 
 // Get coverage root path from command line argument or use default.
-define('COVERAGE_ROOT_PATH', $argv[1] ?? '/var/www/html/.logs/coverage');
+define('COVERAGE_ROOT_PATH', $argv[1] ?? '/app/.logs/coverage');
 
 // Source coverage files to be merged.
 $sources = [

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+##
+# Provision the fixture Drupal site used by the Behat suite.
+#
+# Called from both 'ahoy provision' and the CI workflow. Assumes Composer
+# dependencies are already installed at /app/vendor and the Drupal scaffold
+# has populated /app/build/web.
+#
+# shellcheck disable=SC2015
+
+set -e
+[ -n "${PROVISION_DEBUG}" ] && set -x
+
+LOCALDEV_URL="${LOCALDEV_URL:-http://drupalextension.docker.amazee.io}"
+
+DRUSH=(/app/vendor/bin/drush --root=/app/build/web --uri="${LOCALDEV_URL}" --yes)
+
+echo "==> Provisioning fixture Drupal site at ${LOCALDEV_URL}."
+
+echo "  > Copying Drush configuration."
+mkdir -p /app/build/drush
+cp -Rf /app/tests/behat/fixtures/drupal/drush/. /app/build/drush/
+
+echo "  > Copying 'behat_test' module."
+mkdir -p /app/build/web/modules
+cp -Rf /app/tests/behat/fixtures/drupal/modules/behat_test /app/build/web/modules/
+
+echo "  > Dropping any existing database tables."
+"${DRUSH[@]}" sql-drop 2>/dev/null || true
+
+echo "  > Installing site."
+"${DRUSH[@]}" site-install --db-url=mysql://drupal:drupal@mariadb/drupal --debug
+
+echo "  > Enabling 'behat_test' module."
+"${DRUSH[@]}" en behat_test
+
+echo "  > Running 'deploy:hook'."
+"${DRUSH[@]}" deploy:hook
+
+echo "==> Provisioning finished."

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -11,7 +11,7 @@
 set -e
 [ -n "${PROVISION_DEBUG}" ] && set -x
 
-LOCALDEV_URL="${LOCALDEV_URL:-http://drupalextension.docker.amazee.io}"
+LOCALDEV_URL="${LOCALDEV_URL:-http://${COMPOSE_PROJECT_NAME}.docker.amazee.io}"
 
 DRUSH=(/app/vendor/bin/drush --root=/app/build/web --uri="${LOCALDEV_URL}" --yes)
 

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -25,11 +25,16 @@ echo "  > Copying 'behat_test' module."
 mkdir -p /app/build/web/modules
 cp -Rf /app/tests/behat/fixtures/drupal/modules/behat_test /app/build/web/modules/
 
+echo "  > Removing any leftover settings.php so 'site-install' can rewrite it."
+chmod -f u+w /app/build/web/sites/default 2>/dev/null || true
+chmod -f u+w /app/build/web/sites/default/settings.php 2>/dev/null || true
+rm -f /app/build/web/sites/default/settings.php
+
 echo "  > Dropping any existing database tables."
 "${DRUSH[@]}" sql-drop 2>/dev/null || true
 
 echo "  > Installing site."
-"${DRUSH[@]}" site-install --db-url=mysql://drupal:drupal@mariadb/drupal --debug
+"${DRUSH[@]}" site-install --db-url=mysql://drupal:drupal@mariadb:3306/drupal
 
 echo "  > Enabling 'behat_test' module."
 "${DRUSH[@]}" en behat_test

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -48,9 +48,9 @@ trait BehatCliTrait {
     // Set environment variables for Drupal Finder.
     // This requires Drupal Finder version > 1.2 at commit:
     // @see https://github.com/webflo/drupal-finder/commit/2663b117878f4a45ca56df028460350c977f92c0
-    $this->iSetEnvironmentVariable('DRUPAL_FINDER_DRUPAL_ROOT', '/var/www/html/build/web');
-    $this->iSetEnvironmentVariable('DRUPAL_FINDER_COMPOSER_ROOT', '/var/www/html/build');
-    $this->iSetEnvironmentVariable('DRUPAL_FINDER_VENDOR_DIR', '/var/www/html/build/vendor');
+    $this->iSetEnvironmentVariable('DRUPAL_FINDER_DRUPAL_ROOT', '/app/build/web');
+    $this->iSetEnvironmentVariable('DRUPAL_FINDER_COMPOSER_ROOT', '/app/build');
+    $this->iSetEnvironmentVariable('DRUPAL_FINDER_VENDOR_DIR', '/app/build/vendor');
   }
 
   /**
@@ -124,7 +124,7 @@ EOL;
   #[Given('some behat configuration')]
   public function behatCliWriteBehatYml(): void {
     // @note Hardcoded path to the project root.
-    $source = '/var/www/html/behat.yml';
+    $source = '/app/behat.yml';
 
     $content = file_get_contents($source);
     if ($content === FALSE) {
@@ -162,7 +162,7 @@ EOL;
         'filter' => [
           'include' => [
             'directories' => [
-              '/var/www/html/src' => NULL,
+              '/app/src' => NULL,
             ],
           ],
         ],
@@ -172,7 +172,7 @@ EOL;
             'showOnlySummary' => TRUE,
           ],
           'php' => [
-            'target' => '/var/www/html/.logs/coverage/behat_cli/phpcov/' . $coverage_id . '.php',
+            'target' => '/app/.logs/coverage/behat_cli/phpcov/' . $coverage_id . '.php',
           ],
         ],
       ];
@@ -185,7 +185,7 @@ EOL;
 
     // Resolve the drush binary to an absolute path so subprocess tests
     // can find it regardless of their working directory.
-    // The source behat.yml is at /var/www/html, so resolve relative to that.
+    // The source behat.yml is at /app, so resolve relative to that.
     $project_root = dirname($source);
     $drush_binary = $project_root . '/vendor/bin/drush';
     if (file_exists($drush_binary)) {
@@ -482,7 +482,7 @@ EOL;
     $fixture_path_rel = 'tests/behat/fixtures';
 
     // @note Hardcoded path to the fixture directory.
-    $fixture_path_abs = '/var/www/html/' . DIRECTORY_SEPARATOR . $fixture_path_rel;
+    $fixture_path_abs = '/app/' . DIRECTORY_SEPARATOR . $fixture_path_rel;
 
     if (is_dir($fixture_path_abs)) {
       $dst = $this->workingDir . DIRECTORY_SEPARATOR . $fixture_path_rel;

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -198,7 +198,7 @@ EOL;
     $project_root = dirname($source);
     $drush_binary = $project_root . '/vendor/bin/drush';
     if (file_exists($drush_binary)) {
-      foreach (['default', 'drupal', 'drupal_https'] as $profile) {
+      foreach (['default', 'drupal'] as $profile) {
         if (isset($yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush'])) {
           $yaml[$profile]['extensions']['Drupal\DrupalExtension']['drush']['binary'] = $drush_binary;
         }

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -153,6 +153,15 @@ EOL;
       unset($yaml['drupal']['suites']['default']['contexts'][$index]);
     }
 
+    // Drop 'BlackboxServerContext' from the subprocess config: the parent's
+    // server is already running on 0.0.0.0:8888 and the subprocess shares
+    // the cli container, so reusing it avoids a port collision.
+    foreach ($yaml['default']['suites']['default']['contexts'] as $key => $context) {
+      if (is_array($context) && array_key_exists('BlackboxServerContext', $context)) {
+        unset($yaml['default']['suites']['default']['contexts'][$key]);
+      }
+    }
+
     if (static::behatCliIsCoverageEnabled()) {
       // Update the code coverage configuration to use an alternative
       // coverage report target. This report is merged into a single report

--- a/tests/behat/bootstrap/BlackboxServerContext.php
+++ b/tests/behat/bootstrap/BlackboxServerContext.php
@@ -24,11 +24,17 @@ use DrevOps\BehatPhpServer\PhpServerContext;
  */
 class BlackboxServerContext extends PhpServerContext {
 
+  /**
+   * Starts the PHP server before each scenario.
+   */
   #[BeforeScenario]
   public function blackboxStartServer(BeforeScenarioScope $scope): void {
     $this->start();
   }
 
+  /**
+   * Stops the PHP server after each scenario.
+   */
   #[AfterScenario]
   public function blackboxStopServer(AfterScenarioScope $scope): void {
     $this->stop();

--- a/tests/behat/bootstrap/BlackboxServerContext.php
+++ b/tests/behat/bootstrap/BlackboxServerContext.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Blackbox HTML server context.
+ *
+ * phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+ */
+
+declare(strict_types=1);
+
+use Behat\Behat\Hook\Scope\AfterScenarioScope;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\Hook\AfterScenario;
+use Behat\Hook\BeforeScenario;
+use DrevOps\BehatPhpServer\PhpServerContext;
+
+/**
+ * PhpServerContext variant that serves blackbox HTML fixtures unconditionally.
+ *
+ * Upstream 'PhpServerContext' only starts the server for scenarios tagged
+ * '@phpserver'. Every blackbox scenario in this suite visits a URL, so we
+ * start the server for every scenario instead of tagging each one.
+ */
+class BlackboxServerContext extends PhpServerContext {
+
+  #[BeforeScenario]
+  public function blackboxStartServer(BeforeScenarioScope $scope): void {
+    $this->start();
+  }
+
+  #[AfterScenario]
+  public function blackboxStopServer(AfterScenarioScope $scope): void {
+    $this->stop();
+  }
+
+}

--- a/tests/behat/features/behatcli/README.md
+++ b/tests/behat/features/behatcli/README.md
@@ -72,8 +72,7 @@ The `Given some behat configuration` step copies the real
 
 - Changes to `behat.yml` (regions, selectors, contexts, extensions)
   automatically apply to negative tests.
-- The subprocess has access to all profiles (`default`, `drupal`,
-  `drupal_https`).
+- The subprocess has access to both profiles (`default` and `drupal`).
 - Use `When I run behat` for the default (blackbox) profile, or
   `When I run behat with drupal profile` for the drupal profile.
 

--- a/tests/behat/features/d10.feature
+++ b/tests/behat/features/d10.feature
@@ -3,7 +3,7 @@ Feature: DrupalContext
   I want to use Drupal-specific step definitions
   So that I can test table row links, user roles, and region headings
 
-  @d10 @test-https @api
+  @d10 @test-drupal @api
   Scenario: Target links within table rows (Drupal 10)
     Given I am logged in as a user with the "administrator" role
     When I am at "admin/structure/types"

--- a/tests/behat/fixtures/drupal/drush/drush.yml
+++ b/tests/behat/fixtures/drupal/drush/drush.yml
@@ -1,3 +1,10 @@
+options:
+  # Drush 13 fails with "Invalid URI: Host is malformed" when it tries to
+  # bootstrap Drupal without a --uri. The Behat 'DrushDriver' does not pass
+  # one, so set the default here. Tests run inside the 'cli' container, which
+  # reaches the Lagoon nginx as 'http://nginx:8080'.
+  uri: http://nginx:8080
+
 command:
   sql:
     cli:

--- a/tests/phpunit/src/BrowserKitFactoryTest.php
+++ b/tests/phpunit/src/BrowserKitFactoryTest.php
@@ -119,7 +119,7 @@ class BrowserKitFactoryTest extends TestCase {
     $factory = $this->getMockBuilder(BrowserKitFactory::class)
       ->onlyMethods(['getCwd'])
       ->getMock();
-    $factory->method('getCwd')->willReturn('/var/www/html/build');
+    $factory->method('getCwd')->willReturn('/app/build');
     return $factory;
   }
 


### PR DESCRIPTION
Closes #730

## Summary

Replaces the Wodby + Traefik local stack with Lagoon container images fronted
by Pygmy, matching the layout used by `drevops/behat-steps`. The separate
blackbox nginx container is dropped in favour of an in-process PHP server
(`drevops/behat-phpserver`) started by the new `BlackboxServerContext` inside
the `cli` container, removing the dependency on a second web service.
The `drupal_https` Behat profile and its HTTPS-specific tests are removed as
they were only there to exercise Traefik TLS termination, which no longer exists
in the stack. Provisioning steps previously inlined in `.ahoy.yml` are
extracted into `scripts/provision.sh` so both `ahoy provision` and the CI
workflow share a single, auditable script. Volume mounts and all internal paths
switch from `/var/www/html` to `/app` (the Lagoon convention).

## Changes

### Docker stack (`docker-compose.yml`, `.docker/cli.dockerfile`)

- Replaced Wodby `php`, `drupal` (nginx), `blackbox` (nginx), and `database`
  (mariadb) services with their Lagoon equivalents: `cli`, `php`, `nginx`,
  and `mariadb` (all pinned to `26.2.0`).
- Removed the `proxy` (Traefik) service entirely.
- Added `x-project`, `x-url`, `x-volumes`, `x-user`, and `x-environment` YAML
  anchors for DRY configuration, following the `drevops/behat-steps` layout.
- Added sed-marker pattern (`###` / `##`) so a single
  `sed -i -e "/###/d" && sed -i -e "s/##//"` pass strips local-only lines
  and activates the named-volume override for CI.
- Added `amazeeio-network` external network (local only; stripped in CI so
  Pygmy routes `drupalextension.docker.amazee.io` to the nginx service).
- Added `.docker/cli.dockerfile` that layers `pecl install pcov` on top of
  `uselagoon/php-${PHP_VERSION}-cli-drupal:26.2.0`.

### Blackbox fixture serving
  (`composer.json`, `behat.yml`, `tests/behat/bootstrap/BlackboxServerContext.php`)

- Added `drevops/behat-phpserver` as a Composer dev dependency.
- Added `BlackboxServerContext` (extends `PhpServerContext`) to the `default`
  Behat suite: starts the PHP server before every blackbox scenario and stops
  it after, replacing the `blackbox` nginx container.
- Updated `behat.yml` default suite `base_url` from `http://blackbox` to
  `http://cli:8888`.
- Updated `drupal` suite URLs and paths from `http://drupal` /
  `/var/www/html/...` to `http://nginx:8080` / `/app/...`.
- Removed the `drupal_https` profile and its `base_url: https://proxy` config.

### Provisioning (`scripts/provision.sh`, `.ahoy.yml`)

- Extracted `sql-drop`, `site-install`, `en behat_test`, and `deploy:hook`
  steps from `ahoy provision` into `scripts/provision.sh`. The script also
  copies Drush config and the `behat_test` module into the build directory,
  replacing the ad-hoc `cp` calls that were previously in `ahoy assemble`.
- `ahoy provision` now delegates to `ahoy cli ./scripts/provision.sh`.
- Rewrote the `cli` ahoy command to target the `cli` container instead of
  `php`, adding `-T` for non-interactive use.
- Updated `ahoy drush` to use an absolute path and pass `--uri` explicitly.
- Removed `test-bdd-drupal-https` ahoy command.
- Replaced `/var/www/html/src` with `/app/src` in coverage commands.

### CI workflow (`.github/workflows/ci.yml`)

- Switched all `docker compose exec` calls from `php` to `cli`.
- Added a "Process the codebase to run in CI" step that runs the two `sed`
  commands to strip Pygmy-local lines before `docker compose up`.
- Changed "Build stack" to `docker compose up -d --build` followed by
  `docker cp -L . $(docker compose ps -q cli):/app/` (host-mount replacement
  for CI).
- Moved "Copy Drush configuration" and "Copy test fixtures" into
  `scripts/provision.sh`; the CI step is now a single
  `bash scripts/provision.sh`.
- Dropped the standalone "Adjust Drupal configurations" step (merged into
  provision script).
- Added "Copy logs out of container" step (`docker compose cp cli:/app/.logs/`)
  so coverage and docs artefacts are available to later steps.
- Removed `DOCKER_USER_ID` env var (Lagoon images use a fixed `1000` UID).
- Added Composer download cache (`actions/cache@v4`) to both jobs.
- Removed `drupal_https` run from the non-coverage Behat step.
- Changed the runner to `ubuntu-latest` (was already ubuntu, now explicit).

### Documentation (`CONTRIBUTING.md`, `tests/behat/features/behatcli/README.md`)

- Updated CONTRIBUTING.md: replaced Wodby service descriptions with Lagoon
  equivalents, added Pygmy setup instructions, removed HTTPS profile docs,
  updated URLs from `localhost:8888/8889` to the Pygmy `*.docker.amazee.io`
  address.
- Minor README update for the behatcli feature directory.

### Test fixtures and minor fixes

- Added `tests/behat/fixtures/drupal/drush/drush.yml` (Drush site alias).
- Updated `tests/behat/features/d10.feature` tag to match new conventions.
- Fixed a stray `/var/www/html` reference in `BrowserKitFactoryTest.php`.
- Updated `/var/www/html` path references in `BehatCliTrait.php`,
  `scripts/check-coverage.php`, and `scripts/merge-coverage.php`.

## Before / After

### Service topology

```
BEFORE (Wodby + Traefik)                  AFTER (Lagoon + Pygmy)
========================================  ========================================

  ┌──────────────┐                          ┌──────────────┐
  │   Traefik    │  :80/:443                │   Pygmy      │  :80/:443 (host)
  │   (proxy)    │◄─────────────────────    │  (external)  │◄───────────────────
  └──────┬───────┘                          └──────┬───────┘
         │ Host(`proxy`)                           │ amazeeio-network
         ▼                                         ▼
  ┌──────────────┐                          ┌──────────────┐
  │  drupal      │  wodby/nginx             │  nginx       │  uselagoon/nginx
  │  (nginx)     │  NGINX_BACKEND_HOST=php  │              │  drupalextension
  └──────┬───────┘                          │  .docker.    │
         │                                  │  amazee.io   │
         ▼                                  └──────┬───────┘
  ┌──────────────┐                                 │
  │  php         │  wodby/drupal-php               ▼
  │  (php-fpm)   │  /var/www/html          ┌──────────────┐
  └──────┬───────┘                         │  php         │  uselagoon/php-fpm
         │                                 │  (php-fpm)   │  /app
         ▼                                 └──────┬───────┘
  ┌──────────────┐                                │
  │  database    │  wodby/mariadb                 ▼
  └──────────────┘                         ┌──────────────┐
                                           │  mariadb     │  uselagoon/mariadb
  ┌──────────────┐                         └──────────────┘
  │  blackbox    │  wodby/nginx
  │  (nginx)     │  :8889                  ┌──────────────┐
  └──────────────┘  fixtures               │  cli         │  uselagoon/php-cli
                                           │              │  + pcov layer
                                           │              │  /app
                                           └──────────────┘
                                               │ in-process
                                               ▼
                                           ┌──────────────┐
                                           │  BlackboxSrv │  PHP built-in server
                                           │  :8888       │  per-scenario
                                           └──────────────┘
```

### Fixture serving (blackbox HTML)

```
BEFORE                                    AFTER
======================================    ======================================

  behat.yml                                 behat.yml
  base_url: http://blackbox                 base_url: http://cli:8888

  blackbox nginx container                  BlackboxServerContext
  serves /var/www/html/tests/               extends PhpServerContext
  behat/fixtures/blackbox                   starts PHP built-in server
  statically on :80                         in cli on :8888
                                            per-scenario lifecycle
                                            serves /app/tests/
                                            behat/fixtures/blackbox
```

### Volume mount path

```
BEFORE                    AFTER
========================  ========================
  /var/www/html             /app
  (Wodby convention)        (Lagoon convention)
```

### CI provisioning flow

```
BEFORE                                    AFTER
======================================    ======================================

  CI steps (inline):                        scripts/provision.sh:
  1. Copy Drush config        }               1. Copy Drush config
  2. site-install             }  scattered    2. Copy behat_test module
  3. Copy behat_test module   }  across       3. Remove stale settings.php
  4. en behat_test            }  4 steps      4. sql-drop
  5. deploy:hook                              5. site-install
                                             6. en behat_test
  ahoy provision (inline):                    7. deploy:hook
  - sql-drop
  - site-install                            CI step: bash scripts/provision.sh
  - en behat_test                           ahoy provision: ahoy cli ./scripts/provision.sh
  - deploy:hook
```
