### PR TITLE
[#356] Strengthened 'author' property test to assert author is applied.

### DIFF
--- a/tests/behat/features/drupal.feature
+++ b/tests/behat/features/drupal.feature
@@ -288,15 +288,12 @@ Feature: DrupalContext coverage gaps
 
   @test-drupal @api
   Scenario: Assert "Given the following :type content:" passes for author property
-    Given some behat configuration
-    And scenario steps tagged with "@test-drupal @api":
-      """
-      Given the following users:
-        | name     | mail            | status |
-        | Joe User | joe@example.com | 1      |
-      And the following "article" content:
-        | title          | author   | status |
-        | Article by Joe | Joe User | 1      |
-      """
-    When I run behat with drupal profile
-    Then it should pass
+    Given I am logged in as a user with the "administrator" role
+    And the following users:
+      | name     | mail            | status |
+      | Joe User | joe@example.com | 1      |
+    And the following "article" content:
+      | title          | author   | status |
+      | Article by Joe | Joe User | 1      |
+    When I go to "admin/content"
+    Then I should see the text "Joe User" in the "Article by Joe" row


### PR DESCRIPTION
Closes #356

## Summary

Issue #356 proposed a new step `Given :name create(s) a/an :type with the title :title` to set a node's author by name. That capability already exists: the `Given the following :type content:` step accepts an `author` column, which the drupal-driver remaps to `uid` after looking up the user. A dedicated step would duplicate this without adding capability.

The existing test scenario for the `author` property only asserted "the inner subprocess scenario does not error" - it never verified that the created node was actually authored by the named user. This PR rewrites that scenario as a direct test that proves the author is applied to the created node, providing a working demo of the existing capability.

## Changes

### Tests (`tests/behat/features/drupal.feature`)

Rewrote the scenario `Assert "Given the following :type content:" passes for author property`:

- Removed the subprocess wrapper (`some behat configuration` / `When I run behat with drupal profile` / `it should pass`).
- Logs in as administrator, creates user `Joe User`, creates an `article` with `author = Joe User`.
- Visits `/admin/content` (which renders an Author column) and asserts `Joe User` appears in the `Article by Joe` row.

If the `author` value were ignored or misapplied, the row would render a different name (anonymous or the logged-in admin) and the assertion would fail - so the scenario now fails closed.

## Before / After

```
BEFORE: subprocess-only "the syntax does not error" check.

  ┌──────────────────────────────────────────────┐
  │ outer scenario                               │
  │   "some behat configuration"                 │
  │   "scenario steps tagged ...":               │
  │     ┌────────────────────────────────────┐   │
  │     │ inner subprocess scenario          │   │
  │     │   Given the following users        │   │
  │     │   And the following article        │   │
  │     │     | title | author    |          │   │
  │     │     | ...   | Joe User  |          │   │
  │     │   <no assertion>                   │   │
  │     └────────────────────────────────────┘   │
  │   "When I run behat with drupal profile"     │
  │   Then it should pass    <- only "no error"  │
  └──────────────────────────────────────────────┘

AFTER: direct scenario that proves the author was applied.

  ┌─────────────────────────────────────────────┐
  │ scenario                                    │
  │   Given I am logged in as administrator     │
  │   And the following users                   │
  │     | name     |                            │
  │     | Joe User |                            │
  │   And the following article                 │
  │     | title          | author   |           │
  │     | Article by Joe | Joe User |           │
  │   When I go to "admin/content"              │
  │   Then I should see "Joe User" in           │
  │        "Article by Joe" row                 │
  │                                             │
  │   <- fails if the article's author is       │
  │     anonymous or admin instead of Joe User  │
  └─────────────────────────────────────────────┘
```
