### PR TITLE
[#857] Allowed literal '"' inside unquoted scalar values.

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -116,7 +116,7 @@ a hard configuration error.
 | Scalar containing `,`             | `"Tag, one"`                                                        | `"Tag, one"` (unchanged)                                                                 |
 | Scalar containing ` - `           | `"Alpha - Bravo"` (workaround required)                             | `Alpha - Bravo` (no escape needed)                                                       |
 | Scalar containing `;`             | `Hello; world`                                                      | `"Hello; world"` (new escape required)                                                   |
-| Scalar containing literal `"`     | not expressible                                                     | `note:"He said \"hi\""`                                                                  |
+| Scalar containing literal `"`     | `Hello <a href="x">y</a>` (works incidentally)                      | `Hello <a href="x">y</a>` (allowed; `"` is only structural at item start)                |
 | Scalar that looks like `key:value`| `port:8080` (silent compound risk if value present)                 | `port:8080` (unambiguous scalar)                                                         |
 
 ### Positional compound columns are no longer supported

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "behat/gherkin": "^4.13",
         "behat/mink": "^1.12",
         "behat/mink-browserkit-driver": "^2.1.0",
-        "drupal/drupal-driver": "^3.0.0-rc1",
+        "drupal/drupal-driver": "^3.0.0-RC2",
         "friends-of-behat/mink-extension": "^2.7.1",
         "lullabot/mink-selenium2-driver": "^1.7.4",
         "symfony/css-selector": "^6.4.3 || ^7",

--- a/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
+++ b/src/Drupal/DrupalExtension/Parser/EntityFieldParser.php
@@ -17,7 +17,9 @@ use Drupal\DrupalExtension\Parser\Exception\ParseException;
  *
  *   Scalar mode (no top-level 'key:"...' or 'key:[...]' pattern):
  *     - Plain text or comma-separated list of items.
- *     - Items containing ',' or ';' or '"' must be wrapped in '"..."'.
+ *     - Items containing ',' or ';' must be wrapped in '"..."'.
+ *     - A literal '"' inside an item is allowed; '"' is only structural
+ *       at the start of an item, where it begins a quoted string.
  *
  *   Compound mode (top-level 'key:"...' or 'key:[...]' pattern present):
  *     - One or more 'key: value' columns separated by ','.
@@ -296,7 +298,12 @@ final class EntityFieldParser implements EntityFieldParserInterface {
       else {
         $start = $i;
 
-        while ($i < $length && $cell[$i] !== ',' && $cell[$i] !== ';' && $cell[$i] !== '"') {
+        // '"' is only structural at the start of an item (handled in the
+        // branch above). Once we are inside an unquoted item it can be
+        // any literal character (e.g. an HTML attribute value), so the
+        // stop set is the list separator ',' and the compound-record
+        // separator ';' only.
+        while ($i < $length && $cell[$i] !== ',' && $cell[$i] !== ';') {
           $i++;
         }
 
@@ -310,18 +317,6 @@ final class EntityFieldParser implements EntityFieldParserInterface {
             $cell,
             'Semicolons are not allowed in unquoted scalar values.',
             sprintf('Wrap the value in double quotes: "%s".', $raw),
-          );
-          $i = $length;
-          break;
-        }
-
-        if ($i < $length && $cell[$i] === '"') {
-          $errors[] = new ParseException(
-            'unexpected_quote',
-            $i,
-            $cell,
-            'Unexpected double quote inside an unquoted scalar value.',
-            'Wrap the entire item in double quotes if it contains a literal quote, then escape inner quotes as \\".',
           );
           $i = $length;
           break;

--- a/src/Drupal/DrupalExtension/Parser/README.md
+++ b/src/Drupal/DrupalExtension/Parser/README.md
@@ -15,7 +15,8 @@ A single uniform escape mechanism (double quotes) for compound values. Cells fal
 
 - **Scalar mode** (no top-level `key:"...` or `key:[...]` pattern):
   - Plain text or comma-separated list of items.
-  - Items containing `,` or `;` or `"` must be wrapped in `"..."`.
+  - Items containing `,` or `;` must be wrapped in `"..."`.
+  - A literal `"` inside an item is allowed; `"` is only structural at the start of an item, where it begins a quoted string.
 - **Compound mode** (top-level `key:"...` or `key:[...]` pattern present):
   - One or more `key: value` columns separated by `,`.
   - Multi-value compound: records separated by `;`.
@@ -36,6 +37,8 @@ Errors detected while parsing a single cell are collected and thrown together vi
 | 4  | scalar, single, contains ` - `           | entity_reference title   | `Alpha - Bravo`                                                        |
 | 5  | scalar, single, contains `;`             | text_long                | `"Hello; world"`                                                       |
 | 6  | scalar, looks like `key:value`           | string                   | `port:8080`                                                            |
+| 6a | scalar, single, contains literal `"`     | text_long                | `Hello <a href="https://example.com">link</a>`                         |
+| 6b | scalar, multi-value, items contain `"`   | text_long                | `<a href="https://a.test">A</a>, <a href="https://b.test">B</a>`       |
 | 7  | scalar, multi-value                      | string / list            | `Tag one, Tag two`                                                     |
 | 8  | scalar, multi-value, item contains `,`   | string                   | `Tag one, "Tag, two"`                                                  |
 | 9  | token, single                            | datetime relative        | `[relative:-1 week]`                                                   |
@@ -75,7 +78,7 @@ default:
 
 Parse errors thrown by the modern parser carry:
 
-- `errorCode` - machine-readable identifier (`unclosed_quote`, `unknown_escape`, `unquoted_compound_value`, `empty_record`, `empty_column`, `unclosed_token`, `unquoted_semicolon`, `unexpected_quote`, `unexpected_character`, `expected_quoted_string`, `expected_token`, `trailing_characters`, `invalid_column`).
+- `errorCode` - machine-readable identifier (`unclosed_quote`, `unknown_escape`, `unquoted_compound_value`, `empty_record`, `empty_column`, `unclosed_token`, `unquoted_semicolon`, `unexpected_character`, `expected_quoted_string`, `expected_token`, `trailing_characters`, `invalid_column`).
 - `offset` - zero-based character offset within the cell.
 - `cell` - the cell text being parsed.
 - `description` and optional `hint` - human-readable explanation.

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -22,7 +22,7 @@ use Behat\Hook\AfterScenario;
 use Behat\Hook\BeforeScenario;
 use Behat\Mink\Exception\ExpectationException;
 use Drupal\Core\Database\Database;
-use Drupal\Driver\Core\Field\AbstractHandler;
+use Drupal\Driver\Core\Field\AddressHandler;
 use Drupal\Driver\DrupalDriver;
 use Drupal\Driver\Entity\EntityStub;
 use Drupal\Driver\Entity\EntityStubInterface;
@@ -845,63 +845,21 @@ class FeatureContext extends RawDrupalContext {
  * Handler for the 'behat_test_address_field' fixture field type.
  *
  * The fixture's 'AddressFieldItem' has four columns - country, locality,
- * thoroughfare, postal_code - so the driver's 'DefaultHandler' (single
- * 'value' column only) cannot marshal it. This handler accepts the inline
- * 'key: value' shape produced by 'parseEntityFields()' and returns Drupal
- * storage format directly.
+ * thoroughfare, postal_code - and no single main property. Reuses the
+ * driver's 'AddressHandler' (which already folds multi-column input
+ * shapes into records) by replacing only the visible-fields list.
  *
  * Defined alongside 'FeatureContext' so subprocess Behat runs (which copy
  * only 'FeatureContext.php' to their working dir) pick it up without any
  * extra autoload wiring.
  */
-class BehatTestAddressFieldHandler extends AbstractHandler {
+class BehatTestAddressFieldHandler extends AddressHandler {
 
   /**
    * {@inheritdoc}
    */
-  public function expand($values): array {
-    $columns = ['country', 'locality', 'thoroughfare', 'postal_code'];
-    $expanded = [];
-
-    foreach ($values as $value) {
-      $expanded[] = is_array($value) ? $this->normaliseRow($value, $columns) : [$columns[0] => (string) $value];
-    }
-
-    return $expanded;
-  }
-
-  /**
-   * Normalises a row of key/value or positional values into a column map.
-   *
-   * @param array<int|string, mixed> $value
-   *   Row produced by 'parseEntityFields()'. Keys are either column names
-   *   (when the inline 'key: value' shape was used) or 0-indexed integers
-   *   (when the values were supplied positionally).
-   * @param array<int, string> $columns
-   *   Ordered column names for positional values.
-   *
-   * @return array<string, mixed>
-   *   A row keyed by column name.
-   */
-  protected function normaliseRow(array $value, array $columns): array {
-    $row = [];
-    $position = 0;
-
-    foreach ($value as $key => $field_value) {
-      if (is_string($key)) {
-        $row[$key] = $field_value;
-        continue;
-      }
-
-      if (!isset($columns[$position])) {
-        throw new \RuntimeException(sprintf('Too many positional values supplied for "behat_test_address_field"; only %d columns available.', count($columns)));
-      }
-
-      $row[$columns[$position]] = $field_value;
-      $position++;
-    }
-
-    return $row;
+  protected function getVisibleAddressFields(): array {
+    return ['country', 'locality', 'thoroughfare', 'postal_code'];
   }
 
 }

--- a/tests/behat/features/field_handlers.feature
+++ b/tests/behat/features/field_handlers.feature
@@ -47,6 +47,62 @@ Feature: FieldHandlers
       | field_post_reference | Alpha - Bravo |
     Then I should see "Alpha - Bravo"
 
+  # A scalar cell can carry literal '"' as content. The parser treats '"' as
+  # structural only at the start of an item (where it begins a quoted
+  # string), so HTML attribute values like 'href="..."' pass through.
+  # @see https://github.com/jhedstrom/drupalextension/issues/857
+  @test-drupal @api
+  Scenario: Test multicolumn scalar cell accepts literal '"' in HTML attributes
+    When I am viewing a "post" content with the following fields:
+      | title      | Post with HTML body via multicolumn header                                                                                                                            |
+      | body:value | <p>Visit <a class="internal" href="https://example.com/internal">our internal page</a> or our <a class="external" href="https://example.org/external">partner</a>.</p> |
+      | :format    | basic_html                                                                                                                                                            |
+    Then I should see the link "our internal page"
+    And I should see the link "partner"
+
+  @test-drupal @api
+  Scenario: Test single-cell scalar accepts literal '"' in HTML attributes
+    When I am viewing a "post" content with the following fields:
+      | title | Post with HTML body inline                                                |
+      | body  | Read <a href="https://example.com" data-track="cta">the announcement</a>. |
+    Then I should see "the announcement"
+
+  # Relaxing mid-item '"' must not drop the structural meaning of '"' at the
+  # start of an item: a quoted item with no closing '"' is still a parse
+  # error. Guards against over-relaxation of the scalar grammar.
+  # @see https://github.com/jhedstrom/drupalextension/issues/857
+  @test-drupal @api
+  Scenario: Assert scalar item starting with '"' but never closed is still rejected
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given the following "post" content:
+        | title         | body                 |
+        | Bad scenario  | "unclosed quote body |
+      """
+    When I run behat with drupal profile
+    Then it should fail with a "Drupal\DrupalExtension\Parser\Exception\ParseException" exception:
+      """
+      unclosed_quote
+      """
+
+  # Same guard, complementary case: a closed quoted item followed by extra
+  # unquoted content is still a parse error.
+  @test-drupal @api
+  Scenario: Assert scalar item with trailing junk after closing '"' is still rejected
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given the following "post" content:
+        | title          | body         |
+        | Trailing junk  | "valid"junk  |
+      """
+    When I run behat with drupal profile
+    Then it should fail with a "Drupal\DrupalExtension\Parser\Exception\ParseException" exception:
+      """
+      unexpected_character
+      """
+
   # URI-only link values (no title) are supported via scalar mode: the bare
   # URI is treated as the 'uri' column and the title is left empty, so
   # Drupal renders the URI itself as the visible link text.

--- a/tests/behat/features/field_handlers_legacy.feature
+++ b/tests/behat/features/field_handlers_legacy.feature
@@ -96,7 +96,7 @@ Feature: FieldHandlersLegacyParser
       Then I should see "Alpha - Bravo"
       """
     When I run behat with drupal profile
-    Then it should fail with a "Drupal\Core\Database\InvalidQueryException" exception:
+    Then it should fail with a "InvalidArgumentException" exception:
       """
-      must have an array compatible operator
+      Field record must include the main property "target_id"
       """

--- a/tests/phpunit/src/Parser/EntityFieldParserTest.php
+++ b/tests/phpunit/src/Parser/EntityFieldParserTest.php
@@ -147,6 +147,22 @@ class EntityFieldParserTest extends TestCase {
       ['field_test' => 'port:8080'],
       ['field_test' => ['port:8080']],
     ];
+    // Row 6a: scalar, single, contains literal '"' mid-text. The unquoted
+    // item is read as-is; '"' is only structural at the start of an item.
+    yield '6a. scalar, single, contains literal \'"\'' => [
+      ['field_test' => 'Hello <a href="https://example.com">link</a>'],
+      ['field_test' => ['Hello <a href="https://example.com">link</a>']],
+    ];
+    // Row 6b: scalar, multi-value, each item contains literal '"'.
+    yield '6b. scalar, multi-value, items contain literal \'"\'' => [
+      ['field_test' => '<a href="https://a.test">A</a>, <a href="https://b.test">B</a>'],
+      ['field_test' => ['<a href="https://a.test">A</a>', '<a href="https://b.test">B</a>']],
+    ];
+    // Row 6c: scalar, single, '"' adjacent to the trailing list separator.
+    yield '6c. scalar, multi-value, literal \'"\' right before \',\'' => [
+      ['field_test' => 'abc"def, ghi'],
+      ['field_test' => ['abc"def', 'ghi']],
+    ];
     // Row 7: scalar, multi-value.
     yield '7. scalar, multi-value' => [
       ['field_test' => 'Tag one, Tag two'],
@@ -478,14 +494,6 @@ class EntityFieldParserTest extends TestCase {
       NULL,
       ParseException::class,
       'unexpected_character',
-    ];
-    yield 'error: scalar with unexpected quote inside unquoted item' => [
-      ['field_test' => 'abc"def'],
-      [],
-      NULL,
-      NULL,
-      ParseException::class,
-      'unexpected_quote',
     ];
     yield 'error: compound trailing characters after closing quote' => [
       ['field_test' => 'name:"Alice"junk'],


### PR DESCRIPTION
Closes #857

## Summary

`EntityFieldParser::parseScalarList()` previously stopped scanning an unquoted item the moment it hit a `"` character and threw an `unexpected_quote` error. This broke real-world cells like `<a href="https://example.com">link</a>` even though `"` has no structural meaning mid-item. The fix removes `"` from the unquoted-item stop set so it is treated as a literal character once we are inside an item. The structural role of `"` at the **start** of an item - where it opens a quoted string - is completely unchanged: `"unclosed` still produces `unclosed_quote`, and `"valid"junk` still produces `unexpected_character`. Compound-mode detection (`key:"..."` / `key:[...]` pattern scan) is a separate pass that was not touched.

## Changes

### Parser

- `EntityFieldParser::parseScalarList()` - removed `"` from the `while`-loop stop set in the unquoted-item branch; removed the `unexpected_quote` error block that followed it. `"` is now only structural at the start of an item (the existing branch that enters quoted-string mode is untouched).
- Class docblock + `src/Drupal/DrupalExtension/Parser/README.md` - updated prose and validity table (new rows 6a/6b); removed `unexpected_quote` from the error-code list (no remaining producer).
- `UPGRADING.md` - updated the "Scalar containing literal `"`" migration row to reflect the new behaviour.
- Removed `unexpected_quote` error code entirely - it had no remaining producer.

### Tests

- Unit (`EntityFieldParserTest`): converted the old `error: scalar with unexpected quote inside unquoted item` error case to happy paths; added rows 6a (HTML single value), 6b (HTML multi-value list), 6c (`"` adjacent to `,` separator).
- Behat (`field_handlers.feature`): two positive scenarios asserting that HTML with `href="..."` attributes round-trips through the Drupal field stack; two negative scenarios proving structural meaning of `"` at item start is preserved (`"unclosed` -> `unclosed_quote`; `"valid"junk` -> `unexpected_character`).

## Before / After

```
Scalar-mode item scan (parseScalarList, unquoted-item branch)
─────────────────────────────────────────────────────────────
Before:                              After:
  stop set:  ,   ;   "               stop set:  ,   ;
  on " mid-item → unexpected_quote   on " mid-item → literal character
  (parse aborted, error returned)    (scan continues; item includes '"')
```

```
Parser dispatch for cell '<a href="x">y</a>'
─────────────────────────────────────────────────────────────────────────
parse(cell)
  │
  ├── detectCompoundMode?  ──(unchanged)── no match → scalar path
  │     (looks for top-level 'key:"...' or 'key:[...]' pattern)
  │
  └── parseScalarList()   ──(relaxed)──── unquoted-item scan
        │                                  stop set: , ;   (not ")
        └── items: ['<a href="x">y</a>']   literal " kept as-is
```

The compound-detection pass is a completely separate regex scan that runs
before tokenisation; it was not modified. Only the unquoted-item tokeniser
inside `parseScalarList()` was relaxed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Parser now correctly permits literal double quotes within unquoted scalar values in field definitions.

* **Documentation**
  * Updated parsing documentation to clarify quote handling rules and distinguish between structural and literal quote interpretation.

* **Tests**
  * Expanded test coverage for quote handling in field definition parsing across multiple scenarios and contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhedstrom/drupalextension/pull/858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->