### PR TITLE
[#647] Added 'BEHAT_DRUPALEXTENSION_DISABLE_CLEANUP' env var to skip scenario teardown.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -264,6 +264,12 @@ revert (`ConfigContext`), mail re-enable (`MailContext`), random
 variable reset (`RandomContext`), and static cache clearing all still
 run.
 
+The post-scenario logout is also skipped, so the session of the last
+logged-in user stays open. This is deliberate - the whole point of the
+flag is to let you load the failing page in a browser and look around.
+The flip side is that subsequent scenarios in the same run inherit
+that session, which may change their behaviour.
+
 This is intended for ad-hoc local debugging. Do not enable it on CI -
-leftover data will leak into subsequent scenarios in the same run and
-into subsequent runs against the same database.
+leftover data and sessions will leak into subsequent scenarios in the
+same run and into subsequent runs against the same database.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -240,3 +240,30 @@ persistent for the project. If you prefer `BEHAT_PARAMS`, set the
 `suppress_deprecations` config key there - that drives the same config
 path. The dedicated env var remains a separate override channel and
 takes precedence when both are set.
+
+## Disabling automatic cleanup
+
+After every scenario, `RawDrupalContext` deletes the entities, users,
+and roles it created and logs the current user out. This keeps the
+database tidy between scenarios but makes it hard to inspect state when
+a scenario fails - by the time you look, the data is gone.
+
+Set `BEHAT_DRUPALEXTENSION_DISABLE_CLEANUP=1` to skip the entity, user,
+and role teardown for the run:
+
+```shell
+BEHAT_DRUPALEXTENSION_DISABLE_CLEANUP=1 vendor/bin/behat
+```
+
+Recognised "enabled" spellings (case-insensitive, whitespace trimmed):
+`1`, `true`, `yes`, `on`. Any other value, or unsetting the variable,
+leaves cleanup running.
+
+The toggle only affects entity, user, and role teardown. Config
+revert (`ConfigContext`), mail re-enable (`MailContext`), random
+variable reset (`RandomContext`), and static cache clearing all still
+run.
+
+This is intended for ad-hoc local debugging. Do not enable it on CI -
+leftover data will leak into subsequent scenarios in the same run and
+into subsequent runs against the same database.

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -198,6 +198,10 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface, D
    */
   #[AfterScenario]
   public function cleanEntities(): void {
+    if (!$this->shouldCleanup()) {
+      return;
+    }
+
     if ($this->createdStubs === []) {
       return;
     }
@@ -241,6 +245,10 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface, D
    */
   #[AfterScenario]
   public function cleanUsers(): void {
+    if (!$this->shouldCleanup()) {
+      return;
+    }
+
     $driver = $this->getDriver();
 
     if ($this->userManager->hasUsers() && $driver instanceof UserCapabilityInterface) {
@@ -282,6 +290,10 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface, D
    */
   #[AfterScenario]
   public function cleanRoles(): void {
+    if (!$this->shouldCleanup()) {
+      return;
+    }
+
     if ($this->roles === []) {
       return;
     }
@@ -309,6 +321,24 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface, D
     if ($driver instanceof CacheCapabilityInterface) {
       $driver->cacheClearStatic();
     }
+  }
+
+  /**
+   * Determines whether scenario cleanup should run.
+   *
+   * Set 'BEHAT_DRUPALEXTENSION_DISABLE_CLEANUP' to '1', 'true', 'yes', or
+   * 'on' (case-insensitive) to skip the AfterScenario teardown of
+   * entities, users, and roles. Useful for inspecting state left behind
+   * by a failing scenario; not intended for CI runs.
+   */
+  protected function shouldCleanup(): bool {
+    $env = getenv('BEHAT_DRUPALEXTENSION_DISABLE_CLEANUP');
+
+    if ($env === FALSE || $env === '') {
+      return TRUE;
+    }
+
+    return !in_array(strtolower(trim($env)), ['1', 'true', 'yes', 'on'], TRUE);
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -242,6 +242,12 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface, D
 
   /**
    * Remove any created users.
+   *
+   * The early-return guard intentionally also skips the post-scenario
+   * logout below. The whole point of 'BEHAT_DRUPALEXTENSION_DISABLE_CLEANUP'
+   * is to leave the failing scenario's state intact for inspection - that
+   * includes the session. Subsequent scenarios in the same run will inherit
+   * the leftover login, which is the expected trade-off.
    */
   #[AfterScenario]
   public function cleanUsers(): void {
@@ -260,7 +266,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface, D
       $this->userManager->clearUsers();
     }
 
-    // Always reset auth state, even if no users were created during the
+    // Reset auth state, even if no users were created during the
     // scenario. A scenario may log in as a pre-existing user without calling
     // userCreate(), leaving stale session state for the next scenario.
     if ($this->getAuthenticationManager() instanceof FastLogoutInterface) {

--- a/tests/behat/features/disable_cleanup.feature
+++ b/tests/behat/features/disable_cleanup.feature
@@ -1,0 +1,66 @@
+Feature: Disable automatic cleanup
+  As a developer debugging a failing scenario
+  I want to inspect the entities, users, and roles created by the run
+  So that I can see the state that produced the failure
+
+  # Cleanup is controlled by 'BEHAT_DRUPALEXTENSION_DISABLE_CLEANUP'.
+  # The signal we look for is whether 'cleanUsers()' wiped the user manager
+  # singleton between scenarios in the inner Behat run:
+  #   - Default (cleanup runs): scenario 2's 'I am logged in as :name' raises
+  #     'InvalidArgumentException' because the previous user was cleared.
+  #   - Env var set: scenario 2 logs in successfully because nothing was
+  #     cleared.
+  # See 'src/Drupal/DrupalExtension/Context/RawDrupalContext::shouldCleanup'.
+
+  @test-drupal @api
+  Scenario: Assert cleanup runs by default and the user is gone next scenario
+    Given some behat configuration
+    And a file named "features/stub.feature" with:
+      """
+      Feature: Inner stub
+
+        @test-drupal @api
+        Scenario: Create a user
+          Given the following users:
+            | name        | mail                |
+            | TestPersist | persist@example.com |
+          Then I am logged in as "TestPersist"
+
+        @test-drupal @api
+        Scenario: Verify user from previous scenario persists
+          Given I am logged in as "TestPersist"
+      """
+    When I run behat with drupal profile
+    Then it should fail with a "InvalidArgumentException" exception:
+      """
+      No user with TestPersist name is registered with the driver.
+      """
+
+  @test-drupal @api
+  Scenario: Assert env var "1" disables cleanup so the user persists
+    Given some behat configuration
+    And the "BEHAT_DRUPALEXTENSION_DISABLE_CLEANUP" environment variable is set to "1"
+    And a file named "features/stub.feature" with:
+      """
+      Feature: Inner stub
+
+        @test-drupal @api
+        Scenario: Create a user
+          Given the following users:
+            | name              | mail                       |
+            | TestPersistEnvOn  | persist-env-on@example.com |
+          Then I am logged in as "TestPersistEnvOn"
+
+        @test-drupal @api
+        Scenario: Verify user from previous scenario persists
+          Given I am logged in as "TestPersistEnvOn"
+      """
+    When I run behat with drupal profile
+    Then it should pass with:
+      """
+      2 scenarios (2 passed)
+      """
+    # The inner run intentionally skipped its own cleanup, so the user is
+    # still in Drupal. Remove it here so re-running the suite locally does
+    # not collide on the next user create.
+    And I run drush "user:cancel" "TestPersistEnvOn -y --delete-content"

--- a/tests/phpunit/src/RawDrupalContextTest.php
+++ b/tests/phpunit/src/RawDrupalContextTest.php
@@ -12,6 +12,7 @@ use Drupal\Driver\Entity\EntityStub;
 use Drupal\DrupalExtension\Manager\DriverManagerInterface;
 use Drupal\DrupalExtension\Context\RawDrupalContext;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -25,6 +26,32 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversClass(RawDrupalContext::class)]
 class RawDrupalContextTest extends TestCase {
+
+  /**
+   * Snapshot of the env var to restore after each test, NULL when unset.
+   */
+  private ?string $envBackup;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    $existing = getenv('BEHAT_DRUPALEXTENSION_DISABLE_CLEANUP');
+    $this->envBackup = $existing === FALSE ? NULL : $existing;
+    putenv('BEHAT_DRUPALEXTENSION_DISABLE_CLEANUP');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function tearDown(): void {
+    if ($this->envBackup === NULL) {
+      putenv('BEHAT_DRUPALEXTENSION_DISABLE_CLEANUP');
+    }
+    else {
+      putenv('BEHAT_DRUPALEXTENSION_DISABLE_CLEANUP=' . $this->envBackup);
+    }
+  }
 
   /**
    * Tests that parseEntityFields throws when the driver is not a DrupalDriver.
@@ -78,6 +105,45 @@ class RawDrupalContextTest extends TestCase {
   }
 
   /**
+   * Tests the cleanup decision under different env var values.
+   *
+   * @param string|null $env_value
+   *   Env var value to set for the test, or NULL to leave unset.
+   * @param bool $expected
+   *   Expected return value of 'shouldCleanup()'.
+   */
+  #[DataProvider('dataProviderShouldCleanup')]
+  public function testShouldCleanup(?string $env_value, bool $expected): void {
+    if ($env_value !== NULL) {
+      putenv('BEHAT_DRUPALEXTENSION_DISABLE_CLEANUP=' . $env_value);
+    }
+
+    $context = new TestableRawDrupalContext();
+
+    $this->assertSame($expected, $context->callShouldCleanup());
+  }
+
+  /**
+   * Provides data for testShouldCleanup().
+   */
+  public static function dataProviderShouldCleanup(): \Iterator {
+    yield 'unset env, defaults to cleanup on' => [NULL, TRUE];
+    yield 'empty env, cleanup on' => ['', TRUE];
+    yield 'env "1", cleanup off' => ['1', FALSE];
+    yield 'env "true", cleanup off' => ['true', FALSE];
+    yield 'env "TRUE", case-insensitive, cleanup off' => ['TRUE', FALSE];
+    yield 'env "yes", cleanup off' => ['yes', FALSE];
+    yield 'env "on", cleanup off' => ['on', FALSE];
+    yield 'env " 1 ", whitespace trimmed, cleanup off' => [' 1 ', FALSE];
+    yield 'env "0", cleanup on' => ['0', TRUE];
+    yield 'env "false", cleanup on' => ['false', TRUE];
+    yield 'env "no", cleanup on' => ['no', TRUE];
+    yield 'env "off", cleanup on' => ['off', TRUE];
+    yield 'env "maybe", unrecognised, cleanup on' => ['maybe', TRUE];
+    yield 'env "2", unrecognised numeric, cleanup on' => ['2', TRUE];
+  }
+
+  /**
    * Builds a context wired to an everything-configurable classifier.
    */
   protected function buildContext(): RawDrupalContext {
@@ -97,6 +163,21 @@ class RawDrupalContextTest extends TestCase {
     $context->setDrupal($drupal);
 
     return $context;
+  }
+
+}
+
+/**
+ * Test consumer that exposes the protected cleanup decision.
+ */
+// phpcs:ignore Drupal.Classes.ClassFileName.NoMatch
+class TestableRawDrupalContext extends RawDrupalContext {
+
+  /**
+   * Public bridge to the protected cleanup decision.
+   */
+  public function callShouldCleanup(): bool {
+    return $this->shouldCleanup();
   }
 
 }


### PR DESCRIPTION
Closes #647

## Summary

Introduces the `BEHAT_DRUPALEXTENSION_DISABLE_CLEANUP` environment variable to skip the `AfterScenario` teardown of entities, users, and roles in `RawDrupalContext`. When a scenario fails it is often impossible to inspect the cause because the teardown runs before you can look at the database or reload the page. Setting the variable to `1` (or `true`/`yes`/`on`, case-insensitive) preserves that state for the rest of the run. The post-scenario logout is also skipped deliberately so the session of the last logged-in user remains open, allowing you to reload the failing page in a browser. Other AfterScenario hooks (`ConfigContext`, `MailContext`, `RandomContext`, static-cache clearing) are unaffected. The flag is intended for ad-hoc local debugging and should not be used on CI.

## Changes

### `src/Drupal/DrupalExtension/Context/RawDrupalContext.php`

- Added protected `shouldCleanup()` method that reads and parses `BEHAT_DRUPALEXTENSION_DISABLE_CLEANUP`. Unset or empty returns `true` (cleanup runs); any recognised "enabled" spelling (`1`, `true`, `yes`, `on`, case-insensitive with whitespace trimmed) returns `false`.
- Added an early-return guard at the top of `cleanEntities()`, `cleanUsers()`, and `cleanRoles()` that calls `shouldCleanup()`.
- The guard in `cleanUsers()` intentionally also skips the post-scenario logout. Documented in a method docblock and in `docs/configuration.md`.

### `docs/configuration.md`

- Added "Disabling automatic cleanup" section explaining the env var, recognised spellings, which hooks are skipped, the session-preservation trade-off, and the CI warning.

### `tests/phpunit/src/RawDrupalContextTest.php`

- Added `setUp()`/`tearDown()` to snapshot and restore the env var around each test.
- Added `testShouldCleanup()` with a 14-case data provider (`dataProviderShouldCleanup`) covering: unset, empty, all four enabled spellings, case-insensitivity, whitespace trimming, and five "cleanup stays on" values.
- Added `TestableRawDrupalContext` helper class that exposes the protected `shouldCleanup()` via a public `callShouldCleanup()` bridge.

### `tests/behat/features/disable_cleanup.feature`

- Added two `@test-drupal @api` scenarios that exercise the integration via inner Behat subprocess runs:
  1. Default behaviour: cleanup runs, so a user created in scenario 1 is gone by scenario 2 and `InvalidArgumentException` is raised.
  2. Env var set to `1`: cleanup is skipped, user persists across scenarios, inner run passes. A trailing `drush user:cancel` step cleans up the leftover user so the suite is safe to re-run locally.

## Before / After

### AfterScenario hook behaviour in `cleanUsers()`

**Before (env var unset, cleanup runs)**

```
AfterScenario fires
  └─ cleanUsers()
       ├─ shouldCleanup() → true
       ├─ delete created users via driver
       ├─ clear userManager
       └─ logout (FastLogoutInterface / session reset)
```

**After (env var set to "1", cleanup disabled)**

```
AfterScenario fires
  └─ cleanUsers()
       └─ shouldCleanup() → false  →  return (all teardown skipped)

Result: users, entities, roles, and session remain intact for inspection.
```
