### PR TITLE
Switched 'drupal-driver' to 3.0.0-alpha1 and prepared 'composer.json' for 6.0.0-alpha1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,8 @@ The Drupal Extension is an integration layer between [Behat](http://behat.org),
 provides step definitions for common testing scenarios specific to Drupal
 sites.
 
-> **Note:** This `main` branch is under heavy development for
-> version `6.x`, which will use DrupalDriver `3.x`. For the
-> `5.x` maintenance line, use the
+> **Note:** Version `6.0.0-alpha1` has been released and runs on
+> DrupalDriver `3.x`. For the `5.x` maintenance line, use the
 > [`5.x` branch](https://github.com/jhedstrom/drupalextension/tree/5.x).
 > See the
 > [6.x epic](https://github.com/jhedstrom/drupalextension/issues/782)

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "behat/gherkin": "^4.13",
         "behat/mink": "^1.12",
         "behat/mink-browserkit-driver": "^2.1.0",
-        "drupal/drupal-driver": "dev-master as 3.0.0",
+        "drupal/drupal-driver": "^3.0.0-alpha1",
         "friends-of-behat/mink-extension": "^2.7.1",
         "lullabot/mink-selenium2-driver": "^1.7.4",
         "symfony/css-selector": "^6.4.3 || ^7",
@@ -88,6 +88,7 @@
         "symfony/yaml": "^6.4.3 || ^7",
         "webmozart/assert": "^2"
     },
+    "minimum-stability": "alpha",
     "prefer-stable": true,
     "autoload": {
         "psr-0": {
@@ -107,7 +108,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-5.x": "5.4.x-dev"
+            "dev-main": "6.0.x-dev"
         },
         "drupal-scaffold": {
             "file-mapping": {


### PR DESCRIPTION
## Summary

Switches the `drupal/drupal-driver` dependency from the `dev-master` alias to the released `^3.0.0-alpha1` constraint, now that the upstream package has been tagged. Adds `minimum-stability: alpha` so Composer can resolve the pre-release constraint (the default stability is `stable`). Updates the `branch-alias` to reflect that `main` is the 6.0 line, and updates the README development note to state that `6.0.0-alpha1` has been released.

## Changes

**`composer.json`**
- `drupal/drupal-driver` constraint changed from `"dev-master as 3.0.0"` to `"^3.0.0-alpha1"` - uses the tagged release instead of a dev-master alias; the `^` range allows any compatible 3.x release going forward.
- Added `"minimum-stability": "alpha"` - required because Composer's default stability is `stable` and it will refuse to resolve a `*-alpha1` package without this setting. `prefer-stable: true` is already present, so stable packages are still preferred when available.
- `branch-alias` updated from `"dev-5.x": "5.4.x-dev"` to `"dev-main": "6.0.x-dev"` - the 5.x maintenance line lives on the `5.x` branch now; consumers requiring `dev-main` resolve to 6.0.x-dev.

**`README.md`**
- Development note updated: "This `main` branch is under heavy development for version `6.x`" replaced with "Version `6.0.0-alpha1` has been released and runs on DrupalDriver `3.x`."

## Before / After

```
composer.json - dependency constraint
┌─────────────────────────────────────────────────────────────────┐
│ BEFORE                          │ AFTER                         │
├─────────────────────────────────┼───────────────────────────────┤
│ "drupal/drupal-driver":         │ "drupal/drupal-driver":       │
│   "dev-master as 3.0.0"         │   "^3.0.0-alpha1"             │
│                                 │                               │
│ (no minimum-stability)          │ "minimum-stability": "alpha"  │
│                                 │                               │
│ branch-alias:                   │ branch-alias:                 │
│   "dev-5.x": "5.4.x-dev"        │   "dev-main": "6.0.x-dev"     │
└─────────────────────────────────┴───────────────────────────────┘

Composer resolution path
┌──────────────────────────────────────────────────────────────────┐
│ BEFORE                                                           │
│  composer.json ──► dev-master as 3.0.0 ──► git HEAD of master    │
│                                                                  │
│ AFTER                                                            │
│  composer.json ──► ^3.0.0-alpha1 ──► released tag 3.0.0-alpha1   │
│                    (minimum-stability: alpha unlocks pre-release)│
└──────────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Version 6.0.0-alpha1 release documentation updated; now requires DrupalDriver version 3.x for compatibility.
  * Clear migration path provided for version 5.x users to the dedicated maintenance branch.

* **Chores**
  * Updated package dependencies to align with DrupalDriver 3.x alpha release requirements.
  * Modified stability configuration to properly handle and prefer pre-release versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->