### PR TITLE
[#733] Added test coverage and docs for configurable login and logout URLs.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,6 +167,7 @@ Drupal\DrupalExtension:
   text:
     login_url: '/user'
     logout_url: '/user/logout'
+    logout_confirm_url: '/user/logout/confirm'
     log_out: 'Sign out'
     log_in: 'Sign in'
     password_field: 'Enter your password'

--- a/docs/drivers/blackbox.md
+++ b/docs/drivers/blackbox.md
@@ -123,6 +123,7 @@ Drupal\DrupalExtension:
   text:
     login_url: '/user'
     logout_url: '/user/logout'
+    logout_confirm_url: '/user/logout/confirm'
     log_out: 'Sign out'
     log_in: 'Sign in'
     password_field: 'Enter your password'

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -372,6 +372,26 @@ EOL;
   }
 
   /**
+   * Runs behat with the drupal profile and a YAML block of extension config.
+   *
+   * The provided YAML is merged into the Drupal\DrupalExtension config of
+   * the subprocess behat.yml, so nested keys (e.g. 'text.login_url') can
+   * be overridden in a single step.
+   */
+  #[When('I run behat with drupal profile and config:')]
+  public function behatCliRunWithDrupalProfileAndYamlConfig(PyStringNode $config):void {
+    $config_file = $this->workingDir . DIRECTORY_SEPARATOR . 'behat.yml';
+    $yaml = Yaml::parse(file_get_contents($config_file));
+    $overrides = Yaml::parse((string) $config);
+    $yaml['drupal']['extensions']['Drupal\DrupalExtension'] = array_replace_recursive(
+      $yaml['drupal']['extensions']['Drupal\DrupalExtension'] ?? [],
+      $overrides ?? []
+    );
+    file_put_contents($config_file, Yaml::dump($yaml, 4, 2));
+    $this->iRunBehat('--profile=drupal --no-colors');
+  }
+
+  /**
    * Asserts that behat failed with the given RuntimeException.
    */
   #[Then('it should fail with an exception:')]

--- a/tests/behat/features/login_url.feature
+++ b/tests/behat/features/login_url.feature
@@ -1,0 +1,47 @@
+Feature: Login URL
+  As a developer
+  I want to configure custom login and logout URLs
+  So that Behat can authenticate against sites that disable the default '/user' path
+
+  @test-drupal @api
+  Scenario: Assert login and logout succeed with default URLs
+    Given I am logged in as a user with the "authenticated user" role
+    Then I should be logged in on the backend
+    When I log out via the logout url
+    Then I should be logged out on the backend
+
+  @test-drupal @api
+  Scenario: Assert login and logout succeed with custom "login_url" and "logout_url"
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given I am logged in as a user with the "authenticated user" role
+      Then I should be logged in on the backend
+      When I log out via the logout url
+      Then I should be logged out on the backend
+      """
+    When I run behat with drupal profile and config:
+      """
+      text:
+        login_url: /custom-login
+        logout_url: /custom-logout
+        logout_confirm_url: /custom-logout
+      """
+    Then it should pass
+
+  @test-drupal @api
+  Scenario: Assert login fails when "login_url" points to a non-existent path
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given I am logged in as a user with the "authenticated user" role
+      """
+    When I run behat with drupal profile and config:
+      """
+      text:
+        login_url: /does-not-exist
+      """
+    Then it should fail with:
+      """
+      Form field with id|name|label|value|placeholder "Username" not found.
+      """

--- a/tests/behat/fixtures/drupal/modules/behat_test/behat_test.routing.yml
+++ b/tests/behat/fixtures/drupal/modules/behat_test/behat_test.routing.yml
@@ -1,0 +1,15 @@
+behat_test.custom_login:
+  path: '/custom-login'
+  defaults:
+    _form: '\Drupal\user\Form\UserLoginForm'
+    _title: 'Custom log in'
+  requirements:
+    _user_is_logged_in: 'FALSE'
+
+behat_test.custom_logout:
+  path: '/custom-logout'
+  defaults:
+    _form: '\Drupal\user\Form\UserLogoutConfirm'
+    _title: 'Custom log out'
+  requirements:
+    _user_is_logged_in: 'TRUE'

