### PR TITLE
Allowed bundle fields defined in hooks to be recognised.

### DIFF
--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -424,7 +424,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface, D
       throw new \RuntimeException(sprintf('The active Drupal driver "%s" does not support field inspection.', $driver::class));
     }
 
-    $parser = $this->getFieldParser($stub->getEntityType(), $driver->getCore()->getFieldClassifier());
+    $parser = $this->getFieldParser($stub->getEntityType(), $driver->getCore()->getFieldClassifier(), $stub->getBundle());
     $parser->ignoring($ignored_properties);
 
     $parsed = $parser->parse($stub->getValues());
@@ -440,16 +440,16 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface, D
    * that will be removed in 6.1). Override in a subclass to swap in a
    * custom implementation.
    */
-  protected function getFieldParser(string $entity_type, FieldClassifierInterface $classifier): EntityFieldParserInterface {
+  protected function getFieldParser(string $entity_type, FieldClassifierInterface $classifier, ?string $bundle = null): EntityFieldParserInterface {
     $mode = $this->getParameter('field_parser') ?? 'default';
 
     if ($mode === 'legacy') {
       $this->triggerDeprecation('The legacy field parser is deprecated in drupal-extension:6.0.0 and is removed from drupal-extension:6.1.0. Remove "field_parser: legacy" from your behat.yml to migrate. See https://github.com/jhedstrom/drupalextension/blob/main/UPGRADING.md');
 
-      return new LegacyEntityFieldParser($entity_type, $classifier);
+      return new LegacyEntityFieldParser($entity_type, $classifier, $bundle);
     }
 
-    return new EntityFieldParser($entity_type, $classifier);
+    return new EntityFieldParser($entity_type, $classifier, $bundle);
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -440,7 +440,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface, D
    * that will be removed in 6.1). Override in a subclass to swap in a
    * custom implementation.
    */
-  protected function getFieldParser(string $entity_type, FieldClassifierInterface $classifier, ?string $bundle = null): EntityFieldParserInterface {
+  protected function getFieldParser(string $entity_type, FieldClassifierInterface $classifier, ?string $bundle = NULL): EntityFieldParserInterface {
     $mode = $this->getParameter('field_parser') ?? 'default';
 
     if ($mode === 'legacy') {

--- a/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
+++ b/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
@@ -44,11 +44,23 @@ final class EntityFieldParser implements EntityFieldParserInterface {
   protected array $ignoredProperties = [];
 
   /**
-   * Constructs the parser for one entity-type / classifier pairing.
+   * Constructs the parser for one entity-type / bundle / classifier pairing.
+   *
+   * @param string $entityType
+   *   The entity type ID.
+   * @param \Drupal\Driver\Core\Field\FieldClassifierInterface $fieldClassifier
+   *   The field classifier.
+   * @param string|null $bundle
+   *   The bundle for the stub being parsed, or NULL for entity types
+   *   without bundles. When provided, bundle-scoped fields (F6-F9) are
+   *   accepted as known fields rather than triggering the unknown-field
+   *   guard - their values flow to the entity unchanged so the bundle's
+   *   field item-list class can take over at save.
    */
   public function __construct(
     protected readonly string $entityType,
     protected readonly FieldClassifierInterface $fieldClassifier,
+    protected readonly ?string $bundle = null,
   ) {
   }
 
@@ -113,12 +125,21 @@ final class EntityFieldParser implements EntityFieldParserInterface {
         }
       }
       else {
-        $is_base_field = $this->fieldClassifier->fieldIsBaseStandard($this->entityType, $field_name)
+        $is_known = $this->fieldClassifier->fieldIsBaseStandard($this->entityType, $field_name)
           || $this->fieldClassifier->fieldIsBaseComputedReadOnly($this->entityType, $field_name)
           || $this->fieldClassifier->fieldIsBaseComputedWritable($this->entityType, $field_name)
-          || $this->fieldClassifier->fieldIsBaseCustomStorage($this->entityType, $field_name);
+          || $this->fieldClassifier->fieldIsBaseCustomStorage($this->entityType, $field_name)
+          || (
+            $this->bundle !== null
+            && (
+              $this->fieldClassifier->fieldIsBundleComputedReadOnly($this->entityType, $field_name, $this->bundle)
+              || $this->fieldClassifier->fieldIsBundleComputedWritable($this->entityType, $field_name, $this->bundle)
+              || $this->fieldClassifier->fieldIsBundleCustomStorage($this->entityType, $field_name, $this->bundle)
+              || $this->fieldClassifier->fieldIsBundleStorageBacked($this->entityType, $field_name, $this->bundle)
+            )
+          );
 
-        if (!$is_base_field && !in_array($field_name, $this->ignoredProperties, TRUE)) {
+        if (!$is_known && !in_array($field_name, $this->ignoredProperties, TRUE)) {
           throw new \RuntimeException(sprintf('Field "%s" does not exist on entity type "%s".', $field_name, $this->entityType));
         }
 

--- a/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
+++ b/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
@@ -125,6 +125,13 @@ final class EntityFieldParser implements EntityFieldParserInterface {
         }
       }
       else {
+        // The classifier splits base fields across F1-F4 (standard, computed
+        // read-only, computed writable, custom storage). All four predicates
+        // must be checked so computed and custom-storage base fields like
+        // 'moderation_state' do not trip the unknown-field guard. When the
+        // bundle is known, also accept F6-F9 (bundle-scoped fields) so that
+        // fields contributed via 'hook_entity_bundle_field_info()' are
+        // recognised.
         $is_known = $this->fieldClassifier->fieldIsBaseStandard($this->entityType, $field_name)
           || $this->fieldClassifier->fieldIsBaseComputedReadOnly($this->entityType, $field_name)
           || $this->fieldClassifier->fieldIsBaseComputedWritable($this->entityType, $field_name)

--- a/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
+++ b/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
@@ -60,7 +60,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
   public function __construct(
     protected readonly string $entityType,
     protected readonly FieldClassifierInterface $fieldClassifier,
-    protected readonly ?string $bundle = null,
+    protected readonly ?string $bundle = NULL,
   ) {
   }
 
@@ -137,7 +137,7 @@ final class EntityFieldParser implements EntityFieldParserInterface {
           || $this->fieldClassifier->fieldIsBaseComputedWritable($this->entityType, $field_name)
           || $this->fieldClassifier->fieldIsBaseCustomStorage($this->entityType, $field_name)
           || (
-            $this->bundle !== null
+            $this->bundle !== NULL
             && (
               $this->fieldClassifier->fieldIsBundleComputedReadOnly($this->entityType, $field_name, $this->bundle)
               || $this->fieldClassifier->fieldIsBundleComputedWritable($this->entityType, $field_name, $this->bundle)

--- a/src/Drupal/DrupalExtension/Parser/LegacyEntityFieldParser.php
+++ b/src/Drupal/DrupalExtension/Parser/LegacyEntityFieldParser.php
@@ -86,11 +86,21 @@ final class LegacyEntityFieldParser implements EntityFieldParserInterface {
   protected array $ignoredProperties = [];
 
   /**
-   * Constructs the parser for one entity-type / classifier pairing.
+   * Constructs the parser for one entity-type / bundle / classifier pairing.
+   *
+   * @param string $entityType
+   *   The entity type ID.
+   * @param \Drupal\Driver\Core\Field\FieldClassifierInterface $fieldClassifier
+   *   The field classifier.
+   * @param string|null $bundle
+   *   The bundle for the stub being parsed, or NULL when the entity type
+   *   has no bundles. When provided, bundle-scoped fields (F6-F9) are
+   *   accepted as known fields.
    */
   public function __construct(
     protected readonly string $entityType,
     protected readonly FieldClassifierInterface $fieldClassifier,
+    protected readonly ?string $bundle = null,
   ) {
   }
 
@@ -188,13 +198,25 @@ final class LegacyEntityFieldParser implements EntityFieldParserInterface {
         // The classifier splits base fields across F1-F4 (standard, computed
         // read-only, computed writable, custom storage). All four predicates
         // must be checked so computed and custom-storage base fields like
-        // 'moderation_state' do not trip the unknown-field guard.
-        $is_base_field = $this->fieldClassifier->fieldIsBaseStandard($this->entityType, $field_name)
+        // 'moderation_state' do not trip the unknown-field guard. When the
+        // bundle is known, also accept F6-F9 (bundle-scoped fields) so that
+        // fields contributed via 'hook_entity_bundle_field_info()' such as
+        // rdf_sync's 'uri' are recognised.
+        $is_known = $this->fieldClassifier->fieldIsBaseStandard($this->entityType, $field_name)
           || $this->fieldClassifier->fieldIsBaseComputedReadOnly($this->entityType, $field_name)
           || $this->fieldClassifier->fieldIsBaseComputedWritable($this->entityType, $field_name)
-          || $this->fieldClassifier->fieldIsBaseCustomStorage($this->entityType, $field_name);
+          || $this->fieldClassifier->fieldIsBaseCustomStorage($this->entityType, $field_name)
+          || (
+            $this->bundle !== null
+            && (
+              $this->fieldClassifier->fieldIsBundleComputedReadOnly($this->entityType, $field_name, $this->bundle)
+              || $this->fieldClassifier->fieldIsBundleComputedWritable($this->entityType, $field_name, $this->bundle)
+              || $this->fieldClassifier->fieldIsBundleCustomStorage($this->entityType, $field_name, $this->bundle)
+              || $this->fieldClassifier->fieldIsBundleStorageBacked($this->entityType, $field_name, $this->bundle)
+            )
+          );
 
-        if (!$is_base_field && !in_array($field_name, $this->ignoredProperties, TRUE)) {
+        if (!$is_known && !in_array($field_name, $this->ignoredProperties, TRUE)) {
           throw new \RuntimeException(sprintf('Field "%s" does not exist on entity type "%s".', $field_name, $this->entityType));
         }
 

--- a/src/Drupal/DrupalExtension/Parser/LegacyEntityFieldParser.php
+++ b/src/Drupal/DrupalExtension/Parser/LegacyEntityFieldParser.php
@@ -100,7 +100,7 @@ final class LegacyEntityFieldParser implements EntityFieldParserInterface {
   public function __construct(
     protected readonly string $entityType,
     protected readonly FieldClassifierInterface $fieldClassifier,
-    protected readonly ?string $bundle = null,
+    protected readonly ?string $bundle = NULL,
   ) {
   }
 
@@ -207,7 +207,7 @@ final class LegacyEntityFieldParser implements EntityFieldParserInterface {
           || $this->fieldClassifier->fieldIsBaseComputedWritable($this->entityType, $field_name)
           || $this->fieldClassifier->fieldIsBaseCustomStorage($this->entityType, $field_name)
           || (
-            $this->bundle !== null
+            $this->bundle !== NULL
             && (
               $this->fieldClassifier->fieldIsBundleComputedReadOnly($this->entityType, $field_name, $this->bundle)
               || $this->fieldClassifier->fieldIsBundleComputedWritable($this->entityType, $field_name, $this->bundle)

--- a/src/Drupal/DrupalExtension/Parser/LegacyEntityFieldParser.php
+++ b/src/Drupal/DrupalExtension/Parser/LegacyEntityFieldParser.php
@@ -200,8 +200,8 @@ final class LegacyEntityFieldParser implements EntityFieldParserInterface {
         // must be checked so computed and custom-storage base fields like
         // 'moderation_state' do not trip the unknown-field guard. When the
         // bundle is known, also accept F6-F9 (bundle-scoped fields) so that
-        // fields contributed via 'hook_entity_bundle_field_info()' such as
-        // rdf_sync's 'uri' are recognised.
+        // fields contributed via 'hook_entity_bundle_field_info()' are
+        // recognised.
         $is_known = $this->fieldClassifier->fieldIsBaseStandard($this->entityType, $field_name)
           || $this->fieldClassifier->fieldIsBaseComputedReadOnly($this->entityType, $field_name)
           || $this->fieldClassifier->fieldIsBaseComputedWritable($this->entityType, $field_name)

--- a/tests/phpunit/src/Parser/EntityFieldParserTest.php
+++ b/tests/phpunit/src/Parser/EntityFieldParserTest.php
@@ -542,4 +542,78 @@ class EntityFieldParserTest extends TestCase {
     }
   }
 
+  /**
+   * Tests that bundle-scoped fields pass through when the bundle is known.
+   *
+   * Regression guard: each bundle predicate F6-F9 must be checked so a
+   * field contributed via 'hook_entity_bundle_field_info()' does not
+   * trigger the unknown-field error.
+   *
+   * @param string $true_predicate
+   *   The classifier predicate that returns TRUE for this scenario.
+   */
+  #[DataProvider('dataProviderParseAcceptsBundleFields')]
+  public function testParseAcceptsBundleFields(string $true_predicate): void {
+    $bundle_predicates = [
+      'fieldIsBundleComputedReadOnly',
+      'fieldIsBundleComputedWritable',
+      'fieldIsBundleCustomStorage',
+      'fieldIsBundleStorageBacked',
+    ];
+
+    $classifier = $this->createMock(FieldClassifierInterface::class);
+    $classifier->method('fieldIsConfigurable')->willReturn(FALSE);
+    $classifier->method('fieldIsBaseStandard')->willReturn(FALSE);
+    $classifier->method('fieldIsBaseComputedReadOnly')->willReturn(FALSE);
+    $classifier->method('fieldIsBaseComputedWritable')->willReturn(FALSE);
+    $classifier->method('fieldIsBaseCustomStorage')->willReturn(FALSE);
+
+    foreach ($bundle_predicates as $predicate) {
+      $classifier->method($predicate)->willReturn($predicate === $true_predicate);
+    }
+
+    $parser = new EntityFieldParser('node', $classifier, 'article');
+
+    $this->assertSame(
+      ['uri' => 'http://example.com/node/1'],
+      $parser->parse(['uri' => 'http://example.com/node/1']),
+    );
+  }
+
+  /**
+   * Tests that bundle predicates are not consulted when no bundle is given.
+   *
+   * When the parser is constructed without a bundle, a field that only
+   * matches a bundle predicate must still trip the unknown-field guard.
+   */
+  public function testParseWithoutBundleRejectsBundleField(): void {
+    $classifier = $this->createMock(FieldClassifierInterface::class);
+    $classifier->method('fieldIsConfigurable')->willReturn(FALSE);
+    $classifier->method('fieldIsBaseStandard')->willReturn(FALSE);
+    $classifier->method('fieldIsBaseComputedReadOnly')->willReturn(FALSE);
+    $classifier->method('fieldIsBaseComputedWritable')->willReturn(FALSE);
+    $classifier->method('fieldIsBaseCustomStorage')->willReturn(FALSE);
+    $classifier->expects($this->never())->method('fieldIsBundleComputedReadOnly');
+    $classifier->expects($this->never())->method('fieldIsBundleComputedWritable');
+    $classifier->expects($this->never())->method('fieldIsBundleCustomStorage');
+    $classifier->expects($this->never())->method('fieldIsBundleStorageBacked');
+
+    $parser = new EntityFieldParser('node', $classifier);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Field "uri" does not exist on entity type "node".');
+
+    $parser->parse(['uri' => 'http://example.com/node/1']);
+  }
+
+  /**
+   * Provides data for testParseAcceptsBundleFields().
+   */
+  public static function dataProviderParseAcceptsBundleFields(): \Iterator {
+    yield 'F6 bundle computed read-only' => ['fieldIsBundleComputedReadOnly'];
+    yield 'F7 bundle computed writable' => ['fieldIsBundleComputedWritable'];
+    yield 'F8 bundle custom storage' => ['fieldIsBundleCustomStorage'];
+    yield 'F9 bundle storage backed' => ['fieldIsBundleStorageBacked'];
+  }
+
 }

--- a/tests/phpunit/src/Parser/LegacyEntityFieldParserTest.php
+++ b/tests/phpunit/src/Parser/LegacyEntityFieldParserTest.php
@@ -280,4 +280,78 @@ class LegacyEntityFieldParserTest extends TestCase {
     yield 'F4 base custom storage' => ['fieldIsBaseCustomStorage'];
   }
 
+  /**
+   * Tests that bundle-scoped fields pass through when the bundle is known.
+   *
+   * Regression guard: each bundle predicate F6-F9 must be checked so a
+   * field contributed via 'hook_entity_bundle_field_info()' does not
+   * trigger the unknown-field error.
+   *
+   * @param string $true_predicate
+   *   The classifier predicate that returns TRUE for this scenario.
+   */
+  #[DataProvider('dataProviderParseAcceptsBundleFields')]
+  public function testParseAcceptsBundleFields(string $true_predicate): void {
+    $bundle_predicates = [
+      'fieldIsBundleComputedReadOnly',
+      'fieldIsBundleComputedWritable',
+      'fieldIsBundleCustomStorage',
+      'fieldIsBundleStorageBacked',
+    ];
+
+    $classifier = $this->createMock(FieldClassifierInterface::class);
+    $classifier->method('fieldIsConfigurable')->willReturn(FALSE);
+    $classifier->method('fieldIsBaseStandard')->willReturn(FALSE);
+    $classifier->method('fieldIsBaseComputedReadOnly')->willReturn(FALSE);
+    $classifier->method('fieldIsBaseComputedWritable')->willReturn(FALSE);
+    $classifier->method('fieldIsBaseCustomStorage')->willReturn(FALSE);
+
+    foreach ($bundle_predicates as $predicate) {
+      $classifier->method($predicate)->willReturn($predicate === $true_predicate);
+    }
+
+    $parser = new LegacyEntityFieldParser('node', $classifier, 'article');
+
+    $this->assertSame(
+      ['uri' => 'http://example.com/node/1'],
+      $parser->parse(['uri' => 'http://example.com/node/1']),
+    );
+  }
+
+  /**
+   * Tests that bundle predicates are not consulted when no bundle is given.
+   *
+   * When the parser is constructed without a bundle, a field that only
+   * matches a bundle predicate must still trip the unknown-field guard.
+   */
+  public function testParseWithoutBundleRejectsBundleField(): void {
+    $classifier = $this->createMock(FieldClassifierInterface::class);
+    $classifier->method('fieldIsConfigurable')->willReturn(FALSE);
+    $classifier->method('fieldIsBaseStandard')->willReturn(FALSE);
+    $classifier->method('fieldIsBaseComputedReadOnly')->willReturn(FALSE);
+    $classifier->method('fieldIsBaseComputedWritable')->willReturn(FALSE);
+    $classifier->method('fieldIsBaseCustomStorage')->willReturn(FALSE);
+    $classifier->expects($this->never())->method('fieldIsBundleComputedReadOnly');
+    $classifier->expects($this->never())->method('fieldIsBundleComputedWritable');
+    $classifier->expects($this->never())->method('fieldIsBundleCustomStorage');
+    $classifier->expects($this->never())->method('fieldIsBundleStorageBacked');
+
+    $parser = new LegacyEntityFieldParser('node', $classifier);
+
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('Field "uri" does not exist on entity type "node".');
+
+    $parser->parse(['uri' => 'http://example.com/node/1']);
+  }
+
+  /**
+   * Provides data for testParseAcceptsBundleFields().
+   */
+  public static function dataProviderParseAcceptsBundleFields(): \Iterator {
+    yield 'F6 bundle computed read-only' => ['fieldIsBundleComputedReadOnly'];
+    yield 'F7 bundle computed writable' => ['fieldIsBundleComputedWritable'];
+    yield 'F8 bundle custom storage' => ['fieldIsBundleCustomStorage'];
+    yield 'F9 bundle storage backed' => ['fieldIsBundleStorageBacked'];
+  }
+
 }


### PR DESCRIPTION
> Iterates on #851 by @idimopoulos. Thank you for the contribution!

## Summary

Fields contributed via `hook_entity_bundle_field_info()` - such as the `uri` field provided by the `rdf_sync` module - were being rejected by the entity-field parsers with an "unknown field" exception. This happened because the validation predicate only consulted F1-F4 (the four base-field classifiers), which do not cover bundle-scoped fields. The fix passes the stub's bundle through `RawDrupalContext::parseEntityFields()` and `getFieldParser()` down to both `EntityFieldParser` and `LegacyEntityFieldParser`, which now accept an optional `?string $bundle` constructor parameter. When a bundle is provided, the `$is_known` predicate also consults F6-F9 (`fieldIsBundleComputedReadOnly`, `fieldIsBundleComputedWritable`, `fieldIsBundleCustomStorage`, `fieldIsBundleStorageBacked`), so hook-contributed fields are accepted and their values flow to the entity unchanged for the bundle's field item-list class to handle at save time.

## Changes

- **Bundle context propagation** - `RawDrupalContext::parseEntityFields()` now forwards `$stub->getBundle()` to `getFieldParser()`, and `getFieldParser()` accepts and passes `?string $bundle = NULL` to whichever parser is instantiated.
- **Parser API** - Both `EntityFieldParser` and `LegacyEntityFieldParser` gain an optional `?string $bundle = NULL` constructor parameter stored as a `readonly` property.
- **Validation logic** - The `$is_known` predicate (formerly `$is_base_field`) now also checks F6-F9 when `$bundle !== NULL`, so bundle-scoped fields contributed by hooks are accepted alongside the four base-field predicates.
- **Comment sync** - The F1-F9 classifier explanation block is now identical in both parsers, documenting what each predicate covers and why bundle checks are guarded by `$bundle !== NULL`.
- **Coding standard** - Aligned `null` literal casing to `NULL` throughout the changed files, per Drupal CS.
- **Tests** - Added `dataProviderParseAcceptsBundleFields` in both `EntityFieldParserTest` and `LegacyEntityFieldParserTest`, covering each F6-F9 predicate independently. A companion guard test confirms that bundle predicates are NOT consulted when bundle is `NULL`, preserving the original strict behaviour for entity types without bundles.

## Before / After

**Before** - only F1-F4 base-field predicates checked; hook-contributed fields always throw.

```
parseEntityFields()
    │
    └─► getFieldParser(entityType, classifier)
            │
            └─► EntityFieldParser(entityType, classifier)
                    │
                    ├─ for each field:
                    │       │
                    │       ├─ F1 fieldIsBaseStandard?         ─┐
                    │       ├─ F2 fieldIsBaseComputedReadOnly?   ├─ YES → accept
                    │       ├─ F3 fieldIsBaseComputedWritable?   │
                    │       └─ F4 fieldIsBaseCustomStorage?     ─┘
                    │               │
                    │               └─ NO → throw "unknown field"
                    │                       ▲
                    │                       └── hook_entity_bundle_field_info()
                    │                           fields land here and FAIL
```

**After** - F6-F9 bundle predicates also checked when bundle is known; hook-contributed fields are accepted.

```
parseEntityFields()
    │
    └─► getFieldParser(entityType, classifier, bundle)
            │
            └─► EntityFieldParser(entityType, classifier, bundle)
                    │
                    ├─ for each field:
                    │       │
                    │       ├─ F1 fieldIsBaseStandard?          ─┐
                    │       ├─ F2 fieldIsBaseComputedReadOnly?    ├─ YES → accept
                    │       ├─ F3 fieldIsBaseComputedWritable?    │
                    │       ├─ F4 fieldIsBaseCustomStorage?      ─┘
                    │       │
                    │       └─ bundle !== NULL?
                    │               │
                    │           YES ├─ F6 fieldIsBundleComputedReadOnly?  ─┐
                    │               ├─ F7 fieldIsBundleComputedWritable?   ├─ YES → accept
                    │               ├─ F8 fieldIsBundleCustomStorage?      │
                    │               └─ F9 fieldIsBundleStorageBacked?     ─┘
                    │                       │
                    │           NO  └───────┴─► throw "unknown field"
                    │
                    └── hook_entity_bundle_field_info() fields
                        now matched by F6-F9 and ACCEPTED ✓
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Entity field parsing now properly validates bundle-scoped fields, preventing false "unknown field" errors when working with bundle-specific field configurations.

* **Tests**
  * Added comprehensive test coverage for bundle-scoped field validation scenarios, including both cases with and without bundle specification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhedstrom/drupalextension/pull/852)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->