### PR TITLE
Renamed 'MIGRATION.md' to 'UPGRADING.md' and tightened dist-archive exclusions.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,12 @@
 # Ignore files for distribution archives.
 /.ahoy.yml           export-ignore
+/.docker             export-ignore
 /.editorconfig       export-ignore
 /.gitattributes      export-ignore
 /.github             export-ignore
 /.gitignore          export-ignore
 /CONTRIBUTING.md     export-ignore
+/behat.dist.yml      export-ignore
 /behat.yml           export-ignore
 /build               export-ignore
 /composer.lock       export-ignore

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ sites.
 > [6.x epic](https://github.com/jhedstrom/drupalextension/issues/782)
 > for details and progress.
 >
-> Upgrading from `5.x`? See [`MIGRATION.md`](MIGRATION.md) for the full list
+> Upgrading from `5.x`? See [`UPGRADING.md`](UPGRADING.md) for the full list
 > of breaking changes and the step-text migration table.
 
 ## Use it for testing your Drupal site.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,4 +1,4 @@
-# Migration guide: 5.x → 6.0
+# Upgrading from 5.x to 6.0
 
 Version 6.0 enforces a consistent set of step-definition conventions across
 all bundled contexts. The conventions are documented in

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ testing Drupal sites with Behavior-Driven Development.
 
 - [Step definitions](../STEPS.md) - Generated reference for every step
   shipped with the extension.
-- [Migration guide](../MIGRATION.md) - Breaking changes and upgrade
+- [Upgrading guide](../UPGRADING.md) - Breaking changes and upgrade
   instructions for `5.x` to `6.x`.
 - [Contributing](../CONTRIBUTING.md) - Development setup and
   contribution guidelines.

--- a/src/Drupal/DrupalExtension/Context/MessageContext.php
+++ b/src/Drupal/DrupalExtension/Context/MessageContext.php
@@ -411,7 +411,7 @@ class MessageContext extends RawMinkContext implements TranslatableContext, Para
     $legacy_key = $legacy_key_map[$name];
 
     if (is_array($selectors) && isset($selectors[$legacy_key])) {
-      $this->triggerDeprecation('Configuring message selectors as flat keys under "Drupal\\DrupalExtension.selectors:" is deprecated in drupal-extension:6.0.0 and is removed from drupal-extension:6.1.0. Move them under "Drupal\\DrupalExtension.selectors.messages:" with keys "default", "error", "success", "warning". See https://github.com/jhedstrom/drupalextension/blob/main/MIGRATION.md');
+      $this->triggerDeprecation('Configuring message selectors as flat keys under "Drupal\\DrupalExtension.selectors:" is deprecated in drupal-extension:6.0.0 and is removed from drupal-extension:6.1.0. Move them under "Drupal\\DrupalExtension.selectors.messages:" with keys "default", "error", "success", "warning". See https://github.com/jhedstrom/drupalextension/blob/main/UPGRADING.md');
     }
 
     return $this->getDrupalSelector($legacy_key);

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -444,7 +444,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface, D
     $mode = $this->getParameter('field_parser') ?? 'default';
 
     if ($mode === 'legacy') {
-      $this->triggerDeprecation('The legacy field parser is deprecated in drupal-extension:6.0.0 and is removed from drupal-extension:6.1.0. Remove "field_parser: legacy" from your behat.yml to migrate. See https://github.com/jhedstrom/drupalextension/blob/main/MIGRATION.md');
+      $this->triggerDeprecation('The legacy field parser is deprecated in drupal-extension:6.0.0 and is removed from drupal-extension:6.1.0. Remove "field_parser: legacy" from your behat.yml to migrate. See https://github.com/jhedstrom/drupalextension/blob/main/UPGRADING.md');
 
       return new LegacyEntityFieldParser($entity_type, $classifier);
     }

--- a/src/Drupal/DrupalExtension/Parser/README.md
+++ b/src/Drupal/DrupalExtension/Parser/README.md
@@ -82,6 +82,6 @@ Parse errors thrown by the modern parser carry:
 
 `getMessage()` returns a multi-line string with the cell, a caret line at the offset, and the description, suitable for surfacing directly in a Behat run. `MultipleParseException` collects multiple per-cell errors so authors can fix them all in one edit.
 
-## Migration
+## Upgrading
 
-See [`MIGRATION.md`](../../../../../MIGRATION.md) for the side-by-side syntax mapping, positional-to-named conversion table, escape sequences, and parse-error format.
+See [`UPGRADING.md`](../../../../../UPGRADING.md) for the side-by-side syntax mapping, positional-to-named conversion table, escape sequences, and parse-error format.

--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -239,7 +239,7 @@ class DrupalExtension implements ExtensionInterface {
     $legacy = $config['region_map'] ?? [];
 
     if ($legacy !== []) {
-      $this->triggerDeprecation('The "region_map" configuration key under "Drupal\\DrupalExtension" is deprecated in drupal-extension:6.0.0 and removed from drupal-extension:6.1.0. Rename it to "regions". See https://github.com/jhedstrom/drupalextension/blob/main/MIGRATION.md');
+      $this->triggerDeprecation('The "region_map" configuration key under "Drupal\\DrupalExtension" is deprecated in drupal-extension:6.0.0 and removed from drupal-extension:6.1.0. Rename it to "regions". See https://github.com/jhedstrom/drupalextension/blob/main/UPGRADING.md');
       // 'regions' wins on key collisions; '+' keeps the left-hand keys.
       $regions += $legacy;
     }

--- a/tests/behat/features/regions.feature
+++ b/tests/behat/features/regions.feature
@@ -37,5 +37,5 @@ Feature: regions configuration
     When I run behat
     Then the output should contain:
       """
-      [Deprecation] The "region_map" configuration key under "Drupal\DrupalExtension" is deprecated in drupal-extension:6.0.0 and removed from drupal-extension:6.1.0. Rename it to "regions". See https://github.com/jhedstrom/drupalextension/blob/main/MIGRATION.md
+      [Deprecation] The "region_map" configuration key under "Drupal\DrupalExtension" is deprecated in drupal-extension:6.0.0 and removed from drupal-extension:6.1.0. Rename it to "regions". See https://github.com/jhedstrom/drupalextension/blob/main/UPGRADING.md
       """


### PR DESCRIPTION
## Summary

Renames `MIGRATION.md` to `UPGRADING.md` to better reflect its purpose (version-upgrade guidance, not data migration), and updates the document heading to make the version-bump framing more prominent. All cross-references - README links, PHP deprecation notice URLs, a Behat fixture assertion, and Parser section heading - are updated to point at the new filename. The `.gitattributes` dist-archive exclusion list is also tightened by adding `/.docker` and `/behat.dist.yml`, which were previously leaking into Composer installs.

## Changes

### Rename: `MIGRATION.md` → `UPGRADING.md`

- Renamed via `git mv`, so git history is preserved.
- Changed H1 from `Migration guide: 5.x → 6.0` to `Upgrading from 5.x to 6.0`.

### References updated to `UPGRADING.md`

- `README.md` - link in the upgrading callout block.
- `docs/README.md` - link in the reference list ("Migration guide" → "Upgrading guide").
- `src/Drupal/DrupalExtension/Parser/README.md` - link and section heading (`## Migration` → `## Upgrading`).
- `src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php` - URL in `region_map` deprecation notice.
- `src/Drupal/DrupalExtension/Context/RawDrupalContext.php` - URL in legacy field parser deprecation notice.
- `src/Drupal/DrupalExtension/Context/MessageContext.php` - URL in flat selector keys deprecation notice.
- `tests/behat/features/regions.feature` - fixture assertion that matches the deprecation notice text output by the `region_map` deprecation.

### Distribution archive cleanup (`.gitattributes`)

Added two `export-ignore` entries so they no longer appear in `composer install` archives:

- `/.docker` - dev-only container Dockerfile, only referenced from the already-ignored `docker-compose.yml`.
- `/behat.dist.yml` - test-suite config for local development (the `behat.yml` equivalent was already excluded).

## Before / After

### Dist archive contents (`git archive HEAD | tar -t`)

**Before**

```
LICENSE
README.md
MIGRATION.md
STEPS.md
composer.json
.docker/
.docker/cli.dockerfile
behat.dist.yml
i18n/
src/
```

**After**

```
LICENSE
README.md
UPGRADING.md
STEPS.md
composer.json
i18n/
src/
```

The `.docker/` directory and `behat.dist.yml` are no longer included in Composer distribution archives. `UPGRADING.md` replaces `MIGRATION.md`.
