### PR TITLE
[#469] Added typed random tokens with '[?name:type,args]' syntax and deprecated '<?name>' form.

### DIFF
--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -17,7 +17,7 @@ declared explicitly.
 | `Drupal\DrupalExtension\Context\ConfigContext` | Steps that read and write Drupal configuration. |
 | `Drupal\DrupalExtension\Context\DrushContext` | Steps that invoke arbitrary Drush commands. |
 | `Drupal\DrupalExtension\Context\MailContext` | Steps that assert against the Drupal mail collector. |
-| `Drupal\DrupalExtension\Context\RandomContext` | Transforms placeholders such as `<?title>` into random strings. Pure Behat context - no Drupal driver, no Mink session. |
+| `Drupal\DrupalExtension\Context\RandomContext` | Transforms typed placeholders such as `[?title]` or `[?id:int,1,99]` into random values. Pure Behat context - no Drupal driver, no Mink session. |
 
 For a complete reference of every step each context exposes, see
 [`STEPS.md`](../STEPS.md).

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -87,7 +87,7 @@ suites.
 
 ### Token grammar
 
-```
+```text
 [?<name>:<type>[,<args>]]
    │      │       │
    │      │       └── type-specific args (length, range, ...)

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -172,6 +172,13 @@ notices with the `suppress_deprecations` configuration key or the
 `BEHAT_DRUPALEXTENSION_SUPPRESS_DEPRECATIONS` environment variable -
 see [Configuration](configuration.md).
 
+The legacy form is processed by separate `Transform` methods on
+`RandomContext` (`transformVariablesLegacy()` /
+`transformTableLegacy()`) which exist purely to host the deprecated
+behaviour. They will be removed together once the legacy form is
+dropped, leaving only the modern `transformVariables()` /
+`transformTable()` pair.
+
 ## Custom step definitions
 
 When the prebuilt steps do not cover a behaviour, write your own. Add

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -75,19 +75,102 @@ for the full list.
 
 ## Random data
 
-`RandomContext` lets you reference random tokens in scenarios. The
-same token used twice resolves to the same value within a single
-scenario:
+`RandomContext` substitutes tokens in step text and table cells with
+random values. The same token reused inside one scenario resolves to
+the same value, so two steps can reference the same generated string,
+machine name, or integer without coordinating.
+
+Add `Drupal\DrupalExtension\Context\RandomContext` to the suite's
+`contexts` list in `behat.yml`. The context has no Drupal driver
+dependency, so it works in both Drupal API suites and pure blackbox
+suites.
+
+### Token grammar
+
+```
+[?<name>:<type>[,<args>]]
+   │      │       │
+   │      │       └── type-specific args (length, range, ...)
+   │      └────────── generator type
+   └───────────────── identity / cache key (same name = same value in a scenario)
+```
+
+`name` is the *identity* - reuse it to get the same value back. `type`
+selects the generator. `args` are passed to the generator. Both `type`
+and `args` are optional; bare `[?title]` is equivalent to
+`[?title:string,10]`.
 
 ```gherkin
 @api
 Scenario: Articles get unique titles
-  Given I am viewing an "article" content with the title "<?title>"
-  Then I should see the heading "<?title>"
+  Given I am viewing an "article" content with the title "[?title]"
+  Then I should see the heading "[?title]"
 ```
 
-Add `Drupal\DrupalExtension\Context\RandomContext` to the
-suite's `contexts` list in `behat.yml`.
+### Built-in types
+
+| Type           | Default         | Example                       | Output shape          |
+| -------------- | --------------- | ----------------------------- | --------------------- |
+| `string`       | length `10`     | `[?title:string,8]`           | `a1b2c3d4`            |
+| `name`         | length `10`     | `[?label:name,6]`             | `Az9Bx2`              |
+| `machine_name` | length `10`     | `[?slug:machine_name,8]`      | `ab_cd_e1`            |
+| `int`          | `0..PHP_INT_MAX`| `[?age:int,18,65]`            | `42`                  |
+| `email`        | -               | `[?contact:email]`            | `abcd1234@efgh.test`  |
+| `uuid`         | -               | `[?id:uuid]`                  | `f47ac10b-58cc-4...`  |
+
+`string`, `name`, and `machine_name` differ in case and allowed
+characters: `string` is lowercase alphanumeric, `name` preserves the
+underlying `Random::name()` casing, and `machine_name` adds underscores.
+
+### Cache equivalence
+
+Tokens that normalise to the same `(name, type, args)` triple share one
+cached value within a scenario:
+
+| Literal                  | Canonical key       |
+| ------------------------ | ------------------- |
+| `[?title]`               | `title:string:10`   |
+| `[?title:string]`        | `title:string:10`   |
+| `[?title:string,10]`     | `title:string:10`   |
+| `<?title>` (legacy)      | `title:string:10`   |
+| `[?title:string,8]`      | `title:string:8`    |
+| `[?title:int]`           | `title:int:0,...`   |
+
+So a feature mid-migration from `<?title>` to `[?title]` resolves both
+literals to the same string, letting you swap one usage at a time.
+
+### Custom types
+
+Add types by extending `RandomContext` and overriding `generate()`:
+
+```php
+<?php
+
+use Drupal\DrupalExtension\Context\RandomContext;
+
+class CustomRandomContext extends RandomContext {
+
+  protected function generate(string $type, array $args): string|int {
+    return match ($type) {
+      'phone' => '+1' . random_int(2000000000, 9999999999),
+      default => parent::generate($type, $args),
+    };
+  }
+
+}
+```
+
+Register `CustomRandomContext` in `behat.yml` instead of `RandomContext`,
+then use `[?primary:phone]` in scenarios.
+
+### Legacy `<?token>` syntax
+
+The original `<?token>` form is still accepted but deprecated. Each
+unique legacy literal triggers a one-time `[Deprecation]` notice on
+`STDERR` pointing at the equivalent `[?token]` replacement. Suppress
+notices with the `suppress_deprecations` configuration key or the
+`BEHAT_DRUPALEXTENSION_SUPPRESS_DEPRECATIONS` environment variable -
+see [Configuration](configuration.md).
 
 ## Custom step definitions
 

--- a/src/Drupal/DrupalExtension/Context/RandomContext.php
+++ b/src/Drupal/DrupalExtension/Context/RandomContext.php
@@ -11,57 +11,89 @@ use Behat\Hook\AfterScenario;
 use Behat\Hook\BeforeScenario;
 use Behat\Transformation\Transform;
 use Drupal\Component\Utility\Random;
+use Drupal\DrupalExtension\DeprecationInterface;
+use Drupal\DrupalExtension\DeprecationTrait;
+use Drupal\DrupalExtension\ParametersAwareInterface;
 
 /**
- * Transform tokens into random variables.
+ * Transforms tokens in step text and tables into random values.
  *
- * Operates purely on Gherkin step text - no Mink session, no Drupal driver.
- * Can be registered in any Behat suite, including ones that load neither
- * 'Drupal\MinkExtension' nor 'Drupal\DrupalExtension'.
+ * Operates purely on Gherkin step text - no Mink session, no Drupal
+ * driver - so it can be registered in any Behat suite, including ones
+ * that load neither 'Drupal\MinkExtension' nor 'Drupal\DrupalExtension'.
+ *
+ * Two token forms are supported:
+ *
+ *   '[?<name>:<type>[,<args>]]' - identity, type, and optional type args.
+ *   '<?<name>>'                 - legacy, deprecated; equivalent to
+ *                                 '[?<name>:string,10]'.
+ *
+ * Each unique token (identity + type + args) resolves once per scenario
+ * and re-using the same literal returns the same value. The default type
+ * is 'string' with length '10', so '[?title]', '[?title:string]', and
+ * the legacy '<?title>' all share the same cached value within a
+ * scenario, easing incremental migration.
+ *
+ * See 'docs/writing-tests.md' for the full list of built-in types.
  */
-class RandomContext implements Context {
+class RandomContext implements Context, ParametersAwareInterface, DeprecationInterface {
+
+  use DeprecationTrait;
+
+  protected const SCAN_REGEX = '#(\[\?[a-z0-9_]+(?::[^\]]+)?\]|\<\?[a-z0-9_]+\>)#i';
 
   /**
-   * Tracks variable names for consistent replacement during a given scenario.
+   * Token literal as it appears in the feature file -> canonical cache key.
+   *
+   * Parsing memo so the same literal does not get re-parsed on every
+   * transform invocation.
    *
    * @var array<string, string>
+   */
+  protected array $literals = [];
+
+  /**
+   * Canonical cache key -> generated value.
+   *
+   * Canonical key is 'name:type:arg1,arg2,...' with defaults applied,
+   * so '[?title]', '[?title:string]', '[?title:string,10]' and the
+   * legacy '<?title>' collapse to the same key.
+   *
+   * @var array<string, string|int>
    */
   protected array $values = [];
 
   /**
-   * Random string generator.
+   * Random string generator (lazy).
    */
-  private ?Random $random = NULL;
+  protected ?Random $random = NULL;
 
   /**
-   * The regex to use for variable replacement.
+   * Transforms tokens inside any step argument that contains one.
    *
-   * This matches placeholders in steps of the form `Given a string <?random>`.
-   */
-  const VARIABLE_REGEX = '#(\<\?.*?\>)#';
-
-  /**
-   * Transform random variables.
+   * The regex is intentionally permissive - the precise scan happens
+   * inside this method; the 'Transform' attribute just routes any
+   * argument that contains a '<?' or '[?' marker through here.
    *
    * @return string|array<int, string>|null
    *   The transformed message.
    */
-  #[Transform('#([^<]*\<\?.*\>[^>]*)#')]
+  #[Transform('#(.*(?:\<\?|\[\?).*)#')]
   public function transformVariables(string $message): string|array|null {
     $patterns = [];
     $replacements = [];
 
-    preg_match_all(static::VARIABLE_REGEX, $message, $matches);
-    foreach ($matches[0] as $variable) {
-      $replacements[] = $this->values[$variable];
-      $patterns[] = '#' . preg_quote($variable) . '#';
+    preg_match_all(self::SCAN_REGEX, $message, $matches);
+    foreach ($matches[0] as $literal) {
+      $patterns[] = '#' . preg_quote($literal) . '#';
+      $replacements[] = (string) $this->resolveLiteral($literal);
     }
 
     return preg_replace($patterns, $replacements, $message);
   }
 
   /**
-   * Transform random variables in table arguments.
+   * Transforms tokens inside table arguments.
    */
   #[Transform('table:*')]
   public function transformTable(TableNode $table): TableNode {
@@ -70,50 +102,221 @@ class RandomContext implements Context {
       $transformed = array_map($this->transformVariables(...), $row);
       $rows[] = array_map(static fn (array|string|null $v): string => is_array($v) ? implode(',', $v) : (string) $v, $transformed);
     }
+
     return new TableNode($rows);
   }
 
   /**
-   * Set values for each random variable found in the current scenario.
+   * Pre-resolves every token literal found in the current scenario.
+   *
+   * Running this in a 'BeforeScenario' hook means the cache is warm by
+   * the time the first step runs, and emitted deprecation messages are
+   * grouped at scenario start instead of interleaved with step output.
    */
   #[BeforeScenario]
   public function beforeScenarioSetVariables(ScenarioScope $scope): void {
+    $this->values = [];
+    $this->literals = [];
+
     $steps = [];
+
     if ($scope->getFeature()->hasBackground()) {
       $steps = $scope->getFeature()->getBackground()->getSteps();
     }
+
     $steps = array_merge($steps, $scope->getScenario()->getSteps());
     foreach ($steps as $step) {
-      preg_match_all(static::VARIABLE_REGEX, $step->getText(), $matches);
-      $variables_found = $matches[0];
-      // Find variables in are TableNodes or PyStringNodes.
+      $haystack = $step->getText();
       $step_argument = $step->getArguments();
+
       if (!empty($step_argument) && $step_argument[0] instanceof TableNode) {
-        preg_match_all(static::VARIABLE_REGEX, $step_argument[0]->getTableAsString(), $matches);
-        $variables_found = array_filter(array_merge($variables_found, $matches[0]));
+        $haystack .= "\n" . $step_argument[0]->getTableAsString();
       }
-      foreach ($variables_found as $variable_found) {
-        if (!isset($this->values[$variable_found])) {
-          $value = $this->getRandom()->name(10);
-          // Value forced to lowercase to ensure it is machine-readable.
-          $this->values[$variable_found] = strtolower((string) $value);
-        }
+
+      preg_match_all(self::SCAN_REGEX, $haystack, $matches);
+      foreach ($matches[0] as $literal) {
+        $this->resolveLiteral($literal);
       }
     }
   }
 
   /**
-   * Reset variables after the scenario.
+   * Clears the per-scenario cache.
    */
   #[AfterScenario]
   public function afterScenarioResetVariables(ScenarioScope $scope): void {
     $this->values = [];
+    $this->literals = [];
+  }
+
+  /**
+   * Resolves a token literal to its generated value.
+   *
+   * On first encounter the literal is parsed, normalised to a canonical
+   * '(name, type, args)' tuple, the value is generated and stored under
+   * the canonical key, and the literal is recorded in the parsing memo
+   * so future lookups are O(1). Legacy '<?...>' literals additionally
+   * trigger a single deprecation notice.
+   */
+  protected function resolveLiteral(string $literal): string|int {
+    if (isset($this->literals[$literal])) {
+      return $this->values[$this->literals[$literal]];
+    }
+
+    [$name, $type, $args, $legacy] = $this->parseToken($literal);
+
+    if ($legacy) {
+      $this->triggerDeprecation(sprintf(
+        'The "%s" token syntax is deprecated. Use "[?%s]" instead.',
+        $literal,
+        $name,
+      ));
+    }
+
+    $args = $this->normaliseArgs($type, $args);
+    $key = $name . ':' . $type . ':' . implode(',', $args);
+    $this->literals[$literal] = $key;
+
+    if (!isset($this->values[$key])) {
+      $this->values[$key] = $this->generate($type, $args);
+    }
+
+    return $this->values[$key];
+  }
+
+  /**
+   * Parses a token literal into '[name, type, args, legacy]'.
+   *
+   * @return array{0: string, 1: string, 2: list<string>, 3: bool}
+   *   Tuple of name, type, args, and legacy flag.
+   */
+  protected function parseToken(string $literal): array {
+    if (str_starts_with($literal, '<?')) {
+      return [substr($literal, 2, -1), 'string', [], TRUE];
+    }
+
+    $body = substr($literal, 2, -1);
+    $colon = strpos($body, ':');
+
+    if ($colon === FALSE) {
+      return [$body, 'string', [], FALSE];
+    }
+
+    $name = substr($body, 0, $colon);
+    $spec = substr($body, $colon + 1);
+    $parts = array_map(trim(...), explode(',', $spec));
+    $type = array_shift($parts);
+
+    return [$name, $type === '' ? 'string' : $type, $parts, FALSE];
+  }
+
+  /**
+   * Fills in defaults so equivalent tokens collapse to the same cache key.
+   *
+   * Each branch returns the canonical args list for the given type.
+   * Unknown types pass through unchanged - 'generate()' will reject them.
+   *
+   * @param string $type
+   *   The generator type extracted from the token.
+   * @param list<string> $args
+   *   Raw args parsed from the token literal.
+   *
+   * @return list<string>
+   *   Args with type-specific defaults applied.
+   */
+  protected function normaliseArgs(string $type, array $args): array {
+    return match ($type) {
+      'string', 'name', 'machine_name' => [$args[0] ?? '10'],
+      'int' => [$args[0] ?? '0', $args[1] ?? (string) PHP_INT_MAX],
+      'email', 'uuid' => [],
+      default => $args,
+    };
+  }
+
+  /**
+   * Dispatches to the type-specific generator.
+   *
+   * @param string $type
+   *   The generator type extracted from the token.
+   * @param list<string> $args
+   *   Already normalised args from 'normaliseArgs()'.
+   *
+   * @return string|int
+   *   The generated value.
+   */
+  protected function generate(string $type, array $args): string|int {
+    return match ($type) {
+      'string' => $this->generateString((int) ($args[0] ?? 10)),
+      'name' => $this->generateName((int) ($args[0] ?? 10)),
+      'machine_name' => $this->generateMachineName((int) ($args[0] ?? 10)),
+      'int' => $this->generateInt((int) ($args[0] ?? 0), (int) ($args[1] ?? PHP_INT_MAX)),
+      'email' => $this->generateEmail(),
+      'uuid' => $this->generateUuid(),
+      default => throw new \InvalidArgumentException(sprintf('Unknown random token type "%s".', $type)),
+    };
+  }
+
+  /**
+   * Generates a lowercase string - the default for unknown shape requests.
+   */
+  protected function generateString(int $length): string {
+    return strtolower((string) $this->getRandom()->name(max(1, $length)));
+  }
+
+  /**
+   * Generates a 'Random::name()' string with original case preserved.
+   */
+  protected function generateName(int $length): string {
+    return (string) $this->getRandom()->name(max(1, $length));
+  }
+
+  /**
+   * Generates a Drupal-shaped machine name (lowercase + underscores).
+   */
+  protected function generateMachineName(int $length): string {
+    return $this->getRandom()->machineName(max(1, $length));
+  }
+
+  /**
+   * Generates a random integer in '[min, max]' inclusive.
+   */
+  protected function generateInt(int $min, int $max): int {
+    if ($min > $max) {
+      [$min, $max] = [$max, $min];
+    }
+
+    return random_int($min, $max);
+  }
+
+  /**
+   * Generates a syntactically valid email at the reserved '.test' TLD.
+   *
+   * RFC 6761 reserves '.test' for testing, so generated addresses can
+   * never collide with real domains.
+   */
+  protected function generateEmail(): string {
+    return strtolower(sprintf(
+      '%s@%s.test',
+      (string) $this->getRandom()->name(8),
+      (string) $this->getRandom()->name(6),
+    ));
+  }
+
+  /**
+   * Generates a UUID v4 string.
+   */
+  protected function generateUuid(): string {
+    $data = random_bytes(16);
+    $data[6] = chr(ord($data[6]) & 0x0f | 0x40);
+    $data[8] = chr(ord($data[8]) & 0x3f | 0x80);
+
+    return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
   }
 
   /**
    * Lazily resolves the random string generator.
    */
-  private function getRandom(): Random {
+  protected function getRandom(): Random {
     return $this->random ??= new Random();
   }
 

--- a/src/Drupal/DrupalExtension/Context/RandomContext.php
+++ b/src/Drupal/DrupalExtension/Context/RandomContext.php
@@ -28,6 +28,12 @@ use Drupal\DrupalExtension\ParametersAwareInterface;
  *   '<?<name>>'                 - legacy, deprecated; equivalent to
  *                                 '[?<name>:string,10]'.
  *
+ * The two forms are processed by separate Transform methods - the modern
+ * pair handles '[?...]', the '*Legacy' pair handles '<?...>' and emits
+ * one '[Deprecation]' notice per unique legacy literal. Splitting the
+ * transforms makes the deprecation surface obvious to anyone scanning
+ * the class: every method on the legacy side will be removed together.
+ *
  * Each unique token (identity + type + args) resolves once per scenario
  * and re-using the same literal returns the same value. The default type
  * is 'string' with length '10', so '[?title]', '[?title:string]', and
@@ -40,7 +46,8 @@ class RandomContext implements Context, ParametersAwareInterface, DeprecationInt
 
   use DeprecationTrait;
 
-  protected const SCAN_REGEX = '#(\[\?[a-z0-9_]+(?::[^\]]+)?\]|\<\?[a-z0-9_]+\>)#i';
+  protected const BRACKET_REGEX = '#(\[\?[a-z0-9_]+(?::[^\]]+)?\])#i';
+  protected const LEGACY_REGEX = '#(\<\?[a-z0-9_]+\>)#i';
 
   /**
    * Token literal as it appears in the feature file -> canonical cache key.
@@ -69,49 +76,64 @@ class RandomContext implements Context, ParametersAwareInterface, DeprecationInt
   protected ?Random $random = NULL;
 
   /**
-   * Transforms tokens inside any step argument that contains one.
-   *
-   * The regex is intentionally permissive - the precise scan happens
-   * inside this method; the 'Transform' attribute just routes any
-   * argument that contains a '<?' or '[?' marker through here.
+   * Substitutes modern '[?...]' tokens inside a step argument.
    *
    * @return string|array<int, string>|null
    *   The transformed message.
    */
-  #[Transform('#(.*(?:\<\?|\[\?).*)#')]
+  #[Transform('#(.*\[\?[a-z0-9_]+(?::[^\]]+)?\].*)#i')]
   public function transformVariables(string $message): string|array|null {
-    $patterns = [];
-    $replacements = [];
-
-    preg_match_all(self::SCAN_REGEX, $message, $matches);
-    foreach ($matches[0] as $literal) {
-      $patterns[] = '#' . preg_quote($literal) . '#';
-      $replacements[] = (string) $this->resolveLiteral($literal);
-    }
-
-    return preg_replace($patterns, $replacements, $message);
+    return $this->substituteWithRegex(self::BRACKET_REGEX, $message);
   }
 
   /**
-   * Transforms tokens inside table arguments.
+   * Substitutes legacy '<?...>' tokens inside a step argument.
+   *
+   * Deprecated path: emits one '[Deprecation]' notice per unique legacy
+   * literal before substituting. Will be removed together with
+   * 'transformTableLegacy()' once the legacy form is dropped.
+   *
+   * @return string|array<int, string>|null
+   *   The transformed message.
+   */
+  #[Transform('#(.*\<\?[a-z0-9_]+\>.*)#i')]
+  public function transformVariablesLegacy(string $message): string|array|null {
+    $this->emitLegacyDeprecations($message);
+
+    return $this->substituteWithRegex(self::LEGACY_REGEX, $message);
+  }
+
+  /**
+   * Substitutes modern '[?...]' tokens inside table cells.
    */
   #[Transform('table:*')]
   public function transformTable(TableNode $table): TableNode {
-    $rows = [];
+    return $this->substituteTableWithRegex(self::BRACKET_REGEX, $table);
+  }
+
+  /**
+   * Substitutes legacy '<?...>' tokens inside table cells.
+   *
+   * Deprecated path - see 'transformVariablesLegacy()'.
+   */
+  #[Transform('table:*')]
+  public function transformTableLegacy(TableNode $table): TableNode {
     foreach ($table->getRows() as $row) {
-      $transformed = array_map($this->transformVariables(...), $row);
-      $rows[] = array_map(static fn (array|string|null $v): string => is_array($v) ? implode(',', $v) : (string) $v, $transformed);
+      foreach ($row as $cell) {
+        $this->emitLegacyDeprecations($cell);
+      }
     }
 
-    return new TableNode($rows);
+    return $this->substituteTableWithRegex(self::LEGACY_REGEX, $table);
   }
 
   /**
    * Pre-resolves every token literal found in the current scenario.
    *
    * Running this in a 'BeforeScenario' hook means the cache is warm by
-   * the time the first step runs, and emitted deprecation messages are
-   * grouped at scenario start instead of interleaved with step output.
+   * the time the first step runs, which keeps repeated literals stable
+   * even when their first occurrence is inside a step argument that
+   * Behat dispatches before the rest are visited.
    */
   #[BeforeScenario]
   public function beforeScenarioSetVariables(ScenarioScope $scope): void {
@@ -133,8 +155,10 @@ class RandomContext implements Context, ParametersAwareInterface, DeprecationInt
         $haystack .= "\n" . $step_argument[0]->getTableAsString();
       }
 
-      preg_match_all(self::SCAN_REGEX, $haystack, $matches);
-      foreach ($matches[0] as $literal) {
+      preg_match_all(self::BRACKET_REGEX, $haystack, $modern);
+      preg_match_all(self::LEGACY_REGEX, $haystack, $legacy);
+
+      foreach (array_merge($modern[0], $legacy[0]) as $literal) {
         $this->resolveLiteral($literal);
       }
     }
@@ -150,29 +174,80 @@ class RandomContext implements Context, ParametersAwareInterface, DeprecationInt
   }
 
   /**
-   * Resolves a token literal to its generated value.
+   * Substitutes every '$regex' match in '$message' via 'resolveLiteral()'.
    *
-   * On first encounter the literal is parsed, normalised to a canonical
-   * '(name, type, args)' tuple, the value is generated and stored under
-   * the canonical key, and the literal is recorded in the parsing memo
-   * so future lookups are O(1). Legacy '<?...>' literals additionally
-   * trigger a single deprecation notice.
+   * Modern and legacy paths share the substitution mechanics; only the
+   * regex that selects which literals to substitute differs.
    */
-  protected function resolveLiteral(string $literal): string|int {
-    if (isset($this->literals[$literal])) {
-      return $this->values[$this->literals[$literal]];
+  protected function substituteWithRegex(string $regex, string $message): string {
+    preg_match_all($regex, $message, $matches);
+
+    if ($matches[0] === []) {
+      return $message;
     }
 
-    [$name, $type, $args, $legacy] = $this->parseToken($literal);
+    $patterns = [];
+    $replacements = [];
+    foreach ($matches[0] as $literal) {
+      $patterns[] = '#' . preg_quote($literal) . '#';
+      $replacements[] = (string) $this->resolveLiteral($literal);
+    }
 
-    if ($legacy) {
+    $result = preg_replace($patterns, $replacements, $message);
+
+    return $result ?? $message;
+  }
+
+  /**
+   * Applies 'substituteWithRegex()' across every cell in '$table'.
+   */
+  protected function substituteTableWithRegex(string $regex, TableNode $table): TableNode {
+    $rows = [];
+    foreach ($table->getRows() as $row) {
+      $rows[] = array_map(fn (string $v): string => $this->substituteWithRegex($regex, $v), $row);
+    }
+
+    return new TableNode($rows);
+  }
+
+  /**
+   * Triggers a one-time deprecation notice per legacy literal in '$message'.
+   *
+   * The trait's process-wide dedup would already collapse repeated calls
+   * with the same message, but we dedup here as well so each unique
+   * literal incurs exactly one 'triggerDeprecation()' call regardless of
+   * how often it appears in a single argument.
+   */
+  protected function emitLegacyDeprecations(string $message): void {
+    preg_match_all(self::LEGACY_REGEX, $message, $matches);
+
+    foreach (array_unique($matches[0]) as $literal) {
+      $name = substr($literal, 2, -1);
       $this->triggerDeprecation(sprintf(
         'The "%s" token syntax is deprecated. Use "[?%s]" instead.',
         $literal,
         $name,
       ));
     }
+  }
 
+  /**
+   * Resolves a token literal to its generated value.
+   *
+   * On first encounter the literal is parsed, normalised to a canonical
+   * '(name, type, args)' tuple, the value is generated and stored under
+   * the canonical key, and the literal is recorded in the parsing memo
+   * so future lookups are O(1). The legacy '<?...>' form does not
+   * trigger a deprecation here - that lives in 'emitLegacyDeprecations()'
+   * so the deprecation is fired by the legacy Transform methods, not by
+   * the shared resolution path that the modern form also calls.
+   */
+  protected function resolveLiteral(string $literal): string|int {
+    if (isset($this->literals[$literal])) {
+      return $this->values[$this->literals[$literal]];
+    }
+
+    [$name, $type, $args] = $this->parseToken($literal);
     $args = $this->normaliseArgs($type, $args);
     $key = $name . ':' . $type . ':' . implode(',', $args);
     $this->literals[$literal] = $key;
@@ -185,21 +260,26 @@ class RandomContext implements Context, ParametersAwareInterface, DeprecationInt
   }
 
   /**
-   * Parses a token literal into '[name, type, args, legacy]'.
+   * Parses a token literal into '[name, type, args]'.
    *
-   * @return array{0: string, 1: string, 2: list<string>, 3: bool}
-   *   Tuple of name, type, args, and legacy flag.
+   * The legacy '<?name>' form is folded into the same '(name, string, [])'
+   * tuple as a bare '[?name]' so the resolver does not need to special-case
+   * it. Deprecation emission is handled separately in the legacy Transform
+   * methods.
+   *
+   * @return array{0: string, 1: string, 2: list<string>}
+   *   Tuple of name, type, and args.
    */
   protected function parseToken(string $literal): array {
     if (str_starts_with($literal, '<?')) {
-      return [substr($literal, 2, -1), 'string', [], TRUE];
+      return [substr($literal, 2, -1), 'string', []];
     }
 
     $body = substr($literal, 2, -1);
     $colon = strpos($body, ':');
 
     if ($colon === FALSE) {
-      return [$body, 'string', [], FALSE];
+      return [$body, 'string', []];
     }
 
     $name = substr($body, 0, $colon);
@@ -207,7 +287,7 @@ class RandomContext implements Context, ParametersAwareInterface, DeprecationInt
     $parts = array_map(trim(...), explode(',', $spec));
     $type = array_shift($parts);
 
-    return [$name, $type === '' ? 'string' : $type, $parts, FALSE];
+    return [$name, $type === '' ? 'string' : $type, $parts];
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Context/RandomContext.php
+++ b/src/Drupal/DrupalExtension/Context/RandomContext.php
@@ -291,10 +291,13 @@ class RandomContext implements Context, ParametersAwareInterface, DeprecationInt
   }
 
   /**
-   * Fills in defaults so equivalent tokens collapse to the same cache key.
+   * Validates and fills defaults so equivalent tokens share a cache key.
    *
-   * Each branch returns the canonical args list for the given type.
-   * Unknown types pass through unchanged - 'generate()' will reject them.
+   * Each branch returns the canonical args list for the given type, or
+   * throws 'InvalidArgumentException' when the literal supplies malformed
+   * input (non-integer length, wrong arg count, extra args on argless
+   * types). Failing fast prevents typos like '[?title:string,abc]' from
+   * silently producing a 1-character string.
    *
    * @param string $type
    *   The generator type extracted from the token.
@@ -306,15 +309,91 @@ class RandomContext implements Context, ParametersAwareInterface, DeprecationInt
    */
   protected function normaliseArgs(string $type, array $args): array {
     return match ($type) {
-      'string', 'name', 'machine_name' => [$args[0] ?? '10'],
-      'int' => [$args[0] ?? '0', $args[1] ?? (string) PHP_INT_MAX],
-      'email', 'uuid' => [],
+      'string', 'name', 'machine_name' => $this->normaliseLengthArgs($type, $args),
+      'int' => $this->normaliseIntArgs($args),
+      'email', 'uuid' => $this->normaliseArglessArgs($type, $args),
       default => $args,
     };
   }
 
   /**
+   * Validates length-style args (one optional non-negative integer).
+   *
+   * @param string $type
+   *   The generator type, used for error messages.
+   * @param list<string> $args
+   *   Raw args parsed from the token literal.
+   *
+   * @return list<string>
+   *   Args with the default length filled in if absent.
+   */
+  protected function normaliseLengthArgs(string $type, array $args): array {
+    if (count($args) > 1) {
+      throw new \InvalidArgumentException(sprintf('Type "%s" accepts at most one argument (length); got %d.', $type, count($args)));
+    }
+
+    if (!isset($args[0])) {
+      return ['10'];
+    }
+
+    if (!ctype_digit($args[0])) {
+      throw new \InvalidArgumentException(sprintf('Type "%s" length must be a non-negative integer; got "%s".', $type, $args[0]));
+    }
+
+    return [$args[0]];
+  }
+
+  /**
+   * Validates 'int' args (zero args for full range, or two integer bounds).
+   *
+   * @param list<string> $args
+   *   Raw args parsed from the token literal.
+   *
+   * @return list<string>
+   *   Args with default range filled in if absent.
+   */
+  protected function normaliseIntArgs(array $args): array {
+    if ($args === []) {
+      return ['0', (string) PHP_INT_MAX];
+    }
+
+    if (count($args) !== 2) {
+      throw new \InvalidArgumentException(sprintf('Type "int" accepts no args (full range) or two args (min, max); got %d.', count($args)));
+    }
+
+    foreach ($args as $arg) {
+      if (preg_match('/^-?\d+$/', $arg) !== 1) {
+        throw new \InvalidArgumentException(sprintf('Type "int" args must be integers; got "%s".', $arg));
+      }
+    }
+
+    return [$args[0], $args[1]];
+  }
+
+  /**
+   * Validates argless types ('email', 'uuid'): refuses any positional args.
+   *
+   * @param string $type
+   *   The generator type, used for error messages.
+   * @param list<string> $args
+   *   Raw args parsed from the token literal.
+   *
+   * @return list<string>
+   *   Always empty.
+   */
+  protected function normaliseArglessArgs(string $type, array $args): array {
+    if ($args !== []) {
+      throw new \InvalidArgumentException(sprintf('Type "%s" does not accept arguments; got %d.', $type, count($args)));
+    }
+
+    return [];
+  }
+
+  /**
    * Dispatches to the type-specific generator.
+   *
+   * Args are validated by 'normaliseArgs()' before reaching this method,
+   * so the casts are safe and not a fallback.
    *
    * @param string $type
    *   The generator type extracted from the token.
@@ -326,10 +405,10 @@ class RandomContext implements Context, ParametersAwareInterface, DeprecationInt
    */
   protected function generate(string $type, array $args): string|int {
     return match ($type) {
-      'string' => $this->generateString((int) ($args[0] ?? 10)),
-      'name' => $this->generateName((int) ($args[0] ?? 10)),
-      'machine_name' => $this->generateMachineName((int) ($args[0] ?? 10)),
-      'int' => $this->generateInt((int) ($args[0] ?? 0), (int) ($args[1] ?? PHP_INT_MAX)),
+      'string' => $this->generateString((int) $args[0]),
+      'name' => $this->generateName((int) $args[0]),
+      'machine_name' => $this->generateMachineName((int) $args[0]),
+      'int' => $this->generateInt((int) $args[0], (int) $args[1]),
       'email' => $this->generateEmail(),
       'uuid' => $this->generateUuid(),
       default => throw new \InvalidArgumentException(sprintf('Unknown random token type "%s".', $type)),

--- a/tests/behat/features/random.feature
+++ b/tests/behat/features/random.feature
@@ -65,3 +65,100 @@ Feature: RandomContext functionality
       """
     When I run behat
     Then it should fail
+
+  # The scenarios below cover the modern '[?<name>:<type>[,<args>]]' form.
+
+  @test-drupal @api @random
+  Scenario: Assert "[?user]" transform passes for user creation
+    Given I am at "/user/register"
+    And I fill in "Email address" with "[?user]@example.com"
+    And I fill in "Username" with "[?user]"
+    When I press "Create new account"
+    Then there should be a total of 1 email sent to "[?user]@example.com" with the subject "Account details for [?user]"
+
+  @test-drupal @api @random
+  Scenario: Assert "[?random_page]" transform passes in tables
+    Given I am viewing a page with the following fields:
+      | title | [?random_page] |
+    Then I should see the text "[?random_page]"
+
+  @test-drupal @api @random
+  Scenario: Assert legacy "<?title>" and modern "[?title]" share the same value
+    Given I am viewing a page with the following fields:
+      | title | <?title> |
+    Then I should see the text "[?title]"
+
+  @test-drupal @api @random
+  Scenario: Assert typed "[?slug:machine_name,8]" produces machine-name shape
+    Given I am viewing a page with the following fields:
+      | title | prefix-[?slug:machine_name,8]-suffix |
+    Then I should see the text "[?slug:machine_name,8]"
+
+  @test-blackbox @random
+  Scenario: Assert "[?token]" transform passes in blackbox profile
+    Given some behat configuration
+    And scenario steps tagged with "@test-blackbox @random":
+      """
+      Given I am at "index.html"
+      Then I should not see the text "[?token]"
+      """
+    When I run behat
+    Then it should pass with:
+      """
+      1 scenario (1 passed)
+      """
+
+  @test-blackbox @random
+  Scenario: Assert "[?token]" transform fails when token text expected
+    Given some behat configuration
+    And scenario steps tagged with "@test-blackbox @random":
+      """
+      Given I am at "index.html"
+      Then I should see the text "[?token]"
+      """
+    When I run behat
+    Then it should fail
+
+  @test-blackbox @random
+  Scenario: Assert "[?slug:machine_name,8]" produces machine-name shape under blackbox
+    Given some behat configuration
+    And scenario steps tagged with "@test-blackbox @random":
+      """
+      Given I am at "index.html"
+      Then I should not see the text "[?slug:machine_name,8]"
+      """
+    When I run behat
+    Then it should pass with:
+      """
+      1 scenario (1 passed)
+      """
+
+  # Legacy '<?token>' deprecation assertions.
+
+  @test-blackbox @random
+  Scenario: Assert legacy "<?token>" triggers a deprecation
+    Given some behat configuration
+    And scenario steps tagged with "@test-blackbox @random":
+      """
+      Given I am at "index.html"
+      Then I should not see the text "<?token>"
+      """
+    When I run behat
+    Then the output should contain:
+      """
+      [Deprecation] The "<?token>" token syntax is deprecated. Use "[?token]" instead.
+      """
+
+  @test-blackbox @random
+  Scenario: Assert modern "[?token]" does not trigger a deprecation
+    Given some behat configuration
+    And scenario steps tagged with "@test-blackbox @random":
+      """
+      Given I am at "index.html"
+      Then I should not see the text "[?token]"
+      """
+    When I run behat
+    Then the output should not contain:
+      """
+      [Deprecation]
+      """

--- a/tests/phpunit/src/RandomContextTest.php
+++ b/tests/phpunit/src/RandomContextTest.php
@@ -68,10 +68,10 @@ class RandomContextTest extends TestCase {
   }
 
   /**
-   * Tests substitution covers both legacy and new token forms.
+   * Tests modern '[?...]' substitution via 'transformVariables()'.
    *
    * @param string $message
-   *   The input message containing one or more tokens.
+   *   The input message containing one or more modern tokens.
    * @param string $pattern
    *   Regex the substituted output must match end-to-end.
    * @param int $expected_substitutions
@@ -88,20 +88,17 @@ class RandomContextTest extends TestCase {
   /**
    * Provides cases for testTransformVariablesSubstitutesTokens().
    *
-   * Pattern is anchored end-to-end so a wrongly-substituted output fails.
+   * Modern-form inputs only - legacy '<?...>' is covered separately by
+   * 'testTransformVariablesLegacySubstitutesTokens()'. Pattern is anchored
+   * end-to-end so a wrongly-substituted output fails.
    */
   public static function dataProviderTransformVariablesSubstitutesTokens(): \Iterator {
-    yield 'legacy token resolves to lowercase 10-char string' => [
-      'value: <?token>',
-      '/^value: [a-z0-9]{10}$/',
-      1,
-    ];
-    yield 'new bare token resolves to lowercase 10-char string' => [
+    yield 'bare token resolves to lowercase 10-char string' => [
       'value: [?token]',
       '/^value: [a-z0-9]{10}$/',
       1,
     ];
-    yield 'new typed token with explicit length' => [
+    yield 'typed token with explicit length' => [
       'value: [?token:string,5]',
       '/^value: [a-z0-9]{5}$/',
       1,
@@ -134,6 +131,43 @@ class RandomContextTest extends TestCase {
   }
 
   /**
+   * Tests legacy '<?...>' substitution via 'transformVariablesLegacy()'.
+   *
+   * Asserts both that the substitution works and that exactly one
+   * deprecation message is captured per unique legacy literal.
+   *
+   * @param string $message
+   *   The input message containing legacy tokens.
+   * @param string $pattern
+   *   Regex the substituted output must match end-to-end.
+   * @param int $expected_deprecations
+   *   How many '[Deprecation]' notices should be captured.
+   */
+  #[DataProvider('dataProviderTransformVariablesLegacySubstitutesTokens')]
+  public function testTransformVariablesLegacySubstitutesTokens(string $message, string $pattern, int $expected_deprecations): void {
+    $output = $this->context->transformVariablesLegacy($message);
+    $this->assertIsString($output);
+    $this->assertMatchesRegularExpression($pattern, $output);
+    $this->assertCount($expected_deprecations, $this->context->capturedDeprecations);
+  }
+
+  /**
+   * Provides cases for testTransformVariablesLegacySubstitutesTokens().
+   */
+  public static function dataProviderTransformVariablesLegacySubstitutesTokens(): \Iterator {
+    yield 'single legacy token resolves and emits one deprecation' => [
+      'value: <?token>',
+      '/^value: [a-z0-9]{10}$/',
+      1,
+    ];
+    yield 'two distinct legacy tokens emit two deprecations' => [
+      '<?one> and <?two>',
+      '/^[a-z0-9]{10} and [a-z0-9]{10}$/',
+      2,
+    ];
+  }
+
+  /**
    * Tests that equivalent token forms collapse to the same canonical value.
    *
    * Default 'string' / length '10' means '[?title]', '[?title:string]',
@@ -142,9 +176,10 @@ class RandomContextTest extends TestCase {
    * that lets users migrate one literal at a time.
    */
   public function testEquivalentFormsShareTheSameValue(): void {
-    $output = $this->context->transformVariables(
-      '<?title> [?title] [?title:string] [?title:string,10]'
-    );
+    $message = '<?title> [?title] [?title:string] [?title:string,10]';
+    $modern = $this->context->transformVariables($message);
+    $this->assertIsString($modern);
+    $output = $this->context->transformVariablesLegacy($modern);
     $this->assertIsString($output);
 
     $parts = explode(' ', $output);
@@ -174,12 +209,12 @@ class RandomContextTest extends TestCase {
   }
 
   /**
-   * Tests that 'transformTable()' substitutes tokens in cells.
+   * Tests that 'transformTable()' substitutes modern tokens in cells.
    */
-  public function testTransformTableSubstitutesTokensInCells(): void {
+  public function testTransformTableSubstitutesModernTokensInCells(): void {
     $table = new TableNode([
       ['title', 'value'],
-      ['<?legacy>', '[?modern]'],
+      ['[?one]', '[?two]'],
     ]);
 
     $transformed = $this->context->transformTable($table);
@@ -189,6 +224,25 @@ class RandomContextTest extends TestCase {
     $this->assertMatchesRegularExpression('/^[a-z0-9]{10}$/', $rows[1][0]);
     $this->assertMatchesRegularExpression('/^[a-z0-9]{10}$/', $rows[1][1]);
     $this->assertNotSame($rows[1][0], $rows[1][1]);
+    $this->assertSame([], $this->context->capturedDeprecations);
+  }
+
+  /**
+   * Tests that 'transformTableLegacy()' substitutes and emits deprecations.
+   */
+  public function testTransformTableLegacySubstitutesAndDeprecates(): void {
+    $table = new TableNode([
+      ['title', 'value'],
+      ['<?one>', '<?two>'],
+    ]);
+
+    $transformed = $this->context->transformTableLegacy($table);
+    $rows = $transformed->getRows();
+
+    $this->assertSame(['title', 'value'], $rows[0]);
+    $this->assertMatchesRegularExpression('/^[a-z0-9]{10}$/', $rows[1][0]);
+    $this->assertMatchesRegularExpression('/^[a-z0-9]{10}$/', $rows[1][1]);
+    $this->assertCount(2, $this->context->capturedDeprecations);
   }
 
   /**
@@ -254,10 +308,11 @@ class RandomContextTest extends TestCase {
    *
    * The trait's process-wide dedup means each unique message fires only
    * once, so two uses of '<?token>' produce one notice but '<?one>' plus
-   * '<?two>' produce two.
+   * '<?two>' produce two. Deprecation is the legacy Transform method's
+   * responsibility - 'resolveLiteral()' must not fire on its own.
    */
-  public function testLegacyLiteralsTriggerDeprecation(): void {
-    $this->context->transformVariables('<?one> <?two> <?one>');
+  public function testLegacyTransformTriggersDeprecation(): void {
+    $this->context->transformVariablesLegacy('<?one> <?two> <?one>');
     $messages = $this->context->capturedDeprecations;
 
     $this->assertCount(2, $messages);
@@ -268,10 +323,29 @@ class RandomContextTest extends TestCase {
   }
 
   /**
-   * Tests that new-form tokens never trigger deprecations.
+   * Tests that the modern Transform method never emits a deprecation.
    */
-  public function testModernLiteralsDoNotTriggerDeprecation(): void {
+  public function testModernTransformDoesNotTriggerDeprecation(): void {
     $this->context->transformVariables('[?one] [?two:int,1,9]');
+
+    $this->assertSame([], $this->context->capturedDeprecations);
+  }
+
+  /**
+   * Tests that scenario pre-resolution does not emit deprecations.
+   *
+   * The 'BeforeScenario' hook warms the cache via 'resolveLiteral()'; if
+   * deprecation lived there, every legacy literal in a feature would fire
+   * a notice before any step ran. The legacy Transform methods are the
+   * single source of deprecation emission.
+   */
+  public function testBeforeScenarioDoesNotTriggerDeprecation(): void {
+    $scope = $this->createScenarioScope([
+      new StepNode('Given', 'a string <?legacy>', [], 1),
+      new StepNode('Then', '[?modern]', [], 2),
+    ]);
+
+    $this->context->beforeScenarioSetVariables($scope);
 
     $this->assertSame([], $this->context->capturedDeprecations);
   }

--- a/tests/phpunit/src/RandomContextTest.php
+++ b/tests/phpunit/src/RandomContextTest.php
@@ -12,6 +12,8 @@ use Behat\Gherkin\Node\ScenarioNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
 use Drupal\DrupalExtension\Context\RandomContext;
+use Drupal\DrupalExtension\DeprecationInterface;
+use Drupal\DrupalExtension\ParametersAwareInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -27,21 +29,27 @@ use PHPUnit\Framework\TestCase;
 class RandomContextTest extends TestCase {
 
   /**
-   * The context under test.
+   * The context under test - a subclass that captures deprecations.
    */
-  protected RandomContext $context;
+  protected RecordingRandomContext $context;
 
   /**
-   * Reflection of the protected $values property.
+   * Reflection of the protected $values property (canonical key -> value).
    */
   protected \ReflectionProperty $valuesProperty;
+
+  /**
+   * Reflection of the protected $literals property (literal -> canonical).
+   */
+  protected \ReflectionProperty $literalsProperty;
 
   /**
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    $this->context = new RandomContext();
+    $this->context = new RecordingRandomContext();
     $this->valuesProperty = new \ReflectionProperty(RandomContext::class, 'values');
+    $this->literalsProperty = new \ReflectionProperty(RandomContext::class, 'literals');
   }
 
   /**
@@ -52,160 +60,234 @@ class RandomContextTest extends TestCase {
    * register Mink or the Drupal extension.
    */
   public function testImplementsBareBehatContextWithoutAncestors(): void {
-    $this->assertInstanceOf(Context::class, $this->context);
-    $this->assertSame([], class_parents($this->context));
+    $context = new RandomContext();
+    $this->assertInstanceOf(Context::class, $context);
+    $this->assertInstanceOf(ParametersAwareInterface::class, $context);
+    $this->assertInstanceOf(DeprecationInterface::class, $context);
+    $this->assertSame([], class_parents($context));
   }
 
   /**
-   * Tests 'transformVariables()' substitution behaviour.
+   * Tests substitution covers both legacy and new token forms.
    *
-   * @param array<string, string> $values
-   *   Token-to-value map to seed before invoking the transform.
    * @param string $message
-   *   The input message to transform.
-   * @param string $expected
-   *   The expected message after substitution.
+   *   The input message containing one or more tokens.
+   * @param string $pattern
+   *   Regex the substituted output must match end-to-end.
+   * @param int $expected_substitutions
+   *   How many distinct token literals should be present in the output map.
    */
-  #[DataProvider('dataProviderTransformVariables')]
-  public function testTransformVariables(array $values, string $message, string $expected): void {
-    $this->valuesProperty->setValue($this->context, $values);
-    $this->assertSame($expected, $this->context->transformVariables($message));
+  #[DataProvider('dataProviderTransformVariablesSubstitutesTokens')]
+  public function testTransformVariablesSubstitutesTokens(string $message, string $pattern, int $expected_substitutions): void {
+    $output = $this->context->transformVariables($message);
+    $this->assertIsString($output);
+    $this->assertMatchesRegularExpression($pattern, $output);
+    $this->assertCount($expected_substitutions, $this->literalsProperty->getValue($this->context));
   }
 
   /**
-   * Provides data for testTransformVariables().
+   * Provides cases for testTransformVariablesSubstitutesTokens().
    *
-   * @return \Iterator<string, array{array<string, string>, string, string}>
-   *   Cases keyed by description, each [stored values, input message,
-   *   expected output].
+   * Pattern is anchored end-to-end so a wrongly-substituted output fails.
    */
-  public static function dataProviderTransformVariables(): \Iterator {
-    yield 'no tokens returns input unchanged' => [
-      [],
-      'plain text',
-      'plain text',
-    ];
-    yield 'single token is substituted' => [
-      ['<?token>' => 'abcdef'],
+  public static function dataProviderTransformVariablesSubstitutesTokens(): \Iterator {
+    yield 'legacy token resolves to lowercase 10-char string' => [
       'value: <?token>',
-      'value: abcdef',
+      '/^value: [a-z0-9]{10}$/',
+      1,
     ];
-    yield 'repeated token resolves to same value' => [
-      ['<?token>' => 'abcdef'],
-      '<?token> and <?token>',
-      'abcdef and abcdef',
+    yield 'new bare token resolves to lowercase 10-char string' => [
+      'value: [?token]',
+      '/^value: [a-z0-9]{10}$/',
+      1,
     ];
-    yield 'distinct tokens resolve to their own values' => [
-      ['<?one>' => 'aaaaaa', '<?two>' => 'bbbbbb'],
-      '<?one> and <?two>',
-      'aaaaaa and bbbbbb',
+    yield 'new typed token with explicit length' => [
+      'value: [?token:string,5]',
+      '/^value: [a-z0-9]{5}$/',
+      1,
     ];
-    yield 'surrounding characters are preserved' => [
-      ['<?abc>' => 'value'],
-      '[<?abc>]',
-      '[value]',
+    yield 'machine_name produces snake-shaped string' => [
+      'value: [?slug:machine_name,8]',
+      '/^value: [a-z0-9_]{8}$/',
+      1,
     ];
-    yield 'identifier with underscore is supported' => [
-      ['<?my_token>' => 'value'],
-      'see <?my_token>',
-      'see value',
+    yield 'int produces digits within range' => [
+      'value: [?age:int,18,65]',
+      '/^value: (1[89]|[2-5]\d|6[0-5])$/',
+      1,
     ];
+    yield 'email produces address at .test' => [
+      'value: [?contact:email]',
+      '/^value: [a-z0-9]+@[a-z0-9]+\.test$/',
+      1,
+    ];
+    yield 'uuid produces v4 hex' => [
+      'value: [?id:uuid]',
+      '/^value: [0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+      1,
+    ];
+    yield 'two distinct names yield two distinct cache entries' => [
+      '[?one] and [?two]',
+      '/^[a-z0-9]{10} and [a-z0-9]{10}$/',
+      2,
+    ];
+  }
+
+  /**
+   * Tests that equivalent token forms collapse to the same canonical value.
+   *
+   * Default 'string' / length '10' means '[?title]', '[?title:string]',
+   * '[?title:string,10]', and the legacy '<?title>' must all resolve to
+   * the same string within one scenario - this is the back-compat lever
+   * that lets users migrate one literal at a time.
+   */
+  public function testEquivalentFormsShareTheSameValue(): void {
+    $output = $this->context->transformVariables(
+      '<?title> [?title] [?title:string] [?title:string,10]'
+    );
+    $this->assertIsString($output);
+
+    $parts = explode(' ', $output);
+    $this->assertCount(4, $parts);
+    $this->assertSame([$parts[0]], array_unique($parts));
+  }
+
+  /**
+   * Tests that distinct types under the same name yield distinct values.
+   */
+  public function testDistinctTypesUnderSameNameDoNotCollide(): void {
+    $output = $this->context->transformVariables('[?id] [?id:int,1,9999]');
+    $this->assertIsString($output);
+
+    [$default, $integer] = explode(' ', $output);
+    $this->assertMatchesRegularExpression('/^[a-z0-9]{10}$/', $default);
+    $this->assertMatchesRegularExpression('/^[1-9]\d{0,3}$/', $integer);
+  }
+
+  /**
+   * Tests that an unknown type raises a clear error.
+   */
+  public function testUnknownTypeThrows(): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('Unknown random token type "nope"');
+    $this->context->transformVariables('[?x:nope]');
   }
 
   /**
    * Tests that 'transformTable()' substitutes tokens in cells.
    */
   public function testTransformTableSubstitutesTokensInCells(): void {
-    $this->valuesProperty->setValue($this->context, ['<?title>' => 'mytitle']);
-
     $table = new TableNode([
       ['title', 'value'],
-      ['<?title>', 'static'],
+      ['<?legacy>', '[?modern]'],
     ]);
 
     $transformed = $this->context->transformTable($table);
+    $rows = $transformed->getRows();
 
-    $this->assertSame([
-      ['title', 'value'],
-      ['mytitle', 'static'],
-    ], $transformed->getRows());
+    $this->assertSame(['title', 'value'], $rows[0]);
+    $this->assertMatchesRegularExpression('/^[a-z0-9]{10}$/', $rows[1][0]);
+    $this->assertMatchesRegularExpression('/^[a-z0-9]{10}$/', $rows[1][1]);
+    $this->assertNotSame($rows[1][0], $rows[1][1]);
   }
 
   /**
-   * Tests that 'beforeScenarioSetVariables()' collects tokens from steps.
+   * Tests scenario pre-resolution covers steps, tables, and backgrounds.
    *
-   * Covers tokens in step text, in 'TableNode' step arguments, and in
-   * background steps; same-token reuse and distinct-token uniqueness.
+   * Each entry asserts the canonical cache keys produced after the hook
+   * runs, which is the post-normalisation contract.
    *
-   * @param list<string> $expected_tokens
-   *   Tokens expected to be present in the populated values map, in
-   *   order of first appearance.
+   * @param list<string> $expected_keys
+   *   Canonical keys that should be present in the values map.
    * @param list<\Behat\Gherkin\Node\StepNode> $scenario_steps
    *   Scenario steps to attach to the constructed scope.
    * @param list<\Behat\Gherkin\Node\StepNode>|null $background_steps
    *   Optional background steps; NULL omits the background.
    */
   #[DataProvider('dataProviderBeforeScenarioCollectsTokens')]
-  public function testBeforeScenarioCollectsTokens(array $expected_tokens, array $scenario_steps, ?array $background_steps = NULL): void {
+  public function testBeforeScenarioCollectsTokens(array $expected_keys, array $scenario_steps, ?array $background_steps = NULL): void {
     $background = $background_steps === NULL ? NULL : new BackgroundNode(NULL, $background_steps, 'Background', 1);
     $scope = $this->createScenarioScope($scenario_steps, $background);
 
     $this->context->beforeScenarioSetVariables($scope);
     $values = $this->valuesProperty->getValue($this->context);
 
-    $this->assertSame($expected_tokens, array_keys($values));
-    foreach ($values as $value) {
-      $this->assertMatchesRegularExpression('/^[a-z0-9]{10}$/', (string) $value);
-    }
-    if (count($expected_tokens) > 1) {
-      $this->assertSame(count($expected_tokens), count(array_unique($values)));
-    }
+    $this->assertSame($expected_keys, array_keys($values));
   }
 
   /**
-   * Provides data for testBeforeScenarioCollectsTokens().
-   *
-   * @return \Iterator<string, array{0: list<string>, 1: list<\Behat\Gherkin\Node\StepNode>, 2?: list<\Behat\Gherkin\Node\StepNode>|null}>
-   *   Cases keyed by description, each [expected token list, scenario
-   *   steps, optional background steps].
+   * Provides cases for testBeforeScenarioCollectsTokens().
    */
   public static function dataProviderBeforeScenarioCollectsTokens(): \Iterator {
-    yield 'token in scenario step text' => [
-      ['<?token>'],
+    yield 'legacy token in step text' => [
+      ['token:string:10'],
       [new StepNode('Given', 'a string <?token>', [], 1)],
     ];
-    yield 'repeated token across steps reuses one value' => [
-      ['<?token>'],
+    yield 'new bare token in step text' => [
+      ['token:string:10'],
+      [new StepNode('Given', 'a string [?token]', [], 1)],
+    ];
+    yield 'mixed legacy and new with same name share one key' => [
+      ['token:string:10'],
       [
-        new StepNode('Given', 'a string <?token>', [], 1),
-        new StepNode('Then', 'I see <?token>', [], 2),
+        new StepNode('Given', 'first <?token>', [], 1),
+        new StepNode('Then', 'second [?token]', [], 2),
       ],
     ];
-    yield 'distinct tokens in one step yield distinct values' => [
-      ['<?one>', '<?two>'],
-      [new StepNode('Given', '<?one> and <?two>', [], 1)],
+    yield 'distinct names produce distinct keys' => [
+      ['one:string:10', 'two:string:10'],
+      [new StepNode('Given', '[?one] and [?two]', [], 1)],
     ];
-    yield 'token in TableNode step argument is picked up' => [
-      ['<?random_page>'],
-      [new StepNode('Given', 'a page with the following fields:', [new TableNode([['title', '<?random_page>']])], 1)],
+    yield 'typed token in TableNode argument is picked up' => [
+      ['slug:machine_name:6'],
+      [new StepNode('Given', 'a page with the following fields:', [new TableNode([['title', '[?slug:machine_name,6]']])], 1)],
     ];
-    yield 'tokens in background and scenario steps are merged' => [
-      ['<?from_background>', '<?from_scenario>'],
-      [new StepNode('Then', '<?from_scenario>', [], 2)],
+    yield 'tokens in background and scenario are merged' => [
+      ['from_background:string:10', 'from_scenario:string:10'],
+      [new StepNode('Then', '[?from_scenario]', [], 2)],
       [new StepNode('Given', '<?from_background>', [], 1)],
     ];
   }
 
   /**
-   * Tests that 'afterScenarioResetVariables()' clears the stored map.
+   * Tests that legacy literals trigger one deprecation each.
+   *
+   * The trait's process-wide dedup means each unique message fires only
+   * once, so two uses of '<?token>' produce one notice but '<?one>' plus
+   * '<?two>' produce two.
+   */
+  public function testLegacyLiteralsTriggerDeprecation(): void {
+    $this->context->transformVariables('<?one> <?two> <?one>');
+    $messages = $this->context->capturedDeprecations;
+
+    $this->assertCount(2, $messages);
+    $this->assertStringContainsString('"<?one>" token syntax is deprecated', $messages[0]);
+    $this->assertStringContainsString('Use "[?one]" instead', $messages[0]);
+    $this->assertStringContainsString('"<?two>" token syntax is deprecated', $messages[1]);
+    $this->assertStringContainsString('Use "[?two]" instead', $messages[1]);
+  }
+
+  /**
+   * Tests that new-form tokens never trigger deprecations.
+   */
+  public function testModernLiteralsDoNotTriggerDeprecation(): void {
+    $this->context->transformVariables('[?one] [?two:int,1,9]');
+
+    $this->assertSame([], $this->context->capturedDeprecations);
+  }
+
+  /**
+   * Tests that 'afterScenarioResetVariables()' clears the caches.
    */
   public function testAfterScenarioClearsValues(): void {
-    $this->valuesProperty->setValue($this->context, ['<?token>' => 'abcdef']);
+    $this->context->transformVariables('[?token]');
+    $this->assertNotSame([], $this->valuesProperty->getValue($this->context));
 
     $scope = $this->createScenarioScope([]);
     $this->context->afterScenarioResetVariables($scope);
 
     $this->assertSame([], $this->valuesProperty->getValue($this->context));
+    $this->assertSame([], $this->literalsProperty->getValue($this->context));
   }
 
   /**
@@ -235,6 +317,32 @@ class RandomContextTest extends TestCase {
     $scope->method('getScenario')->willReturn($scenario);
 
     return $scope;
+  }
+
+}
+
+/**
+ * Subclass that records deprecations instead of writing to 'STDERR'.
+ *
+ * 'DeprecationTrait::triggerDeprecation()' writes through 'fwrite(STDERR,
+ * ...)' which sidesteps PHP output buffering, so capturing it from a
+ * unit test is awkward. Overriding the method is the simplest hook.
+ */
+// phpcs:ignore Drupal.Classes.ClassFileName.NoMatch
+class RecordingRandomContext extends RandomContext {
+
+  /**
+   * Deprecation messages captured during the test.
+   *
+   * @var list<string>
+   */
+  public array $capturedDeprecations = [];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function triggerDeprecation(string $message): void {
+    $this->capturedDeprecations[] = $message;
   }
 
 }

--- a/tests/phpunit/src/RandomContextTest.php
+++ b/tests/phpunit/src/RandomContextTest.php
@@ -209,6 +209,61 @@ class RandomContextTest extends TestCase {
   }
 
   /**
+   * Tests that malformed token args fail loudly instead of being coerced.
+   *
+   * A typo like '[?title:string,abc]' would otherwise silently generate a
+   * 1-character string, hiding the typo and producing test data that is
+   * almost-but-not-what-the-author-meant. Each row asserts the literal
+   * raises 'InvalidArgumentException' with a message that names the
+   * offending input.
+   *
+   * @param string $literal
+   *   The malformed token literal embedded in a step argument.
+   * @param string $expected_message_fragment
+   *   Substring that must appear in the thrown exception message.
+   */
+  #[DataProvider('dataProviderMalformedArgsThrow')]
+  public function testMalformedArgsThrow(string $literal, string $expected_message_fragment): void {
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage($expected_message_fragment);
+    $this->context->transformVariables($literal);
+  }
+
+  /**
+   * Provides cases for testMalformedArgsThrow().
+   */
+  public static function dataProviderMalformedArgsThrow(): \Iterator {
+    yield 'string length is non-numeric' => [
+      'value: [?title:string,abc]',
+      'length must be a non-negative integer; got "abc"',
+    ];
+    yield 'string takes too many args' => [
+      'value: [?title:string,5,extra]',
+      'Type "string" accepts at most one argument',
+    ];
+    yield 'machine_name length is signed' => [
+      'value: [?slug:machine_name,-3]',
+      'length must be a non-negative integer; got "-3"',
+    ];
+    yield 'int with one arg is ambiguous' => [
+      'value: [?age:int,18]',
+      'Type "int" accepts no args (full range) or two args',
+    ];
+    yield 'int with non-integer arg' => [
+      'value: [?age:int,18,foo]',
+      'Type "int" args must be integers; got "foo"',
+    ];
+    yield 'email rejects extra args' => [
+      'value: [?contact:email,extra]',
+      'Type "email" does not accept arguments',
+    ];
+    yield 'uuid rejects extra args' => [
+      'value: [?id:uuid,extra]',
+      'Type "uuid" does not accept arguments',
+    ];
+  }
+
+  /**
    * Tests that 'transformTable()' substitutes modern tokens in cells.
    */
   public function testTransformTableSubstitutesModernTokensInCells(): void {


### PR DESCRIPTION
Closes #469

## Summary

`RandomContext` previously supported a single token form - `<?token>` - which always generated a
10-character lowercase alphanumeric string. This PR replaces it with a typed grammar,
`[?name:type,args]`, that ships six built-in generators (`string`, `name`, `machine_name`, `int`,
`email`, `uuid`) and lets consumers add their own by overriding one method. The legacy `<?token>`
form still works but now emits a `[Deprecation]` notice via the existing `DeprecationTrait`, so
suites can migrate at their own pace without any hard break.

## Changes

**`RandomContext.php`** - rewritten around the new grammar

- New `SCAN_REGEX` constant matches both `[?...]` and `<?...>` in one pass.
- `resolveLiteral()` is the new resolution path: parse -> normalise -> generate -> cache under a
  canonical `name:type:arg1,...` key. Literal -> canonical key is memoised in a separate `$literals`
  map so repeated literals are O(1) after first encounter.
- `parseToken()` handles both forms; `normaliseArgs()` fills defaults so equivalent literals share
  one cache entry; `generate()` dispatches to six typed generators.
- All members are `protected` so subclasses can override `generate()` to add custom types.
- Legacy `<?token>` literals trigger a single `triggerDeprecation()` call per unique literal per
  process run (the trait deduplicates across scenarios).

**`RandomContextTest.php`** - provider-driven, no test method duplication

- `RecordingRandomContext` subclass captures deprecations instead of writing to `STDERR`, avoiding
  output-buffering complications in unit tests.
- Providers cover: all six built-in types, cache-equivalence across all four equivalent forms,
  distinct-type isolation under the same name, table substitution, deprecation capture, and
  scenario reset.

**`random.feature`** - existing 6 scenarios untouched; 9 new scenarios added

- 4 `@test-drupal @api @random` direct scenarios: user creation via email token, table substitution,
  legacy+modern back-compat, and `machine_name` shape verification.
- 5 `@test-blackbox @random` subprocess scenarios: basic pass/fail, `machine_name` shape, legacy
  deprecation positive, and modern no-deprecation negative.

**`docs/writing-tests.md`** - "Random data" section rewritten with full reference

- Token grammar diagram, built-in type table, cache-equivalence table, custom-type extension example,
  deprecation/suppression note.

**`docs/contexts.md`** - one-line update to the `RandomContext` row.

## Before / After

### Token grammar

```
Before (single form only):
  <?name>
   └── always a 10-char lowercase alphanumeric string

After (new primary form, legacy still accepted):
  [?<name>:<type>[,<args>]]
     │      │       │
     │      │       └── type-specific args (length, range, ...)
     │      └────────── generator type (string | name | machine_name | int | email | uuid)
     └───────────────── identity / cache key (same name = same value in a scenario)

  <?name>   (legacy - still works, triggers [Deprecation] notice)
```

### Resolution flow

```
Before                                        After
──────────────────────────────────────────    ──────────────────────────────────────────────────
literal ──► $values[literal] ?                literal ──► $literals[literal] ?
              │ hit                                          │ hit
              └──► return stored string                     └──► return $values[canonical_key]
              │ miss                                         │ miss
              └──► Random::name(10)                         └──► parseToken()
                   strtolower()                                     │
                   store $values[literal]                           ▼
                   return                                  normaliseArgs() (fill defaults)
                                                                    │
                                                                    ▼
                                                           canonical key = name:type:arg1,...
                                                           store $literals[literal] = key
                                                                    │
                                                  legacy? ──► triggerDeprecation() (once)
                                                                    │
                                                           $values[key] set? ──► return it
                                                                    │ miss
                                                                    ▼
                                                           generate(type, args)
                                                           store $values[key]
                                                           return
```

### Type catalogue

```
Before          After
──────────────  ──────────────────────────────────────────────────────
<?name>         [?name]           — string, 10-char lowercase alphanum
  (one type)    [?name:string,N]  — explicit length
                [?label:name,N]   — mixed-case, via Random::name()
                [?slug:machine_name,N]  — lowercase + underscores
                [?age:int,MIN,MAX]      — random integer in range
                [?email:email]          — user@domain.test
                [?id:uuid]              — UUID v4
                  (six built-in types + extensible via override)
```

### Cache equivalence (back-compat lever)

```
Literal                   Canonical key
────────────────────────  ─────────────────
[?title]                  title:string:10 ─┐
[?title:string]           title:string:10  │─ all resolve to the same
[?title:string,10]        title:string:10  │  value within a scenario
<?title>  (legacy)        title:string:10 ─┘

[?title:string,8]         title:string:8   ← different length, different value
[?title:int]              title:int:0,...  ← different type, different value
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for typed random placeholder syntax with multiple generator types (string, name, machine name, integer, email, UUID) and optional arguments in step definitions and table data.
  * Implemented scenario-scoped caching to ensure consistent random values within a test scenario.

* **Documentation**
  * Updated documentation with token syntax specification and generator type reference.

* **Deprecation**
  * Legacy placeholder syntax now emits deprecation notices; modern syntax recommended for new tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->