### PR TITLE
[#694] Extended 'login_wait' to cover the last-resort logout link lookup.

### DIFF
--- a/behat.dist.yml
+++ b/behat.dist.yml
@@ -71,7 +71,8 @@ default:
         Footer: '#footer'
         Left sidebar: '#sidebar-first'
         Right sidebar: '#sidebar-second'
-      # Seconds to wait for the browser to load after login. 0 to disable.
+      # Maximum seconds to wait for post-login DOM signals (URL change, body
+      # render, logged-in selector, logout link). 0 to disable.
       login_wait: 0
       # Maximum time (in seconds) to wait for AJAX calls to complete.
       ajax_timeout: 5

--- a/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
+++ b/src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php
@@ -192,8 +192,19 @@ class DrupalAuthenticationManager implements DrupalAuthenticationManagerInterfac
 
     // As a last resort, if a logout link is found, we are logged in.
     // While not perfect, this is how Drupal SimpleTests currently work as
-    // well.
+    // well. On themes that defer header navigation (e.g. via Critical CSS
+    // or a late JS render), the logout link may not be present in the DOM
+    // at the moment of this lookup. Poll for it within the same window
+    // configured by 'login_wait' so this last-resort check tolerates the
+    // same delays as the post-submit waits in 'logIn()'.
     $session->visit($this->locatePath('/'));
+    $login_wait = (int) $this->getParameter('login_wait');
+    if ($login_wait > 0) {
+      $timeout = microtime(TRUE) + $login_wait;
+      while (microtime(TRUE) < $timeout && !$this->getLogoutElement() instanceof NodeElement) {
+        usleep(100000);
+      }
+    }
     if ($this->getLogoutElement() instanceof NodeElement) {
       return TRUE;
     }

--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -166,7 +166,7 @@ class DrupalExtension implements ExtensionInterface {
         ->integerNode('login_wait')
           ->min(0)
           ->defaultValue(0)
-          ->info('Seconds to wait for the browser to load after login. Set to 0 to disable waiting.')
+          ->info('Maximum seconds to wait for post-login DOM signals (URL change, body render, logged-in selector, logout link). Set to 0 to disable waiting.')
         ->end()
         ->integerNode('ajax_timeout')
           ->min(0)

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -148,6 +148,28 @@ class FeatureContext extends RawDrupalContext {
   }
 
   /**
+   * Override the active 'login_wait' parameter on the authentication manager.
+   *
+   * 'login_wait' is normally read once from behat.yml at boot. This step
+   * uses reflection to mutate the live manager so a single scenario can
+   * exercise the wait branches without spawning a subprocess to rewrite
+   * the config file.
+   *
+   * @code
+   * Given the post-login wait is set to 3 seconds
+   * @endcode
+   */
+  #[Given('the post-login wait is set to :seconds second(s)')]
+  public function testSetPostLoginWait(int|string $seconds): void {
+    $manager = $this->getAuthenticationManager();
+    $reflection = new \ReflectionObject($manager);
+    $property = $reflection->getProperty('parameters');
+    $params = $property->getValue($manager);
+    $params['login_wait'] = (int) $seconds;
+    $property->setValue($manager, $params);
+  }
+
+  /**
    * Registers fixture-only field handlers with the active driver's core.
    *
    * The fixture module 'behat_test' ships an 'address_field' type with four

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -740,6 +740,22 @@ class FeatureContext extends RawDrupalContext {
   }
 
   /**
+   * Resets the SlowLoginSubscriber state keys after slow-login scenarios.
+   *
+   * Scenarios tagged '@slow_login_state' set 'behat_test.slow_login' and/or
+   * 'behat_test.slow_logout_link' to non-zero values to simulate delayed
+   * post-login DOM signals. Clear them on the way out so other features
+   * are not affected, even if the scenario fails before its cleanup step
+   * would run.
+   */
+  #[AfterScenario('@slow_login_state')]
+  public function testResetSlowLoginStateAfterScenario(): void {
+    $state = \Drupal::state();
+    $state->set('behat_test.slow_login', 0);
+    $state->set('behat_test.slow_logout_link', 0);
+  }
+
+  /**
    * Uninstalls 'big_pipe' after every '@bigpipe' scenario.
    *
    * Subprocess scenarios install 'big_pipe' against the shared Drupal

--- a/tests/behat/features/login_wait.feature
+++ b/tests/behat/features/login_wait.feature
@@ -38,6 +38,20 @@ Feature: Login wait
     And I am logged in as a user with the "authenticated user" role
     Then I should see the link "My account"
 
+  @test-drupal @api @javascript
+  Scenario: Assert "login_wait" extends to the last-resort logout link lookup
+    # Body class is stripped on every response and never re-added during the
+    # test, forcing 'loggedIn()' to fall through to the third-resort logout
+    # link check. The logout link itself is delayed by 800ms so the
+    # synchronous lookup fails and the wait introduced by 'login_wait' must
+    # poll the DOM until the link appears.
+    Given the post-login wait is set to 3 seconds
+    And I run drush "state:set behat_test.slow_login 60000"
+    And I run drush "state:set behat_test.slow_logout_link 800"
+    When I am logged in as a user with the "authenticated user" role
+    Then I should see the link "My account"
+
   @test-drupal @api
   Scenario: Assert slow login state is cleaned up
     Given I run drush "state:set behat_test.slow_login 0"
+    And I run drush "state:set behat_test.slow_logout_link 0"

--- a/tests/behat/features/login_wait.feature
+++ b/tests/behat/features/login_wait.feature
@@ -32,13 +32,13 @@ Feature: Login wait
       The value -1 is too small for path
       """
 
-  @test-drupal @api @javascript
+  @test-drupal @api @javascript @slow_login_state
   Scenario: Assert login succeeds with "login_wait" when logged-in class is delayed by JS
     Given I run drush "state:set behat_test.slow_login 1500"
     And I am logged in as a user with the "authenticated user" role
     Then I should see the link "My account"
 
-  @test-drupal @api @javascript
+  @test-drupal @api @javascript @slow_login_state
   Scenario: Assert "login_wait" extends to the last-resort logout link lookup
     # Body class is stripped on every response and never re-added during the
     # test, forcing 'loggedIn()' to fall through to the third-resort logout
@@ -50,8 +50,3 @@ Feature: Login wait
     And I run drush "state:set behat_test.slow_logout_link 800"
     When I am logged in as a user with the "authenticated user" role
     Then I should see the link "My account"
-
-  @test-drupal @api
-  Scenario: Assert slow login state is cleaned up
-    Given I run drush "state:set behat_test.slow_login 0"
-    And I run drush "state:set behat_test.slow_logout_link 0"

--- a/tests/behat/fixtures/drupal/modules/behat_test/src/EventSubscriber/SlowLoginSubscriber.php
+++ b/tests/behat/fixtures/drupal/modules/behat_test/src/EventSubscriber/SlowLoginSubscriber.php
@@ -10,14 +10,17 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
- * Simulates a slow post-login page by delaying the logged-in body class.
+ * Simulates slow post-login DOM signals.
  *
- * When 'behat_test.slow_login' state is set to a positive integer (ms),
- * strips the 'logged-in' class from the body tag and injects JavaScript
- * that re-adds it after the configured delay. This reproduces the race
- * condition where JS or async processing delays the logged-in indicator.
+ * Two independent state keys control which signal is delayed:
  *
- * Requires a JS-capable driver (Selenium) to observe the effect.
+ * - 'behat_test.slow_login' (ms): strips the 'logged-in' class from the
+ *   body tag and re-adds it via JS after the configured delay.
+ * - 'behat_test.slow_logout_link' (ms): strips logout links from the
+ *   response and re-injects one via JS after the configured delay.
+ *
+ * Both manipulations rely on a JS-capable driver (Selenium) to observe the
+ * delayed re-addition.
  */
 class SlowLoginSubscriber implements EventSubscriberInterface {
 
@@ -33,11 +36,13 @@ class SlowLoginSubscriber implements EventSubscriberInterface {
   }
 
   /**
-   * Removes the logged-in class and re-adds it after a delay.
+   * Strips logged-in indicators and schedules their delayed re-addition.
    */
   public function onResponse(ResponseEvent $event): void {
-    $delay = (int) $this->state->get('behat_test.slow_login', 0);
-    if ($delay <= 0) {
+    $login_delay = (int) $this->state->get('behat_test.slow_login', 0);
+    $logout_link_delay = (int) $this->state->get('behat_test.slow_logout_link', 0);
+
+    if ($login_delay <= 0 && $logout_link_delay <= 0) {
       return;
     }
 
@@ -47,22 +52,32 @@ class SlowLoginSubscriber implements EventSubscriberInterface {
       return;
     }
 
-    // Only act on pages where the logged-in class is present.
-    if (!str_contains($content, 'logged-in')) {
-      return;
+    $scripts = '';
+
+    if ($login_delay > 0 && str_contains($content, 'logged-in')) {
+      $content = preg_replace('/(<body[^>]*class="[^"]*)\blogged-in\b/', '$1', $content);
+      $scripts .= sprintf(
+        '<script>setTimeout(function(){document.body.classList.add("logged-in");}, %d);</script>',
+        $login_delay
+      );
     }
 
-    // Remove the logged-in class from the body tag.
-    $content = preg_replace('/(<body[^>]*class="[^"]*)\blogged-in\b/', '$1', $content);
+    if ($logout_link_delay > 0) {
+      $count = 0;
+      $stripped = preg_replace('/<a\b[^>]*href="[^"]*\/user\/logout[^"]*"[^>]*>.*?<\/a>/is', '', $content, -1, $count);
+      if ($count > 0) {
+        $content = $stripped;
+        $scripts .= sprintf(
+          '<script>setTimeout(function(){var a=document.createElement("a");a.href="/user/logout";a.textContent="Log out";document.body.appendChild(a);}, %d);</script>',
+          $logout_link_delay
+        );
+      }
+    }
 
-    // Inject JS to re-add it after the configured delay.
-    $js = sprintf(
-      '<script>setTimeout(function(){document.body.classList.add("logged-in");}, %d);</script>',
-      $delay
-    );
-    $content = str_replace('</body>', $js . '</body>', $content);
-
-    $response->setContent($content);
+    if ($scripts !== '') {
+      $content = str_replace('</body>', $scripts . '</body>', $content);
+      $response->setContent($content);
+    }
   }
 
 }

--- a/tests/phpunit/src/Manager/DrupalAuthenticationManagerTest.php
+++ b/tests/phpunit/src/Manager/DrupalAuthenticationManagerTest.php
@@ -335,6 +335,90 @@ class DrupalAuthenticationManagerTest extends TestCase {
   }
 
   /**
+   * Tests that loggedIn() polls for the logout link when login_wait > 0.
+   *
+   * Simulates the Critical CSS / late JS race: the logged-in selector
+   * never appears, the login form is absent (we are logged in), and the
+   * logout link is initially missing but materialises a few polls later.
+   * With login_wait > 0, the third-resort check must keep polling.
+   */
+  public function testLoggedInPollsForLogoutLinkWhenLoginWaitSet(): void {
+    $link = $this->createMock(NodeElement::class);
+
+    $call_count = 0;
+    $page = $this->createMock(DocumentElement::class);
+    $page->method('has')->willReturn(FALSE);
+    $page->method('findLink')->willReturnCallback(function () use (&$call_count, $link): ?NodeElement {
+      $call_count++;
+      return $call_count >= 3 ? $link : NULL;
+    });
+
+    $session = $this->createSessionMock($page);
+    // @phpstan-ignore method.notFound
+    $session->method('isStarted')->willReturn(TRUE);
+
+    $params = self::DRUPAL_PARAMS;
+    $params['login_wait'] = 2;
+
+    $manager = $this->createManager($session, NULL, NULL, $params);
+    $this->assertTrue($manager->loggedIn());
+    $this->assertGreaterThanOrEqual(3, $call_count);
+  }
+
+  /**
+   * Tests that loggedIn() does not poll when login_wait is 0.
+   *
+   * Confirms the wait loop is skipped entirely when waiting is disabled,
+   * preserving the historical single-lookup behaviour for the third-
+   * resort check.
+   */
+  public function testLoggedInDoesNotPollWhenLoginWaitIsZero(): void {
+    $call_count = 0;
+    $page = $this->createMock(DocumentElement::class);
+    $page->method('has')->willReturn(FALSE);
+    $page->method('findLink')->willReturnCallback(function () use (&$call_count): ?NodeElement {
+      $call_count++;
+      return NULL;
+    });
+
+    $session = $this->createSessionMock($page);
+    // @phpstan-ignore method.notFound
+    $session->method('isStarted')->willReturn(TRUE);
+
+    $params = self::DRUPAL_PARAMS;
+    $params['login_wait'] = 0;
+
+    $manager = $this->createManager($session, NULL, NULL, $params);
+    $this->assertFalse($manager->loggedIn());
+    $this->assertSame(1, $call_count);
+  }
+
+  /**
+   * Tests that loggedIn() returns FALSE when the wait elapses.
+   *
+   * The logout link never appears, so the wait expires after login_wait
+   * seconds and the method falls through to the anonymous-state cleanup.
+   */
+  public function testLoggedInReturnsFalseWhenLogoutLinkWaitTimesOut(): void {
+    $page = $this->createMock(DocumentElement::class);
+    $page->method('has')->willReturn(FALSE);
+    $page->method('findLink')->willReturn(NULL);
+
+    $session = $this->createSessionMock($page);
+    // @phpstan-ignore method.notFound
+    $session->method('isStarted')->willReturn(TRUE);
+
+    $params = self::DRUPAL_PARAMS;
+    $params['login_wait'] = 1;
+
+    $manager = $this->createManager($session, NULL, NULL, $params);
+    $start = microtime(TRUE);
+    $this->assertFalse($manager->loggedIn());
+    $elapsed = microtime(TRUE) - $start;
+    $this->assertGreaterThanOrEqual(1.0, $elapsed);
+  }
+
+  /**
    * Tests that loggedIn() handles a DriverException gracefully.
    */
   public function testLoggedInHandlesDriverException(): void {


### PR DESCRIPTION
Closes #694

## Summary

The `loggedIn()` method in `DrupalAuthenticationManager` uses up to three fallback checks to determine whether a user is logged in. The third check - visiting `/` and looking for a logout link - was a single synchronous DOM lookup with no retry. On themes that defer header navigation via Critical CSS or a late JS render, the logout link may not be present at the moment of that lookup, causing `loggedIn()` to return `false` for a user who is actually authenticated.

This change reuses the existing `login_wait` polling window (already applied to the earlier `logIn()` waits) to cover the third-resort logout link lookup as well. When `login_wait > 0`, the check polls the DOM at 100 ms intervals until the link appears or the window expires, matching the tolerance already granted to the post-submit waits.

The `login_wait` info text and the `behat.dist.yml` comment are broadened to reflect that the parameter covers all post-login DOM signals, not just the post-submit page load.

## Changes

- **`src/Drupal/DrupalExtension/Manager/DrupalAuthenticationManager.php`** - added a `login_wait`-gated polling loop around the third-resort logout link check in `loggedIn()`
- **`src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php`** - broadened the `login_wait` node `info()` text to cover all post-login DOM signals
- **`behat.dist.yml`** - broadened the inline comment for `login_wait` to match
- **`tests/behat/fixtures/drupal/modules/behat_test/src/EventSubscriber/SlowLoginSubscriber.php`** - extended to support a second state key `behat_test.slow_logout_link` (delay in ms) that strips logout links from the response and re-injects one via JS after the delay, independently of the existing `behat_test.slow_login` key
- **`tests/behat/features/login_wait.feature`** - added a `@javascript` scenario that enables both slow-login and slow-logout-link delays to reproduce the race, then asserts the wait resolves it; extended the cleanup scenario to reset the new state key
- **`tests/behat/bootstrap/FeatureContext.php`** - added a test-only step `the post-login wait is set to :seconds second(s)` that uses reflection to mutate `login_wait` at runtime, avoiding the need for a subprocess to rewrite `behat.yml`
- **`tests/phpunit/src/Manager/DrupalAuthenticationManagerTest.php`** - added three unit tests: polls and finds the link after a few attempts, skips polling when `login_wait` is 0 (single lookup), and returns `false` when the wait expires without the link appearing

## Before / After

```
loggedIn() — BEFORE
─────────────────────────────────────────────────────────────────
  Check 1: logged-in selector present?           YES → return TRUE
                                                  NO  ↓
  Check 2: login form present?                   YES → return FALSE
                                                  NO  ↓
  Check 3: visit /, find logout link?
  ┌──────────────────────────────────────────┐
  │  session->visit('/')                     │
  │  getLogoutElement()  ← single lookup     │  link absent on async
  │      └─ NULL  ──────────────────────────►│  theme → falls through
  └──────────────────────────────────────────┘
       NO link found → return FALSE  ✗ (false negative for logged-in user)


loggedIn() — AFTER
─────────────────────────────────────────────────────────────────
  Check 1: logged-in selector present?           YES → return TRUE
                                                  NO  ↓
  Check 2: login form present?                   YES → return FALSE
                                                  NO  ↓
  Check 3: visit /, poll for logout link
  ┌──────────────────────────────────────────┐
  │  session->visit('/')                     │
  │  if login_wait > 0:                      │
  │    deadline = now + login_wait           │
  │    loop every 100 ms:                    │
  │      getLogoutElement()                  │
  │        link found ──────────────────────►│→ return TRUE  ✓
  │        deadline elapsed ────────────────►│→ exit loop
  │  single final getLogoutElement() check   │
  │    YES → return TRUE                     │
  │    NO  → return FALSE                    │
  └──────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Login detection now polls for post-login DOM signals (including delayed logout link) using the configurable timeout instead of a single immediate check.

* **Documentation**
  * Clarified `login_wait` text to describe waiting for post‑login DOM signals rather than browser load timing.

* **Tests**
  * Added scenarios, fixtures and unit tests covering delayed post‑login rendering and logout‑link appearance; added steps/hooks to set/reset the post‑login wait for scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->