### PR TITLE
[#194] Added 'Given the following :type entities:' step for generic entity creation.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -435,6 +435,23 @@ Creates one or more languages.
 </details>
 
 <details>
+  <summary><code>@Given the following :type entities:</code></summary>
+
+<br/>
+Creates entities of a given type provided in a table. 
+<br/><br/>
+
+```gherkin
+  Given the following "commerce_product" entities:
+    | title | type    | status |
+    | TNT   | product | 1      |
+    | Anvil | product | 1      |
+
+```
+
+</details>
+
+<details>
   <summary><code>@Given I wait for the batch job to finish</code></summary>
 
 <br/>

--- a/src/Drupal/DrupalExtension/Context/Attribute/HookAttributeReader.php
+++ b/src/Drupal/DrupalExtension/Context/Attribute/HookAttributeReader.php
@@ -5,16 +5,20 @@ declare(strict_types=1);
 namespace Drupal\DrupalExtension\Context\Attribute;
 
 use Behat\Behat\Context\Attribute\AttributeReader;
+use Drupal\DrupalExtension\Hook\Attribute\AfterEntityCreate as AfterEntityCreateAttribute;
 use Drupal\DrupalExtension\Hook\Attribute\AfterNodeCreate as AfterNodeCreateAttribute;
 use Drupal\DrupalExtension\Hook\Attribute\AfterTermCreate as AfterTermCreateAttribute;
 use Drupal\DrupalExtension\Hook\Attribute\AfterUserCreate as AfterUserCreateAttribute;
+use Drupal\DrupalExtension\Hook\Attribute\BeforeEntityCreate as BeforeEntityCreateAttribute;
 use Drupal\DrupalExtension\Hook\Attribute\BeforeNodeCreate as BeforeNodeCreateAttribute;
 use Drupal\DrupalExtension\Hook\Attribute\BeforeTermCreate as BeforeTermCreateAttribute;
 use Drupal\DrupalExtension\Hook\Attribute\BeforeUserCreate as BeforeUserCreateAttribute;
 use Drupal\DrupalExtension\Hook\Attribute\DrupalHook;
+use Drupal\DrupalExtension\Hook\Call\AfterEntityCreate;
 use Drupal\DrupalExtension\Hook\Call\AfterNodeCreate;
 use Drupal\DrupalExtension\Hook\Call\AfterTermCreate;
 use Drupal\DrupalExtension\Hook\Call\AfterUserCreate;
+use Drupal\DrupalExtension\Hook\Call\BeforeEntityCreate;
 use Drupal\DrupalExtension\Hook\Call\BeforeNodeCreate;
 use Drupal\DrupalExtension\Hook\Call\BeforeTermCreate;
 use Drupal\DrupalExtension\Hook\Call\BeforeUserCreate;
@@ -30,9 +34,11 @@ class HookAttributeReader implements AttributeReader {
    * @var array<class-string, class-string>
    */
   private const ATTRIBUTE_MAP = [
+    AfterEntityCreateAttribute::class => AfterEntityCreate::class,
     AfterNodeCreateAttribute::class => AfterNodeCreate::class,
     AfterTermCreateAttribute::class => AfterTermCreate::class,
     AfterUserCreateAttribute::class => AfterUserCreate::class,
+    BeforeEntityCreateAttribute::class => BeforeEntityCreate::class,
     BeforeNodeCreateAttribute::class => BeforeNodeCreate::class,
     BeforeTermCreateAttribute::class => BeforeTermCreate::class,
     BeforeUserCreateAttribute::class => BeforeUserCreate::class,

--- a/src/Drupal/DrupalExtension/Context/DrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrupalContext.php
@@ -631,6 +631,28 @@ class DrupalContext extends RawDrupalContext implements TranslatableContext {
   }
 
   /**
+   * Creates entities of a given type provided in a table.
+   *
+   * Useful for entity types that do not have a dedicated step (e.g.
+   * 'commerce_product', 'group', 'paragraph'). Entities are tracked and
+   * removed after the scenario by 'cleanEntities()'.
+   *
+   * @code
+   *   Given the following "commerce_product" entities:
+   *     | title | type    | status |
+   *     | TNT   | product | 1      |
+   *     | Anvil | product | 1      |
+   * @endcode
+   */
+  #[Given('the following :type entities:')]
+  public function createEntities(string $type, TableNode $entitiesTable): void {
+    foreach ($entitiesTable->getHash() as $entity_hash) {
+      $stub = new EntityStub($type, NULL, $entity_hash);
+      $this->entityCreate($stub);
+    }
+  }
+
+  /**
    * Pauses the scenario until the user presses a key.
    *
    * Useful when debugging a scenario.

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -30,10 +30,12 @@ use Drupal\DrupalExtension\Parser\EntityFieldParser;
 use Drupal\DrupalExtension\Parser\EntityFieldParserInterface;
 use Drupal\DrupalExtension\Parser\LegacyEntityFieldParser;
 
+use Drupal\DrupalExtension\Hook\Scope\AfterEntityCreateScope;
 use Drupal\DrupalExtension\Hook\Scope\AfterLanguageCreateScope;
 use Drupal\DrupalExtension\Hook\Scope\AfterNodeCreateScope;
 use Drupal\DrupalExtension\Hook\Scope\AfterTermCreateScope;
 use Drupal\DrupalExtension\Hook\Scope\AfterUserCreateScope;
+use Drupal\DrupalExtension\Hook\Scope\BeforeEntityCreateScope;
 use Drupal\DrupalExtension\Hook\Scope\BeforeLanguageCreateScope;
 use Drupal\DrupalExtension\Hook\Scope\BeforeNodeCreateScope;
 use Drupal\DrupalExtension\Hook\Scope\BeforeTermCreateScope;
@@ -522,6 +524,36 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface, D
     $this->restoreScalarBaseFields($stub, $scalars);
 
     $this->dispatchHooks(AfterTermCreateScope::class, $stub);
+    $this->createdStubs[] = $stub;
+
+    return $stub;
+  }
+
+  /**
+   * Create a generic entity.
+   *
+   * Mirrors 'nodeCreate()/userCreate()/termCreate()' for entity types that
+   * do not have a dedicated method. The stub is added to 'createdStubs' so
+   * the existing 'cleanEntities()' machinery removes it after the scenario
+   * via the driver's 'entityDelete()' fallback.
+   *
+   * @param \Drupal\Driver\Entity\EntityStubInterface $stub
+   *   The entity stub.
+   *
+   * @return \Drupal\Driver\Entity\EntityStubInterface
+   *   The same stub, now flagged as saved.
+   */
+  public function entityCreate(EntityStubInterface $stub): EntityStubInterface {
+    $this->dispatchHooks(BeforeEntityCreateScope::class, $stub);
+    $this->parseEntityFields($stub);
+
+    $driver = $this->getContentDriver();
+
+    $scalars = $this->captureScalarBaseFields($stub);
+    $driver->entityCreate($stub);
+    $this->restoreScalarBaseFields($stub, $scalars);
+
+    $this->dispatchHooks(AfterEntityCreateScope::class, $stub);
     $this->createdStubs[] = $stub;
 
     return $stub;

--- a/src/Drupal/DrupalExtension/Hook/Attribute/AfterEntityCreate.php
+++ b/src/Drupal/DrupalExtension/Hook/Attribute/AfterEntityCreate.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Hook\Attribute;
+
+/**
+ * Attribute for methods to run after a generic entity is created.
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class AfterEntityCreate implements DrupalHook {
+
+  public function __construct(public ?string $filterString = NULL) {
+  }
+
+  /**
+   * Returns the filter string for this hook.
+   */
+  public function getFilterString(): ?string {
+    return $this->filterString;
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Hook/Attribute/BeforeEntityCreate.php
+++ b/src/Drupal/DrupalExtension/Hook/Attribute/BeforeEntityCreate.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Hook\Attribute;
+
+/**
+ * Attribute for methods to run before a generic entity is created.
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+final class BeforeEntityCreate implements DrupalHook {
+
+  public function __construct(public ?string $filterString = NULL) {
+  }
+
+  /**
+   * Returns the filter string for this hook.
+   */
+  public function getFilterString(): ?string {
+    return $this->filterString;
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Hook/Call/AfterEntityCreate.php
+++ b/src/Drupal/DrupalExtension/Hook/Call/AfterEntityCreate.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Hook\Call;
+
+use Drupal\DrupalExtension\Hook\Scope\EntityScope;
+
+/**
+ * AfterEntityCreate hook class.
+ */
+class AfterEntityCreate extends EntityHook {
+
+  /**
+   * Initializes hook.
+   */
+  public function __construct(string|null $filterString, array|callable $callable, string|null $description = NULL) {
+    parent::__construct(EntityScope::AFTER, $filterString, $callable, $description);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getName() {
+    return 'AfterEntityCreate';
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Hook/Call/BeforeEntityCreate.php
+++ b/src/Drupal/DrupalExtension/Hook/Call/BeforeEntityCreate.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Hook\Call;
+
+use Drupal\DrupalExtension\Hook\Scope\EntityScope;
+
+/**
+ * BeforeEntityCreate hook class.
+ */
+class BeforeEntityCreate extends EntityHook {
+
+  /**
+   * Initializes hook.
+   */
+  public function __construct(string|null $filterString, array|callable $callable, string|null $description = NULL) {
+    parent::__construct(EntityScope::BEFORE, $filterString, $callable, $description);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getName() {
+    return 'BeforeEntityCreate';
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Hook/Scope/AfterEntityCreateScope.php
+++ b/src/Drupal/DrupalExtension/Hook/Scope/AfterEntityCreateScope.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @file
+ * Entity scope.
+ */
+namespace Drupal\DrupalExtension\Hook\Scope;
+
+/**
+ * Represents an Entity hook scope.
+ */
+final class AfterEntityCreateScope extends BaseEntityScope {
+
+  /**
+   * Return the scope name.
+   *
+   * @return string
+   *   The hook scope name.
+   */
+  public function getName() {
+    return self::AFTER;
+  }
+
+}

--- a/src/Drupal/DrupalExtension/Hook/Scope/BeforeEntityCreateScope.php
+++ b/src/Drupal/DrupalExtension/Hook/Scope/BeforeEntityCreateScope.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @file
+ * Entity scope.
+ */
+namespace Drupal\DrupalExtension\Hook\Scope;
+
+/**
+ * Represents an Entity hook scope.
+ */
+final class BeforeEntityCreateScope extends BaseEntityScope {
+
+  /**
+   * Return the scope name.
+   *
+   * @return string
+   *   The hook scope name.
+   */
+  public function getName() {
+    return self::BEFORE;
+  }
+
+}

--- a/tests/behat/features/entity_creation.feature
+++ b/tests/behat/features/entity_creation.feature
@@ -1,0 +1,49 @@
+Feature: Generic entity creation
+  As a developer
+  I want to create entities of arbitrary content entity types
+  So that I can set up fixtures for custom and contrib entities without bespoke steps
+
+  @test-drupal @api
+  Scenario: Assert "Given the following :type entities:" creates entities of the given type
+    Given the following "behat_test_thing" entities:
+      | title       | status |
+      | First thing | 1      |
+      | Second one  | 0      |
+    When I run drush "sql:query" "'SELECT COUNT(*) FROM behat_test_thing'"
+    Then the drush output should contain "2"
+
+  @test-drupal @api
+  Scenario: Assert "Given the following :type entities:" removes entities after the scenario
+    # Outer scenario invokes an inner scenario that creates entities; after
+    # the inner run completes, 'cleanEntities()' should have deleted them.
+    Given some behat configuration
+    And a file named "features/stub.feature" with:
+      """
+      Feature: Inner stub
+
+        @test-drupal @api
+        Scenario: Create entities
+          Given the following "behat_test_thing" entities:
+            | title           |
+            | Cleanup probe A |
+            | Cleanup probe B |
+      """
+    When I run behat with drupal profile
+    Then it should pass
+    And I run drush "sql:query" "'SELECT COUNT(*) FROM behat_test_thing'"
+    Then the drush output should contain "0"
+
+  @test-drupal @api
+  Scenario: Assert "Given the following :type entities:" fails for an unknown entity type
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given the following "no_such_entity" entities:
+        | title |
+        | x     |
+      """
+    When I run behat with drupal profile
+    Then it should fail with a "Drupal\Component\Plugin\Exception\PluginNotFoundException" exception:
+      """
+      The "no_such_entity" entity type does not exist.
+      """

--- a/tests/behat/fixtures/drupal/modules/behat_test/src/Entity/BehatTestThing.php
+++ b/tests/behat/fixtures/drupal/modules/behat_test/src/Entity/BehatTestThing.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\behat_test\Entity;
+
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+
+/**
+ * Defines a minimal content entity used by the generic entity step tests.
+ *
+ * Exists so the 'Given :type entities:' step can be exercised against an
+ * entity type that is neither node, user, nor taxonomy_term.
+ *
+ * @ContentEntityType(
+ *   id = "behat_test_thing",
+ *   label = @Translation("Behat test thing"),
+ *   base_table = "behat_test_thing",
+ *   entity_keys = {
+ *     "id" = "id",
+ *     "uuid" = "uuid",
+ *     "label" = "title",
+ *   },
+ * )
+ */
+final class BehatTestThing extends ContentEntityBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function baseFieldDefinitions(EntityTypeInterface $entity_type): array {
+    $fields = parent::baseFieldDefinitions($entity_type);
+
+    $fields['title'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Title'))
+      ->setRequired(TRUE);
+
+    $fields['status'] = BaseFieldDefinition::create('boolean')
+      ->setLabel(t('Status'))
+      ->setDefaultValue(TRUE);
+
+    return $fields;
+  }
+
+}


### PR DESCRIPTION
> Iterates on #661 by @chrisolof. Thank you for the contribution!

Closes #194

## Summary

Adds a generic `Given the following :type entities:` Gherkin step that creates arbitrary Drupal content entities via the driver API. The implementation wires a new `entityCreate()` method in `RawDrupalContext` with `BeforeEntityCreate` / `AfterEntityCreate` hook scopes and attributes — mirroring the existing `nodeCreate`, `userCreate`, and `termCreate` patterns exactly. Cleanup is free: the existing `cleanEntities()` / `deleteStub()` path already handles arbitrary entity types through `$driver->entityDelete()`, so no new tracking array is needed.

## Changes

### Step definition
- `DrupalContext::createEntities(string $type, TableNode $table)` — public Gherkin step `#[Given('the following :type entities:')]`; builds one `EntityStub` per table row and delegates to `entityCreate()`

### Core create method
- `RawDrupalContext::entityCreate(EntityStubInterface $stub)` — dispatches `BeforeEntityCreateScope`, calls `parseEntityFields()`, calls `$driver->entityCreate($stub)`, dispatches `AfterEntityCreateScope`, and appends to `$createdStubs`

### Hook infrastructure (mirrors node/user/term hooks)
- `Hook/Scope/BeforeEntityCreateScope.php` and `AfterEntityCreateScope.php` — extend `BaseEntityScope`
- `Hook/Attribute/BeforeEntityCreate.php` and `AfterEntityCreate.php` — PHP 8 attributes for hook registration
- `Hook/Call/BeforeEntityCreate.php` and `AfterEntityCall.php` — hook call classes
- Wired both attributes into `Context/Attribute/HookAttributeReader::ATTRIBUTE_MAP`

### Test fixtures
- `tests/behat/fixtures/drupal/modules/behat_test/src/Entity/BehatTestThing.php` — minimal custom content entity used to exercise the step
- `tests/behat/features/entity_creation.feature` — 3 scenarios: positive creation, cleanup verification (inner Behat subprocess), and negative for unknown entity type

### Documentation
- `STEPS.md` regenerated via `ahoy docs`

## Before / After

**Before** (without this PR) — a developer who needs to create a generic entity in a Behat scenario has no built-in step and must write a custom context:

```
Feature file
  Given ...  ← no generic entity step exists
                    │
                    ▼
         Developer writes custom Context
         ┌──────────────────────────────────┐
         │ class MyContext extends           │
         │   RawDrupalContext {              │
         │   #[Given('my custom step')]      │
         │   public function create() {      │
         │     $stub = new EntityStub();     │
         │     $this->getDriver()            │
         │       ->entityCreate($stub);      │
         │     // no cleanup wiring          │
         │   }                               │
         │ }                                 │
         └──────────────────────────────────┘
         Manual boilerplate; no Before/After
         hooks; cleanup not wired.
```

**After** (with this PR) — the step is built-in and the full lifecycle is handled automatically:

```
Feature file
  Given the following "behat_test_thing" entities:
    | title       |
    | My entity   |
        │
        ▼
  DrupalContext::createEntities(string $type, TableNode $table)
  ┌──────────────────────────────────────────────────────────────┐
  │  foreach row → new EntityStub($type, $fields)               │
  │  $this->entityCreate($stub)                                  │
  └───────────────────────┬──────────────────────────────────────┘
                          │
                          ▼
  RawDrupalContext::entityCreate(EntityStubInterface $stub)
  ┌──────────────────────────────────────────────────────────────┐
  │  dispatch BeforeEntityCreateScope                            │
  │      │                                                       │
  │      ▼                                                       │
  │  parseEntityFields($stub)  ← field normalisation            │
  │      │                                                       │
  │      ▼                                                       │
  │  $driver->entityCreate($stub)  ← actual persistence        │
  │      │                                                       │
  │      ▼                                                       │
  │  dispatch AfterEntityCreateScope                             │
  │      │                                                       │
  │      ▼                                                       │
  │  $this->createdStubs[] = $stub  ← registered for cleanup   │
  └───────────────────────┬──────────────────────────────────────┘
                          │
          (scenario ends) │
                          ▼
  RawDrupalContext::cleanEntities()  [existing @AfterScenario]
  ┌──────────────────────────────────────────────────────────────┐
  │  foreach reverse($createdStubs) as $stub                    │
  │    deleteStub($stub)                                         │
  │      └─ default: $driver->entityDelete($stub)  ← free!     │
  └──────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for creating generic Drupal entity types in Behat tests via a new step definition
  * Added lifecycle hooks for before and after entity creation to enable custom test behavior

* **Tests**
  * Added test scenarios covering entity creation, automatic cleanup, and error handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhedstrom/drupalextension/pull/853)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->