### PR TITLE
[#854] Made 'Before/AfterEntityCreate' hooks fire for every entity create path.

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -492,3 +492,38 @@ store name.
 5. If you subclass any bundled context, rename overridden `@Then` methods to
    the `<concern>Assert<action>` form.
 6. Re-run your Behat suite.
+
+# Upgrading from 6.0 to 6.1
+
+## `Before/AfterEntityCreate` hooks fan out to every entity create path
+
+In 6.0 the `Before/AfterEntityCreateScope` hooks (registered via the
+`#[BeforeEntityCreate]` / `#[AfterEntityCreate]` attributes) only fired
+for the generic `Given the following :type entities:` step that
+`entityCreate()` backs.
+
+In 6.1 these scopes also fire as siblings of the per-type scopes inside
+`nodeCreate()`, `userCreate()`, and `termCreate()`. A single
+`#[BeforeEntityCreate]` / `#[AfterEntityCreate]` handler now observes
+every entity create within a scenario - node, term, user, and generic -
+making it the right tool for cross-cutting concerns like audit logging,
+tagging, or scenario-wide telemetry.
+
+The per-type scopes (`BeforeNodeCreateScope`, `BeforeTermCreateScope`,
+`BeforeUserCreateScope` and their `After*` counterparts) are unchanged
+and remain the correct choice for type-targeted handlers.
+
+Dispatch order within each create path is per-type first, then entity:
+
+```
+nodeCreate()    → BeforeNodeCreateScope    → BeforeEntityCreateScope    → save → AfterNodeCreateScope    → AfterEntityCreateScope
+userCreate()    → BeforeUserCreateScope    → BeforeEntityCreateScope    → save → AfterUserCreateScope    → AfterEntityCreateScope
+termCreate()    → BeforeTermCreateScope    → BeforeEntityCreateScope    → save → AfterTermCreateScope    → AfterEntityCreateScope
+entityCreate()  →                             BeforeEntityCreateScope    → save →                            AfterEntityCreateScope
+```
+
+This is purely additive - no deprecations and no API breaks. If you
+already registered an `#[BeforeEntityCreate]` or `#[AfterEntityCreate]`
+handler against 6.0 expecting it to fire only for the generic step,
+audit the handler before upgrading: it will now fire for every entity
+create in the scenario.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -515,7 +515,7 @@ and remain the correct choice for type-targeted handlers.
 
 Dispatch order within each create path is per-type first, then entity:
 
-```
+```text
 nodeCreate()    → BeforeNodeCreateScope    → BeforeEntityCreateScope    → save → AfterNodeCreateScope    → AfterEntityCreateScope
 userCreate()    → BeforeUserCreateScope    → BeforeEntityCreateScope    → save → AfterUserCreateScope    → AfterEntityCreateScope
 termCreate()    → BeforeTermCreateScope    → BeforeEntityCreateScope    → save → AfterTermCreateScope    → AfterEntityCreateScope

--- a/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawDrupalContext.php
@@ -381,6 +381,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface, D
    */
   public function nodeCreate(EntityStubInterface $stub): EntityStubInterface {
     $this->dispatchHooks(BeforeNodeCreateScope::class, $stub);
+    $this->dispatchHooks(BeforeEntityCreateScope::class, $stub);
     $this->parseEntityFields($stub, ['author']);
 
     $driver = $this->getContentDriver();
@@ -390,6 +391,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface, D
     $this->restoreScalarBaseFields($stub, $scalars);
 
     $this->dispatchHooks(AfterNodeCreateScope::class, $stub);
+    $this->dispatchHooks(AfterEntityCreateScope::class, $stub);
     $this->createdStubs[] = $stub;
 
     return $stub;
@@ -465,6 +467,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface, D
    */
   public function userCreate(EntityStubInterface $stub): EntityStubInterface {
     $this->dispatchHooks(BeforeUserCreateScope::class, $stub);
+    $this->dispatchHooks(BeforeEntityCreateScope::class, $stub);
     $this->parseEntityFields($stub, ['role']);
 
     $driver = $this->getDriver();
@@ -478,6 +481,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface, D
     $this->restoreScalarBaseFields($stub, $scalars);
 
     $this->dispatchHooks(AfterUserCreateScope::class, $stub);
+    $this->dispatchHooks(AfterEntityCreateScope::class, $stub);
     $this->userManager->addUser($stub);
 
     return $stub;
@@ -515,6 +519,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface, D
     }
 
     $this->dispatchHooks(BeforeTermCreateScope::class, $stub);
+    $this->dispatchHooks(BeforeEntityCreateScope::class, $stub);
     $this->parseEntityFields($stub, ['vocabulary_machine_name']);
 
     $driver = $this->getContentDriver();
@@ -524,6 +529,7 @@ class RawDrupalContext extends RawMinkContext implements DrupalAwareInterface, D
     $this->restoreScalarBaseFields($stub, $scalars);
 
     $this->dispatchHooks(AfterTermCreateScope::class, $stub);
+    $this->dispatchHooks(AfterEntityCreateScope::class, $stub);
     $this->createdStubs[] = $stub;
 
     return $stub;

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -27,9 +27,11 @@ use Drupal\Driver\DrupalDriver;
 use Drupal\Driver\Entity\EntityStub;
 use Drupal\Driver\Entity\EntityStubInterface;
 use Drupal\DrupalExtension\Context\MinkContext;
+use Drupal\DrupalExtension\Hook\Attribute\AfterEntityCreate;
 use Drupal\DrupalExtension\Hook\Attribute\AfterNodeCreate;
 use Drupal\DrupalExtension\Hook\Attribute\AfterTermCreate;
 use Drupal\DrupalExtension\Hook\Attribute\AfterUserCreate;
+use Drupal\DrupalExtension\Hook\Attribute\BeforeEntityCreate;
 use Drupal\DrupalExtension\Hook\Attribute\BeforeNodeCreate;
 use Drupal\DrupalExtension\Hook\Attribute\BeforeTermCreate;
 use Drupal\DrupalExtension\Hook\Attribute\BeforeUserCreate;
@@ -51,6 +53,18 @@ class FeatureContext extends RawDrupalContext {
    * The previously remembered user name.
    */
   protected string $previousUserName = '';
+
+  /**
+   * Entity types observed by the generic 'Before/AfterEntityCreate' hooks.
+   *
+   * Populated by 'testRecordBeforeEntityCreate()' /
+   * 'testRecordAfterEntityCreate()' and asserted by
+   * 'testAssertGenericEntityHookFiredFor()'. Reset implicitly by Behat
+   * re-instantiating 'FeatureContext' per scenario.
+   *
+   * @var array<int, string>
+   */
+  protected array $observedEntityCreates = [];
 
   /**
    * Captured MinkContext used by 'testAjaxWaitTimesOutVerbose()'.
@@ -290,6 +304,50 @@ class FeatureContext extends RawDrupalContext {
   public static function testAfterUserCreate(EntityScope $scope): void {
     if ($scope->getStub()->getValues() === []) {
       throw new \Exception('Failed to find a user in @afterUserCreate hook.');
+    }
+  }
+
+  /**
+   * Records every entity type that fires the generic Before hook.
+   */
+  #[BeforeEntityCreate]
+  public function testRecordBeforeEntityCreate(EntityScope $scope): void {
+    $this->observedEntityCreates[] = 'before:' . $scope->getStub()->getEntityType();
+  }
+
+  /**
+   * Records every entity type that fires the generic After hook.
+   */
+  #[AfterEntityCreate]
+  public function testRecordAfterEntityCreate(EntityScope $scope): void {
+    $this->observedEntityCreates[] = 'after:' . $scope->getStub()->getEntityType();
+  }
+
+  /**
+   * Asserts every expected entity type appeared in both Before and After hooks.
+   *
+   * Compares 'observedEntityCreates' against a Gherkin table of expected
+   * entity types. Each expected type must appear as both 'before:<type>' and
+   * 'after:<type>' at least once.
+   */
+  #[Then('the generic entity create hook should have fired for:')]
+  public function testAssertGenericEntityHookFiredFor(TableNode $table): void {
+    $expected = array_column($table->getHash(), 'entity_type');
+    $missing = [];
+
+    foreach ($expected as $type) {
+      foreach (['before', 'after'] as $phase) {
+        if (!in_array($phase . ':' . $type, $this->observedEntityCreates, TRUE)) {
+          $missing[] = $phase . ':' . $type;
+        }
+      }
+    }
+
+    if ($missing !== []) {
+      throw new ExpectationException(
+        sprintf("Generic entity create hook did not fire for: %s.\nObserved: %s.", implode(', ', $missing), implode(', ', $this->observedEntityCreates)),
+        $this->getSession()->getDriver()
+      );
     }
   }
 

--- a/tests/behat/features/entity_creation.feature
+++ b/tests/behat/features/entity_creation.feature
@@ -47,3 +47,27 @@ Feature: Generic entity creation
       """
       The "no_such_entity" entity type does not exist.
       """
+
+  @test-drupal @api
+  Scenario: Assert "Before/AfterEntityCreate" hooks fire for every entity create path
+    # A single Before/AfterEntityCreate handler registered in FeatureContext
+    # must observe all four create paths - user, term, node, and the generic
+    # entityCreate() path - within one scenario.
+    Given the following users:
+      | name        |
+      | Hook probe  |
+    And the following "tags" terms:
+      | name      |
+      | Hook tag  |
+    And the following "article" content:
+      | title         |
+      | Hook article  |
+    And the following "behat_test_thing" entities:
+      | title      |
+      | Hook thing |
+    Then the generic entity create hook should have fired for:
+      | entity_type      |
+      | user             |
+      | taxonomy_term    |
+      | node             |
+      | behat_test_thing |


### PR DESCRIPTION
Closes #854

## Summary

After #853 introduced `BeforeEntityCreateScope` / `AfterEntityCreateScope`, those hooks only fired via the generic `entityCreate()` path (`Given the following :type entities:`). Consumers wanting a single "any entity was created" handler had to register four separate hooks - one per type - to cover node, user, term, and generic creates.

This PR makes `nodeCreate()`, `userCreate()`, and `termCreate()` each dispatch `BeforeEntityCreateScope` and `AfterEntityCreateScope` as siblings of their per-type scopes. Per-type scopes are unchanged. The change is purely additive with no deprecations or API breaks.

## Changes

**`src/Drupal/DrupalExtension/Context/RawDrupalContext.php`**
- Added `dispatchHooks(BeforeEntityCreateScope::class, $stub)` after the per-type Before hook in `nodeCreate()`, `userCreate()`, and `termCreate()`.
- Added `dispatchHooks(AfterEntityCreateScope::class, $stub)` after the per-type After hook in the same three methods.

**`tests/behat/bootstrap/FeatureContext.php`**
- Added `$observedEntityCreates` array property to accumulate hook fire records per scenario.
- Added `#[BeforeEntityCreate]` recorder `testRecordBeforeEntityCreate()` and `#[AfterEntityCreate]` recorder `testRecordAfterEntityCreate()`.
- Added `#[Then]` step `testAssertGenericEntityHookFiredFor()` that asserts all expected entity types appeared in both phases.

**`tests/behat/features/entity_creation.feature`**
- Added a `@test-drupal @api` scenario that creates a user, term, node, and generic entity in one run, then asserts the recorder observed all four types in both `before` and `after` phases.

**`UPGRADING.md`**
- Added "Upgrading from 6.0 to 6.1" section documenting the fan-out behaviour and the dispatch order, with a note for consumers who registered `#[BeforeEntityCreate]` / `#[AfterEntityCreate]` under 6.0 expecting it to fire only for the generic step.

## Before / After

```
Before (6.0)
============

nodeCreate()   ---> BeforeNodeCreateScope
                                           ---> [save]
               ---> AfterNodeCreateScope

userCreate()   ---> BeforeUserCreateScope
                                           ---> [save]
               ---> AfterUserCreateScope

termCreate()   ---> BeforeTermCreateScope
                                           ---> [save]
               ---> AfterTermCreateScope

entityCreate() ---> BeforeEntityCreateScope
                                           ---> [save]
               ---> AfterEntityCreateScope


After (6.1)
===========

nodeCreate()   ---> BeforeNodeCreateScope ---> BeforeEntityCreateScope
                                                                        ---> [save]
               ---> AfterNodeCreateScope  ---> AfterEntityCreateScope

userCreate()   ---> BeforeUserCreateScope ---> BeforeEntityCreateScope
                                                                        ---> [save]
               ---> AfterUserCreateScope  ---> AfterEntityCreateScope

termCreate()   ---> BeforeTermCreateScope ---> BeforeEntityCreateScope
                                                                        ---> [save]
               ---> AfterTermCreateScope  ---> AfterEntityCreateScope

entityCreate() ---> BeforeEntityCreateScope
                                           ---> [save]
               ---> AfterEntityCreateScope

A single #[BeforeEntityCreate] / #[AfterEntityCreate] handler now
observes all four paths. Per-type handlers are unaffected.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added upgrade guide: generic Before/After entity-create hooks now also run for node, user, term and other entity creation paths; guide documents per-path dispatch order and notes this is additive with no API breaks.

* **Tests**
  * Added scenario and step definitions that verify generic Before/After entity-create hooks fire for each entity type created in a scenario.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhedstrom/drupalextension/pull/855)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->