### PR TITLE
[#860] Added a test for 'color_field' field support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "behat/gherkin": "^4.13",
         "behat/mink": "^1.12",
         "behat/mink-browserkit-driver": "^2.1.0",
-        "drupal/drupal-driver": "dev-feature/374-color-field-handler as 3.0.x-dev",
+        "drupal/drupal-driver": "dev-feature/374-color-field-handler#7ea0992a351d1cb29cd98e674742db53c25abdac as 3.0.x-dev",
         "friends-of-behat/mink-extension": "^2.7.1",
         "lullabot/mink-selenium2-driver": "^1.7.4",
         "symfony/css-selector": "^6.4.3 || ^7",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "behat/gherkin": "^4.13",
         "behat/mink": "^1.12",
         "behat/mink-browserkit-driver": "^2.1.0",
-        "drupal/drupal-driver": "^3.0",
+        "drupal/drupal-driver": "dev-feature/374-color-field-handler as 3.0.x-dev",
         "friends-of-behat/mink-extension": "^2.7.1",
         "lullabot/mink-selenium2-driver": "^1.7.4",
         "symfony/css-selector": "^6.4.3 || ^7",
@@ -55,6 +55,7 @@
         "drevops/behat-screenshot": "^2.2",
         "drevops/phpcs-standard": "^0.7.0",
         "drupal/coder": "^8.3.27",
+        "drupal/color_field": "^3.0",
         "drupal/core": "^11",
         "drupal/core-composer-scaffold": "^11",
         "drush/drush": "^12.5.2 || ^13.7",
@@ -90,6 +91,17 @@
     },
     "conflict": {
         "drupal/drupal-driver": "<3"
+    },
+    "repositories": {
+        "drupal": {
+            "type": "composer",
+            "url": "https://packages.drupal.org/8"
+        },
+        "drupal-driver": {
+            "no-api": true,
+            "type": "vcs",
+            "url": "https://github.com/jhedstrom/DrupalDriver.git"
+        }
     },
     "minimum-stability": "stable",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "behat/gherkin": "^4.13",
         "behat/mink": "^1.12",
         "behat/mink-browserkit-driver": "^2.1.0",
-        "drupal/drupal-driver": "dev-feature/374-color-field-handler#7ea0992a351d1cb29cd98e674742db53c25abdac as 3.0.x-dev",
+        "drupal/drupal-driver": "^3.1",
         "friends-of-behat/mink-extension": "^2.7.1",
         "lullabot/mink-selenium2-driver": "^1.7.4",
         "symfony/css-selector": "^6.4.3 || ^7",
@@ -96,11 +96,6 @@
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
-        },
-        "drupal-driver": {
-            "no-api": true,
-            "type": "vcs",
-            "url": "https://github.com/jhedstrom/DrupalDriver.git"
         }
     },
     "minimum-stability": "stable",

--- a/tests/behat/features/field_handlers.feature
+++ b/tests/behat/features/field_handlers.feature
@@ -35,6 +35,24 @@ Feature: FieldHandlers
     And I should see "1000"
     And I should see "Louisalaan 1"
 
+  # The color_field contrib module's 'color_field_type' stores a hex color
+  # plus an optional opacity across two columns. Its text formatter lowercases
+  # the hex and appends the opacity, so the stored '#3C5A99' renders as
+  # '#3c5a99' (bare) or '#3c5a99 0.5' (with opacity).
+  @test-drupal @api
+  Scenario: Test color field handler with the bare hex shorthand
+    When I am viewing a "post" content with the following fields:
+      | title            | Post with a bare color |
+      | field_post_color | #3C5A99                |
+    Then I should see "#3c5a99"
+
+  @test-drupal @api
+  Scenario: Test color field handler with an explicit color and opacity
+    When I am viewing a "post" content with the following fields:
+      | title            | Post with color and opacity    |
+      | field_post_color | color:"#3C5A99", opacity:"0.5" |
+    Then I should see "#3c5a99 0.5"
+
   # Entity reference titles containing ' - ' no longer need any escape under
   # the modern parser - dashes are just literal characters in scalar mode.
   @test-drupal @api

