### PR TITLE
[#415] Added test coverage for URI-only link field values.

### DIFF
--- a/tests/behat/features/field_handlers.feature
+++ b/tests/behat/features/field_handlers.feature
@@ -47,6 +47,39 @@ Feature: FieldHandlers
       | field_post_reference | Alpha - Bravo |
     Then I should see "Alpha - Bravo"
 
+  # URI-only link values (no title) are supported via scalar mode: the bare
+  # URI is treated as the 'uri' column and the title is left empty, so
+  # Drupal renders the URI itself as the visible link text.
+  @test-drupal @api
+  Scenario: Test link field with a single URI-only value in scalar mode
+    When I am viewing a "post" content with the following fields:
+      | title            | Post with URI-only link |
+      | field_post_links | http://example.com      |
+    Then I should see the link "http://example.com"
+
+  @test-drupal @api
+  Scenario: Test link field with multiple URI-only values in scalar mode
+    When I am viewing a "post" content with the following fields:
+      | title            | Post with multiple URI-only links      |
+      | field_post_links | http://first.com, http://second.com    |
+    Then I should see the link "http://first.com"
+    And I should see the link "http://second.com"
+
+  @test-drupal @api
+  Scenario: Test link field with a URI-only value using named compound column
+    When I am viewing a "post" content with the following fields:
+      | title            | Post with named URI-only link |
+      | field_post_links | uri:"http://example.com"      |
+    Then I should see the link "http://example.com"
+
+  @test-drupal @api
+  Scenario: Test link field mixing a titled link and a URI-only link in compound mode
+    When I am viewing a "post" content with the following fields:
+      | title            | Post mixing titled and URI-only links                           |
+      | field_post_links | title:"Titled", uri:"http://first.com"; uri:"http://second.com" |
+    Then I should see the link "Titled"
+    And I should see the link "http://second.com"
+
   @test-drupal @api
   Scenario: Test using human readable names for fields using @Transform
     Given the following "page" content:

--- a/tests/behat/features/field_handlers_legacy.feature
+++ b/tests/behat/features/field_handlers_legacy.feature
@@ -42,6 +42,23 @@ Feature: FieldHandlersLegacyParser
       """
 
   @test-drupal @api
+  Scenario: Assert URI-only link value passes under field_parser:legacy
+    Given some behat configuration
+    And the behat configuration uses the legacy field parser
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      When I am viewing a "post" content with the following fields:
+        | title            | Post with URI-only link |
+        | field_post_links | http://example.com      |
+      Then I should see the link "http://example.com"
+      """
+    When I run behat with drupal profile
+    Then it should pass with:
+      """
+      1 scenario (1 passed)
+      """
+
+  @test-drupal @api
   Scenario: Assert quoted entity reference with compound separator passes under field_parser:legacy
     Given some behat configuration
     And the behat configuration uses the legacy field parser


### PR DESCRIPTION
Closes #415

## Summary

Adds integration test coverage for URI-only link field values (links with a URI but no title). The actual upstream fix lives in drupal/drupal-driver PR #313, where `LinkHandler` was updated to wrap a bare string value as `['uri' => $value]` instead of requiring an explicit `uri` key. This PR exercises that fix through Behat scenarios so the behaviour is covered at the drupalextension level.

## Changes

**`tests/behat/features/field_handlers.feature`** - 4 new scenarios:
- Single URI-only value in scalar mode (bare `http://example.com`)
- Multiple URI-only values in scalar mode (comma-separated URIs)
- URI-only value using the named `uri:` compound column
- Mixed scenario: one titled link and one URI-only link in compound mode

**`tests/behat/features/field_handlers_legacy.feature`** - 1 new scenario:
- Confirms the same scalar URI-only mode works under `field_parser:legacy`, running Behat as a subprocess and asserting it passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for link field handling with URI-only inputs, verifying correct rendering of single URIs, multiple comma-separated URIs, and mixed titled and URI-only links.
  * Added legacy field parser regression test to ensure consistent behavior across versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->