--- a/tests/phpunit/src/Manager/DrupalAuthenticationManagerTest.php
+++ b/tests/phpunit/src/Manager/DrupalAuthenticationManagerTest.php
@@ -563,6 +563,78 @@ class DrupalAuthenticationManagerTest extends TestCase {
   }
 
   /**
+   * Tests that logIn() visits the URL resolved from the 'login_url' config.
+   */
+  public function testLogInVisitsConfiguredLoginUrl(): void {
+    $submit = $this->createMock(NodeElement::class);
+
+    $page = $this->createMock(DocumentElement::class);
+    $page->method('findButton')->with('Log in')->willReturn($submit);
+    $page->method('has')->willReturn(TRUE);
+
+    $session = $this->createSessionMock($page);
+    // @phpstan-ignore method.notFound
+    $session->method('isStarted')->willReturn(TRUE);
+    // @phpstan-ignore method.notFound
+    $session->expects($this->once())->method('visit')->with('http://localhost/custom-login');
+
+    $params = self::DRUPAL_PARAMS;
+    $params['text']['login_url'] = '/custom-login';
+
+    $manager = $this->createManager($session, NULL, NULL, $params);
+    $manager->logIn(new EntityStub('user', NULL, ['name' => 'admin', 'pass' => 'password']));
+  }
+
+  /**
+   * Tests that logout() visits the URL resolved from the 'logout_url' config.
+   */
+  public function testLogoutVisitsConfiguredLogoutUrl(): void {
+    $page = $this->createMock(DocumentElement::class);
+
+    $session = $this->createSessionMock($page);
+    // @phpstan-ignore method.notFound
+    $session->expects($this->once())->method('visit')->with('http://localhost/custom-logout');
+    // @phpstan-ignore method.notFound
+    $session->method('getCurrentUrl')->willReturn('http://localhost/custom-logout');
+
+    $params = self::DRUPAL_PARAMS;
+    $params['text']['logout_url'] = '/custom-logout';
+
+    $user_manager = new DrupalUserManager();
+    $user_manager->setCurrentUser(new EntityStub('user', NULL, ['name' => 'admin']));
+
+    $manager = $this->createManager($session, $user_manager, NULL, $params);
+    $manager->logout();
+    $this->assertFalse($user_manager->getCurrentUser());
+  }
+
+  /**
+   * Tests that logout() recognises the confirm page from 'logout_confirm_url'.
+   */
+  public function testLogoutConfirmUsesConfiguredUrls(): void {
+    $submit = $this->createMock(NodeElement::class);
+    $submit->expects($this->once())->method('click');
+
+    $page = $this->createMock(DocumentElement::class);
+    $page->method('findButton')->with('Log out')->willReturn($submit);
+
+    $session = $this->createSessionMock($page);
+    // @phpstan-ignore method.notFound
+    $session->expects($this->once())->method('visit')->with('http://localhost/custom-logout');
+    // @phpstan-ignore method.notFound
+    $session->method('getCurrentUrl')->willReturn('http://localhost/custom-logout/confirm');
+
+    $params = self::DRUPAL_PARAMS;
+    $params['text']['logout_url'] = '/custom-logout';
+    $params['text']['logout_confirm_url'] = '/custom-logout/confirm';
+
+    $user_manager = new DrupalUserManager();
+    $manager = $this->createManager($session, $user_manager, NULL, $params);
+    $manager->logout();
+    $this->assertFalse($user_manager->getCurrentUser());
+  }
+
+  /**
    * Creates a DrupalAuthenticationManager with optional overrides.
    *
    * @param \Behat\Mink\Session|null $session


### PR DESCRIPTION
Closes #733

## Summary

The login/logout URL configuration (`login_url`, `logout_url`, `logout_confirm_url`) was already implemented in `DrupalAuthenticationManager`, but the existing test suite never asserted that `visit()` was called with the configured paths. A regression that hardcoded `/user` back into the manager would have passed undetected. This PR adds three explicit unit tests that verify each configurable URL is actually used, and adds the missing `logout_confirm_url` entry to the documentation examples.

## Changes

### Test coverage (`tests/phpunit/src/Manager/DrupalAuthenticationManagerTest.php`)

- `testLogInVisitsConfiguredLoginUrl()` - asserts `visit()` is called with the URL resolved from a custom `login_url`
- `testLogoutVisitsConfiguredLogoutUrl()` - asserts `visit()` is called with the URL resolved from a custom `logout_url`
- `testLogoutConfirmUsesConfiguredUrls()` - exercises the confirm-page branch with non-default `logout_url` and `logout_confirm_url`, asserting the button click occurs and the current user is cleared

### Documentation (`docs/configuration.md`, `docs/drivers/blackbox.md`)

- Added the missing `logout_confirm_url` entry to the `text:` YAML examples in both files so all three URL keys are shown together

## Before / After

```
Before: DRUPAL_PARAMS set login/logout URLs in tests but visit() was never asserted
────────────────────────────────────────────────────────────────────────────────────

  DrupalAuthenticationManagerTest
  ├── testLogIn()                          # visited some URL, but which one?
  ├── testLogout()                         # same issue
  └── testLogoutWithConfirmPage()          # same issue

  DrupalAuthenticationManager::logIn()
  └── visit( login_url )  ← no test assertion pinned this call

  docs/configuration.md  text:
  ├── login_url: '/user'
  └── logout_url: '/user/logout'
      (logout_confirm_url omitted)


After: Each configurable URL has a dedicated test that pins the visit() argument
──────────────────────────────────────────────────────────────────────────────────

  DrupalAuthenticationManagerTest
  ├── testLogIn()
  ├── testLogout()
  ├── testLogoutWithConfirmPage()
  ├── testLogInVisitsConfiguredLoginUrl()    ← NEW: visit('/custom-login') asserted
  ├── testLogoutVisitsConfiguredLogoutUrl()  ← NEW: visit('/custom-logout') asserted
  └── testLogoutConfirmUsesConfiguredUrls()  ← NEW: confirm-page branch + both URLs

  docs/configuration.md  text:
  ├── login_url: '/user'
  ├── logout_url: '/user/logout'
  └── logout_confirm_url: '/user/logout/confirm'  ← NEW
```
