### PR TITLE
[#735] Added test coverage and docs for options in 'I run drush :command :arguments' step.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -608,6 +608,7 @@ Run a Drush command with arguments.
 
 ```gherkin
 Given I run drush "pm:list" "--status=enabled"
+Given I run drush "config:get" "system.site uuid --format=string"
 
 ```
 

--- a/src/Drupal/DrupalExtension/Context/DrushContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrushContext.php
@@ -58,8 +58,12 @@ class DrushContext extends RawDrupalContext implements TranslatableContext {
   /**
    * Run a Drush command with arguments.
    *
+   * The arguments string is appended to the command verbatim, so it may
+   * contain Drush options (flags) as well as positional arguments.
+   *
    * @code
    * Given I run drush "pm:list" "--status=enabled"
+   * Given I run drush "config:get" "system.site uuid --format=string"
    * @endcode
    */
   #[Given('I run drush :command :arguments')]

--- a/tests/behat/features/drush.feature
+++ b/tests/behat/features/drush.feature
@@ -9,9 +9,15 @@ Feature: DrushContext
     Then the drush output should contain "Drupal version"
 
   @test-drupal @api
-  Scenario: Assert "Given I run drush :command :arguments" passes
+  Scenario: Assert "Given I run drush :command :arguments" passes with a flag-only arguments string
     Given I run drush "pm:list" "--status=enabled"
     Then the drush output should contain "Enabled"
+
+  @test-drupal @api
+  Scenario: Assert "Given I run drush :command :arguments" passes with positional arguments and options combined
+    Given I run drush "config:get" "system.site uuid --format=string"
+    Then the drush output should match "/[a-f0-9-]{30,}/"
+    And the drush output should not contain "system.site"
 
   @test-drupal @api
   Scenario: Assert "Then the drush output should contain :output" passes


### PR DESCRIPTION
Closes #735

## Summary

Issue #735 requested a dedicated step `I run drush :command :arguments and options :options` for passing Drush flags. The existing `I run drush :command :arguments` step already supports this because the arguments string is appended verbatim to the shell command - flags, positional arguments, and combinations of both all work today. Rather than add a redundant step, this PR documents the existing behaviour explicitly in the docblock and adds a test scenario that demonstrates mixing positional arguments with a Drush option in a single arguments string.

## Changes

- `src/Drupal/DrupalExtension/Context/DrushContext.php`: added a prose note to the docblock explaining that the arguments string is appended verbatim and may therefore include Drush options; added a second `@code` example showing combined positional argument and flag.
- `tests/behat/features/drush.feature`: renamed the existing scenario for clarity; added a new scenario that runs `config:get` with a combined `"system.site uuid --format=string"` arguments string and asserts the UUID value is returned without the key prefix.
- `STEPS.md`: regenerated via `ahoy docs` to pick up the new docblock example.

## Before / After

```
BEFORE
------
Docblock showed one example - only flags in the arguments string:

  Given I run drush "pm:list" "--status=enabled"

Developers wanting to pass positional args + flags would not know
whether the step supported it, and issue #735 assumed it did not.

AFTER
-----
Docblock note + second example make the behaviour explicit:

  Given I run drush "pm:list" "--status=enabled"
  Given I run drush "config:get" "system.site uuid --format=string"
                                  ^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^^^
                                  positional   flag appended in same string

No new step needed - existing wiring already handles both cases.
```