--- a/tests/behat/features/field_handlers_legacy.feature
+++ b/tests/behat/features/field_handlers_legacy.feature
@@ -100,3 +100,27 @@ Feature: FieldHandlersLegacyParser
       """
       Field record must include the main property "target_id"
       """
+
+  # The color field handler resolves the same under either parser: the bare
+  # hex maps to the main 'color' property and the ' - '-separated form carries
+  # the opacity. The text formatter lowercases the hex and appends opacity.
+  @test-drupal @api
+  Scenario: Assert color field handler passes under field_parser:legacy
+    Given some behat configuration
+    And the behat configuration uses the legacy field parser
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      When I am viewing a "post" content with the following fields:
+        | title            | Bare color post |
+        | field_post_color | #3C5A99         |
+      Then I should see "#3c5a99"
+      When I am viewing a "post" content with the following fields:
+        | title            | Color and opacity post        |
+        | field_post_color | color: #3C5A99 - opacity: 0.5 |
+      Then I should see "#3c5a99 0.5"
+      """
+    When I run behat with drupal profile
+    Then it should pass with:
+      """
+      1 scenario (1 passed)
+      """

--- a/tests/behat/fixtures/drupal/modules/behat_test/behat_test.info.yml
+++ b/tests/behat/fixtures/drupal/modules/behat_test/behat_test.info.yml
@@ -4,5 +4,6 @@ description: 'Test feature exposing basic configuration for Behat Drupal extensi
 package: Test
 core_version_requirement: ^9 || ^10 || ^11
 dependencies:
+  - color_field:color_field
   - drupal:content_moderation
   - drupal:language

--- a/tests/behat/fixtures/drupal/modules/behat_test/config/install/core.entity_form_display.node.post.default.yml
+++ b/tests/behat/fixtures/drupal/modules/behat_test/config/install/core.entity_form_display.node.post.default.yml
@@ -4,12 +4,14 @@ dependencies:
   config:
     - field.field.node.post.body
     - field.field.node.post.field_post_address
+    - field.field.node.post.field_post_color
     - field.field.node.post.field_post_date
     - field.field.node.post.field_post_links
     - field.field.node.post.field_post_reference
     - field.field.node.post.field_post_select
     - node.type.post
   module:
+    - color_field
     - datetime
     - link
     - path
@@ -77,6 +79,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: behat_test_address_field_default
+  field_post_color:
+    weight: 38
+    settings:
+      placeholder_color: ''
+      placeholder_opacity: ''
+    third_party_settings: {  }
+    type: color_field_widget_default
   field_post_date:
     weight: 33
     settings: {  }

--- a/tests/behat/fixtures/drupal/modules/behat_test/config/install/core.entity_view_display.node.post.default.yml
+++ b/tests/behat/fixtures/drupal/modules/behat_test/config/install/core.entity_view_display.node.post.default.yml
@@ -4,12 +4,14 @@ dependencies:
   config:
     - field.field.node.post.body
     - field.field.node.post.field_post_address
+    - field.field.node.post.field_post_color
     - field.field.node.post.field_post_date
     - field.field.node.post.field_post_links
     - field.field.node.post.field_post_reference
     - field.field.node.post.field_post_select
     - node.type.post
   module:
+    - color_field
     - datetime
     - link
     - options
@@ -43,6 +45,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: behat_test_address_field
+  field_post_color:
+    weight: 108
+    label: above
+    settings:
+      format: hex
+      opacity: true
+    third_party_settings: {  }
+    type: color_field_formatter_text
   field_post_date:
     weight: 103
     label: above

--- a/tests/behat/fixtures/drupal/modules/behat_test/config/install/field.field.node.post.field_post_color.yml
+++ b/tests/behat/fixtures/drupal/modules/behat_test/config/install/field.field.node.post.field_post_color.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_post_color
+    - node.type.post
+  module:
+    - color_field
+id: node.post.field_post_color
+field_name: field_post_color
+entity_type: node
+bundle: post
+label: Color
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  opacity: true
+field_type: color_field_type

--- a/tests/behat/fixtures/drupal/modules/behat_test/config/install/field.storage.node.field_post_color.yml
+++ b/tests/behat/fixtures/drupal/modules/behat_test/config/install/field.storage.node.field_post_color.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - color_field
+    - node
+id: node.field_post_color
+field_name: field_post_color
+entity_type: node
+type: color_field_type
+settings:
+  format: '#HEXHEX'
+module: color_field
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false


### PR DESCRIPTION
Closes #860

## Summary

Adds end-to-end test coverage for the `color_field` contrib module's `color_field_type` field, exercised through the full Drupal Extension path: a Gherkin table cell, the entity-field parser, `drupal/drupal-driver`, Drupal storage, and rendered output. The driver gained a first-class `ColorFieldTypeHandler` in jhedstrom/DrupalDriver#375 (released in `drupal/drupal-driver` v3.1.0). The driver already covers the driver-to-storage hop with a kernel test, but nothing here covered the extension-level path a user actually drives - this closes that gap.

## Changes

### Fixture (`behat_test` module)

- New `field_post_color` field (`color_field_type`) on the `post` node type: `field.storage.node.field_post_color.yml` (storage, `format: '#HEXHEX'`) and `field.field.node.post.field_post_color.yml` (instance, `opacity: true`).
- Wired into the form display (`color_field_widget_default`) and the view display (`color_field_formatter_text`, which renders the value as visible text).
- `behat_test` now depends on `color_field:color_field` so the module is enabled on provision.

### Scenarios

- `field_handlers.feature` (modern parser): the bare-hex shorthand and the `color:"...", opacity:"..."` form.
- `field_handlers_legacy.feature` (legacy parser): the same two forms through the deprecated parser, proving the driver handler resolves identically under either parser.

### Composer

- Added `drupal/color_field` as a `require-dev` test dependency (the issue's recommended option, matching how the driver itself tests the field type for fidelity to its real `preSave()`), and added the `packages.drupal.org/8` repository so the contrib module resolves (the repo had no contrib dependencies before - its `drupal/*` packages are all on Packagist).
- Bumped `drupal/drupal-driver` from `^3.0` to `^3.1`, the release that ships `ColorFieldTypeHandler`.

## Data flow

```
 Gherkin table cell
   | field_post_color | #3C5A99 |
            |
            v
 DrupalExtension entity-field parser        modern: field_handlers.feature
   parse + normalise to a field record      legacy: field_handlers_legacy.feature
            |   ['color' => '#3C5A99']  (or + 'opacity' => '0.5')
            v
 drupal-driver  ColorFieldTypeHandler        <- drupal/drupal-driver v3.1.0
   marshals the two-column value; field type preSave() formats the hex
            |
            v
 Drupal storage   field_post_color.{ color, opacity }
            |
            v
 color_field_formatter_text  ->  rendered "#3c5a99"  /  "#3c5a99 0.5"
            |
            v
 Then I should see "#3c5a99"
```

## Coordination with the driver

`ColorFieldTypeHandler` is new in `drupal/drupal-driver` v3.1.0 (jhedstrom/DrupalDriver#375), which is why this PR requires `^3.1`. The handler and these extension-level scenarios were validated together against the driver branch before that release was tagged, so the two are confirmed compatible.

## Note on rendered output

`color_field_formatter_text` lowercases the hex and appends the opacity, so a stored `#3C5A99` renders as `#3c5a99` (bare) or `#3c5a99 0.5` (with opacity). The scenario assertions reflect this.

## Validation

All 24 field-handlers scenarios pass (145 steps) on Drupal 11 against the released `drupal/drupal-driver` v3.1.0, including no regression in the existing address/reference/link/date scenarios that share the edited display configs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test scenarios for color field formatting with hex shorthand rendering
  * Added test coverage for color field with opacity handling
  * Added legacy field parser test coverage for color field inputs

* **Chores**
  * Updated dependencies to include color_field module support
  * Configured test fixtures for color field functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->