### PR TITLE
Fixed chrome port and AJAX assertion after Pygmy and Lagoon stack migration.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,13 @@ Once the environment is running, you can reach the site in your
 browser at the Pygmy URL:
 
 - Drupal site: http://drupalextension.docker.amazee.io
-- Selenium VNC: `ahoy info` prints the dynamically-assigned port
+- Selenium VNC: `ahoy info` prints a ready-to-open URL like
+  `http://localhost:59216/?autoconnect=1&password=secret` (port is
+  dynamically assigned; password is `secret`). Open it in a browser
+  to watch the Chromium session driven by `@javascript` scenarios.
+- Xdebug status: `ahoy info` shows whether Xdebug is enabled or
+  disabled, with a hint to enable it via `ahoy debug` (see
+  [Debugging with Xdebug](#debugging-with-xdebug)).
 
 If port 80 or 443 is already taken on the host, stop the colliding
 service or set `LOCALDEV_URL` and `PROJECT` to a unique pair before

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
   chrome:
     image: selenium/standalone-chromium:latest
     ports:
-      - "7900:7900"
+      - "7900"
     expose:
       - "8888"
     shm_size: '1gb'

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -115,7 +115,8 @@ class FeatureContext extends RawDrupalContext {
       $message = $e->getMessage();
       $required = [
         'Unable to complete AJAX request after',
-        'URL: http://blackbox/ajax_hang.html',
+        'URL: http://',
+        '/ajax_hang.html',
         'Drupal AJAX instances active: 1',
         "url: '/never-completes'",
         "selector: '#fake-button'",


### PR DESCRIPTION
## Summary

After migrating the local stack to Pygmy and Lagoon images, two regressions appeared: the Selenium VNC port was pinned to a fixed host mapping (`7900:7900`) instead of letting Docker assign it dynamically, and the AJAX timeout assertion in `FeatureContext` hardcoded `http://blackbox` as the expected host, which no longer matched the new in-process PHP server host (`http://cli:8888`). This PR fixes both issues and expands the `CONTRIBUTING.md` guidance for the dynamically-assigned VNC and Xdebug URLs produced by `ahoy info`.

## Changes

**`docker-compose.yml`**
- Changed the `chrome` service VNC port mapping from `"7900:7900"` (fixed host binding) to `"7900"` (Docker-assigned ephemeral port). This matches how the Pygmy/Lagoon stack exposes ports and prevents conflicts when the host port is already in use.

**`tests/behat/bootstrap/FeatureContext.php`**
- Replaced the hardcoded `URL: http://blackbox/ajax_hang.html` substring check in the AJAX timeout assertion with two host-agnostic substrings: `URL: http://` and `/ajax_hang.html`. The assertion still verifies the URL structure without being tied to a specific host, so it works across all stack configurations (blackbox, cli, localhost).

**`CONTRIBUTING.md`**
- Expanded the Selenium VNC bullet to show an example of the `ahoy info` URL output (`http://localhost:<port>/?autoconnect=1&password=secret`) and note that the port is dynamically assigned and the default password is `secret`.
- Added an Xdebug status bullet explaining that `ahoy info` shows whether Xdebug is enabled or disabled, with a reference to the Xdebug debugging section.
