### PR TITLE
Prepared v6 stable release: pinned 'drupal/drupal-driver' to stable v3 and tidied release docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,10 @@ The Drupal Extension is an integration layer between [Behat](http://behat.org),
 provides step definitions for common testing scenarios specific to Drupal
 sites.
 
-> **Note:** Version `6.0.0-alpha1` has been released and runs on
-> DrupalDriver `3.x`. For the `5.x` maintenance line, use the
-> [`5.x` branch](https://github.com/jhedstrom/drupalextension/tree/5.x).
-> See the
-> [6.x epic](https://github.com/jhedstrom/drupalextension/issues/782)
-> for details and progress.
->
-> Upgrading from `5.x`? See [`UPGRADING.md`](UPGRADING.md) for the full list
-> of breaking changes and the step-text migration table.
+> **Note:** v6 supports Drupal 10 and 11 on PHP 8.2+ and runs on
+> DrupalDriver `3.x`. Sites that need Drupal 7 or PHP 8.1 should pin
+> to the [`5.x` branch](https://github.com/jhedstrom/drupalextension/tree/5.x).
+> See [`UPGRADING.md`](UPGRADING.md) for the v5 to v6 migration guide.
 
 ## Use it for testing your Drupal site.
 
@@ -144,7 +139,7 @@ For detailed step documentation, see: vendor/drupal/drupal-extension/STEPS.md
 
 ## Release notes
 
-See [CHANGELOG](CHANGELOG.md).
+See [GitHub Releases](https://github.com/jhedstrom/drupalextension/releases).
 
 ## Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "behat/gherkin": "^4.13",
         "behat/mink": "^1.12",
         "behat/mink-browserkit-driver": "^2.1.0",
-        "drupal/drupal-driver": "^3.0.0-RC2",
+        "drupal/drupal-driver": "^3.0",
         "friends-of-behat/mink-extension": "^2.7.1",
         "lullabot/mink-selenium2-driver": "^1.7.4",
         "symfony/css-selector": "^6.4.3 || ^7",
@@ -88,7 +88,10 @@
         "symfony/yaml": "^6.4.3 || ^7",
         "webmozart/assert": "^2"
     },
-    "minimum-stability": "RC",
+    "conflict": {
+        "drupal/drupal-driver": "<3"
+    },
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "autoload": {
         "psr-0": {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- PHP 8.1 or higher with the `curl`, `mbstring`, and `dom` extensions.
+- PHP 8.2 or higher with the `curl`, `mbstring`, and `dom` extensions.
 - [Composer](https://getcomposer.org/).
 - Drupal 10 or 11.
 - A web server reachable from the machine running Behat (for tests that


### PR DESCRIPTION
## Summary

Prepares the v6 stable release of `drupal/drupal-extension`, pairing it with the now-stable `drupal/drupal-driver` v3. The driver constraint is relaxed from the RC pin to `^3.0` (stable), a `conflict` block is added to block the v2 driver, and `minimum-stability` is tightened from `RC` to `stable`. Supporting documentation is updated to reflect the stable release status and correct PHP requirements.

## Changes

- **`composer.json`**: Relaxed `drupal/drupal-driver` constraint from `^3.0.0-RC2` to `^3.0`; added a `conflict` block to explicitly block `drupal/drupal-driver: <3`; tightened `minimum-stability` from `RC` to `stable`.
- **`README.md`**: Rewrote the top "Note" banner to drop alpha/in-development language and instead document stable v6 support (Drupal 10/11, PHP 8.2+) with a pointer to the `5.x` branch for Drupal 7 / PHP 8.1 users; replaced the broken `CHANGELOG.md` link with a link to GitHub Releases.
- **`docs/installation.md`**: Bumped the PHP requirement from 8.1 to 8.2, matching the `php: ">=8.2"` floor already declared in `composer.json`.

## Before / After

### `composer.json` constraint and stability

```
BEFORE                                          AFTER
┌─────────────────────────────────────────┐    ┌─────────────────────────────────────────────┐
│ "drupal/drupal-driver": "^3.0.0-RC2"    │    │ "drupal/drupal-driver": "^3.0"              │
│                                         │    │                                             │
│ (no conflict block)                     │    │ "conflict": {                               │
│                                         │    │     "drupal/drupal-driver": "<3"            │
│ "minimum-stability": "RC"               │    │ }                                           │
└─────────────────────────────────────────┘    │                                             │
                                               │ "minimum-stability": "stable"               │
                                               └─────────────────────────────────────────────┘
```

### README banner

```
BEFORE                                          AFTER
┌───────────────────────────────────────────┐  ┌───────────────────────────────────────────────┐
│ > Note: Version 6.0.0-alpha1 has been     │  │ > Note: v6 supports Drupal 10 and 11 on       │
│ > released and runs on DrupalDriver 3.x.  │  │ > PHP 8.2+ and runs on DrupalDriver 3.x.      │
│ > For the 5.x maintenance line, use the   │  │ > Sites that need Drupal 7 or PHP 8.1 should  │
│ > 5.x branch. See the 6.x epic for        │  │ > pin to the 5.x branch.                      │
│ > details and progress.                   │  │ > See UPGRADING.md for the v5 to v6 guide.    │
│ >                                         │  └───────────────────────────────────────────────┘
│ > Upgrading from 5.x? See UPGRADING.md   │
│ > for breaking changes.                   │
└───────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated minimum PHP requirement to 8.2+ (previously 8.1+)
  * v6 officially supports Drupal 10 and 11 with stable DrupalDriver 3.x
  * Users on older PHP or Drupal versions should stay on v5.x
  * Migration guide now available for v5 to v6 upgrades
  * Release notes moved to GitHub Releases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jhedstrom/drupalextension/pull/859?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->