### PR TITLE
[#115] Added 'MappingContext' resolving '{{ Key }}' tokens from 'mappings' config.

### DIFF
--- a/behat.dist.yml
+++ b/behat.dist.yml
@@ -96,6 +96,16 @@ default:
           warning: '.messages--warning'
         login_form_selector: 'form#user-login,form#user-login-form'
         logged_in_selector: 'body.logged-in,body.user-logged-in'
+      # Named value mappings grouped for organisation. A "{{ Key }}" token in
+      # any step argument or table cell is replaced with the mapped value
+      # before the step runs (whitespace inside the braces is ignored). Group
+      # names are organisational only - a key must be unique across all groups.
+      mappings:
+        paths:
+          User Registration: /user/register
+          User Login: /user/login
+        text:
+          Welcome: Welcome back
 
 # Drupal API profile: tests that bootstrap Drupal.
 drupal:

--- a/behat.yml
+++ b/behat.yml
@@ -47,6 +47,7 @@ default:
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\MarkupContext
         - Drupal\DrupalExtension\Context\RandomContext
+        - Drupal\DrupalExtension\Context\MappingContext
         # Helper contexts for test execution and reporting.
         - FeatureContext
         - BehatCliContext
@@ -98,6 +99,11 @@ default:
           error: '.static-messages.static-error'
           success: '.static-messages.static-status'
           warning: '.static-messages.static-warning'
+      mappings:
+        paths:
+          Form Page: "form_controls.html"
+        text:
+          Submit Button: "Submit"
 
     DrevOps\BehatScreenshotExtension:
         dir: '%paths.base%/.logs/screenshots'
@@ -140,6 +146,7 @@ drupal:
         - Drupal\DrupalExtension\Context\MessageContext
         - Drupal\DrupalExtension\Context\MailContext
         - Drupal\DrupalExtension\Context\RandomContext
+        - Drupal\DrupalExtension\Context\MappingContext
         # Helper contexts for test execution and reporting.
         - FeatureContext
         - BehatCliContext
@@ -167,3 +174,8 @@ drupal:
           error: '.messages--error'
           success: '.messages--status'
           warning: '.messages--warning'
+      mappings:
+        paths:
+          User Login: "/user/login"
+        text:
+          Mapped Title: "Welcome Home"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,6 +75,7 @@ Drupal\DrupalExtension:
 | `drush` | Configuration for the [Drush driver](drivers/drush.md). |
 | `drupal` | Configuration for the [Drupal API driver](drivers/drupal-api.md). |
 | `regions` | Maps human-readable region names to CSS selectors. |
+| `mappings` | Named value groups; `{{ Key }}` tokens in steps resolve to the mapped value. See [Mappings](#mappings). |
 | `selectors` | CSS selectors for Drupal status, error, and success messages. |
 | `suppress_deprecations` | Silences `[Deprecation]` notices. See [Suppressing deprecation notices](#suppressing-deprecation-notices). |
 | `text` | Localised or themed strings used by the built-in steps. |
@@ -198,6 +199,40 @@ for the full pattern.
 > map. It still works in 6.0 but emits a deprecation notice and is
 > removed in 6.1. Rename it to `regions`. If both keys are present, an
 > entry under `regions` overrides the same key under `region_map`.
+
+## Mappings
+
+Name values once and reference them with `{{ Key }}` tokens in any step.
+The token is replaced before the step runs, so it works in paths, field
+values, button labels, assertion text - anywhere a step takes a string -
+and in table cells:
+
+```yaml
+Drupal\DrupalExtension:
+  mappings:
+    paths:
+      User Registration: '/user/register'
+      User Login: '/user/login'
+    text:
+      Welcome: 'Welcome back'
+```
+
+```gherkin
+Scenario: Visit a named page
+  Given I am at "{{ User Registration }}"
+  Then I should see the heading "Create new account"
+```
+
+Groups (`paths`, `text` above) exist only to organise the file; a token
+resolves by its bare key, so a key must be unique across every group - a
+duplicate is rejected when Behat loads. Whitespace inside the braces is
+ignored, so `{{ User Login }}` and `{{User Login}}` are equivalent. An
+unknown key fails the step rather than passing the token through, so a
+typo surfaces immediately.
+
+Resolution is provided by `MappingContext`, which must be listed under
+the suite's `contexts`. It is a pure Behat context with no Drupal driver
+dependency - see [Contexts](contexts.md).
 
 ## Suppressing deprecation notices
 

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -18,6 +18,7 @@ declared explicitly.
 | `Drupal\DrupalExtension\Context\DrushContext` | Steps that invoke arbitrary Drush commands. |
 | `Drupal\DrupalExtension\Context\MailContext` | Steps that assert against the Drupal mail collector. |
 | `Drupal\DrupalExtension\Context\RandomContext` | Transforms typed placeholders such as `[?title]` or `[?id:int,1,99]` into random values. Pure Behat context - no Drupal driver, no Mink session. |
+| `Drupal\DrupalExtension\Context\MappingContext` | Replaces `{{ Key }}` tokens with values configured under the `mappings` key. Pure Behat context - no Drupal driver, no Mink session. |
 
 For a complete reference of every step each context exposes, see
 [`STEPS.md`](../STEPS.md).
@@ -135,9 +136,10 @@ browser can extend `RawMinkContext` (or `MinkContext`) and pull in two
 lightweight traits:
 
 - `Drupal\DrupalExtension\ParametersTrait` exposes `getParameter()`,
-  `getDrupalText()`, and `getDrupalSelector()`. It is the consumption
-  point for parameter, text, and selector access from any context,
-  regardless of whether it inherits from `RawDrupalContext`. The
+  `getDrupalText()`, `getDrupalSelector()`, and `getMapping()`. It is the
+  consumption point for parameter, text, selector, and mapping access
+  from any context, regardless of whether it inherits from
+  `RawDrupalContext`. The
   context must also implement
   `Drupal\DrupalExtension\ParametersAwareInterface` so the
   initializer knows to inject the parameter array.
@@ -177,7 +179,7 @@ class CustomMinkContext extends RawMinkContext implements ParametersAwareInterfa
 The bundled `MinkContext`, `MarkupContext`, and `MessageContext`
 follow this pattern - none of them inherit from `RawDrupalContext`.
 
-`RandomContext` goes one step further: it implements
-`Behat\Behat\Context\Context` directly and uses no Mink session at all.
-A consumer can register it in any Behat suite, even one that does not
+`RandomContext` and `MappingContext` go one step further: they implement
+`Behat\Behat\Context\Context` directly and use no Mink session at all.
+A consumer can register them in any Behat suite, even one that does not
 load `Drupal\MinkExtension`.

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -179,6 +179,46 @@ behaviour. They will be removed together once the legacy form is
 dropped, leaving only the modern `transformVariables()` /
 `transformTable()` pair.
 
+## Mappings
+
+`MappingContext` replaces `{{ Key }}` tokens in step text and table
+cells with values configured under the `mappings` key in `behat.yml`.
+Use it to name a path, label, or string once and reuse it across
+scenarios.
+
+Add `Drupal\DrupalExtension\Context\MappingContext` to the suite's
+`contexts` list. Like `RandomContext`, it has no Drupal driver
+dependency, so it works in both Drupal API suites and pure blackbox
+suites.
+
+```yaml
+Drupal\DrupalExtension:
+  mappings:
+    paths:
+      User Registration: '/user/register'
+    text:
+      Welcome: 'Welcome back'
+```
+
+```gherkin
+Scenario: Register through the named page
+  Given I am at "{{ User Registration }}"
+  Then I should see the heading "Create new account"
+  And I should see the text "{{ Welcome }}"
+```
+
+A token resolves by its bare key, so the group it lives in (`paths`,
+`text`) is purely organisational - keys must be unique across all
+groups. Whitespace inside the braces is ignored (`{{ Welcome }}` equals
+`{{Welcome}}`), and an unknown key fails the step instead of passing the
+token through unresolved.
+
+Because resolution happens in a step-argument transform, the token works
+anywhere a step accepts a string - paths, field values, button labels,
+assertion text - not just in dedicated steps. See
+[Configuration - Mappings](configuration.md#mappings) for the config
+reference.
+
 ## Custom step definitions
 
 When the prebuilt steps do not cover a behaviour, write your own. Add

--- a/src/Drupal/DrupalExtension/Context/MappingContext.php
+++ b/src/Drupal/DrupalExtension/Context/MappingContext.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Transformation\Transform;
+use Drupal\DrupalExtension\ParametersAwareInterface;
+use Drupal\DrupalExtension\ParametersTrait;
+
+/**
+ * Replaces '{{ Key }}' tokens in step text and tables with mapped values.
+ *
+ * Mappings are configured under 'Drupal\DrupalExtension: mappings:' as named
+ * groups of key/value pairs. A token of the form '{{ Key }}' in any step
+ * argument or table cell is replaced with the value mapped to 'Key' before
+ * the step runs. Whitespace immediately inside the braces is ignored, so
+ * '{{ Key }}' and '{{Key}}' resolve identically.
+ *
+ * Operates purely on Gherkin step text - no Mink session, no Drupal driver -
+ * so it can be registered in any Behat suite. Resolution keys off the token's
+ * own '{{ }}' delimiters, never the argument's placeholder name, so a single
+ * map covers every step that takes a string without the step having to opt in.
+ *
+ * An unknown key fails the step immediately rather than passing the token
+ * through unresolved, so a typo surfaces as an error instead of a silent
+ * mismatch against literal text.
+ */
+class MappingContext implements Context, ParametersAwareInterface {
+
+  use ParametersTrait;
+
+  /**
+   * Matches one '{{ Key }}' token, capturing the still-untrimmed key.
+   */
+  protected const TOKEN_REGEX = '#\{\{(.+?)\}\}#';
+
+  /**
+   * Replaces every '{{ Key }}' token inside a scalar step argument.
+   *
+   * @param string $argument
+   *   The raw step argument.
+   *
+   * @return string
+   *   The argument with every mapping token resolved.
+   */
+  #[Transform('#(.*\{\{.+?\}\}.*)#')]
+  public function transformMappings(string $argument): string {
+    return $this->substitute($argument);
+  }
+
+  /**
+   * Replaces every '{{ Key }}' token inside a table's cells.
+   *
+   * @param \Behat\Gherkin\Node\TableNode $table
+   *   The raw table argument.
+   *
+   * @return \Behat\Gherkin\Node\TableNode
+   *   A new table with every cell's mapping tokens resolved.
+   */
+  #[Transform('table:*')]
+  public function transformMappingsTable(TableNode $table): TableNode {
+    $rows = [];
+
+    foreach ($table->getRows() as $row) {
+      $rows[] = array_map($this->substitute(...), $row);
+    }
+
+    return new TableNode($rows);
+  }
+
+  /**
+   * Substitutes every mapping token found in a single string.
+   *
+   * @param string $value
+   *   The string to resolve tokens in.
+   *
+   * @return string
+   *   The string with every '{{ Key }}' replaced by its mapped value.
+   */
+  protected function substitute(string $value): string {
+    $result = preg_replace_callback(self::TOKEN_REGEX, fn (array $match): string => (string) $this->getMapping(trim($match[1])), $value);
+
+    return $result ?? $value;
+  }
+
+}

--- a/src/Drupal/DrupalExtension/ParametersTrait.php
+++ b/src/Drupal/DrupalExtension/ParametersTrait.php
@@ -91,4 +91,27 @@ trait ParametersTrait {
     return $text[$name];
   }
 
+  /**
+   * Returns a mapped value by its key.
+   *
+   * Keys are unique across every configured 'mappings' group, so the group
+   * a key lives in is irrelevant to the lookup.
+   *
+   * @param string $name
+   *   The mapping key.
+   *
+   * @return string
+   *   The mapped value.
+   *
+   * @throws \RuntimeException
+   *   Thrown when the key is not present in the configured mappings.
+   */
+  public function getMapping(string $name) {
+    $mappings = $this->getParameter('mappings');
+    if (!isset($mappings[$name])) {
+      throw new \RuntimeException(sprintf('No such mapping: %s', $name));
+    }
+    return $mappings[$name];
+  }
+
 }

--- a/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
+++ b/src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php
@@ -14,6 +14,7 @@ use Drupal\DrupalExtension\Generator\ClassGenerator;
 use Behat\Mink\Element\DocumentElement as MinkDocumentElement;
 use Drupal\DrupalExtension\Element\DocumentElement;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -198,6 +199,17 @@ class DrupalExtension implements ExtensionInterface {
             ->end()
           ->end()
         ->end()
+        ->arrayNode('mappings')
+          ->info('Named value mappings grouped for organisation. A "{{ Key }}" token in any step argument or table cell is replaced with the mapped value before the step runs; whitespace inside the braces is ignored, so "{{ Key }}" and "{{Key}}" are equivalent. Group names are organisational only - a key must be unique across all groups.' . PHP_EOL
+            . '  paths:' . PHP_EOL
+            . '    User Registration: "/user/register"' . PHP_EOL
+            . '    User Login: "/user/login"' . PHP_EOL)
+          ->useAttributeAsKey('group')
+          ->prototype('array')
+            ->useAttributeAsKey('key')
+            ->prototype('scalar')->end()
+          ->end()
+        ->end()
         // Drupal drivers.
         ->arrayNode('blackbox')->end()
         ->arrayNode('drupal')
@@ -250,8 +262,44 @@ class DrupalExtension implements ExtensionInterface {
     $config['regions'] = $regions;
     unset($config['region_map']);
 
+    // Flatten the grouped mappings to a single key => value map that
+    // contexts resolve '{{ Key }}' tokens against. Groups are only a way
+    // to organise the configuration, so a key must be unique across them.
+    $config['mappings'] = $this->flattenMappings($config['mappings'] ?? []);
+
     $container->setParameter('drupal.parameters', $config);
     $container->setParameter('drupal.regions', $regions);
+  }
+
+  /**
+   * Flattens grouped mappings into a single key => value map.
+   *
+   * @param array<string, array<string, string>> $grouped
+   *   Mappings as configured: group name => (key => value).
+   *
+   * @return array<string, string>
+   *   The flattened key => value map.
+   *
+   * @throws \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+   *   When the same key appears in more than one group, which would make the
+   *   bare-key '{{ Key }}' token ambiguous.
+   */
+  protected function flattenMappings(array $grouped): array {
+    $flat = [];
+    $groups = [];
+
+    foreach ($grouped as $group => $entries) {
+      foreach ($entries as $key => $value) {
+        if (isset($groups[$key])) {
+          throw new InvalidConfigurationException(sprintf('Duplicate mapping key "%s" found in groups "%s" and "%s" under "Drupal\DrupalExtension: mappings:". Mapping keys must be unique across all groups.', $key, $groups[$key], $group));
+        }
+
+        $groups[$key] = $group;
+        $flat[$key] = (string) $value;
+      }
+    }
+
+    return $flat;
   }
 
   /**

--- a/tests/behat/bootstrap/BehatCliTrait.php
+++ b/tests/behat/bootstrap/BehatCliTrait.php
@@ -108,7 +108,10 @@ Feature: Stub feature';
 EOL;
 
     $content = strtr($content, $tokens);
-    $content = preg_replace('/\{\{[^\}]+\}\}/', '', $content);
+    // Strip only the harness's own UPPER_SNAKE placeholders if any remain.
+    // A broader '{{...}}' match would also eat MappingContext tokens like
+    // '{{ Some Key }}' that a subprocess scenario legitimately uses.
+    $content = preg_replace('/\{\{[A-Z_]+\}\}/', '', $content);
 
     $filename = 'features/stub.feature';
     $this->createFileInWorkingDir($filename, $content);

--- a/tests/behat/features/mapping.feature
+++ b/tests/behat/features/mapping.feature
@@ -1,0 +1,53 @@
+Feature: mappings configuration
+  As a developer
+  I want to replace "{{ Key }}" tokens in steps with values configured under
+  the "mappings" key in behat.yml
+  So that paths and strings can be named once and reused across scenarios
+
+  # Mappings are grouped only for organisation; tokens resolve by bare key.
+  # The MappingContext transform runs against any step argument, so a token
+  # works wherever a string is accepted, not just in path steps.
+
+  @test-blackbox @mapping
+  Scenario: Assert "{{ Key }}" resolves a configured path
+    Given I am at "{{ Form Page }}"
+    Then I should see the button "Submit" in the "static content" region
+
+  @test-blackbox @mapping
+  Scenario: Assert "{{ Key }}" ignores whitespace inside the braces
+    Given I am at "{{Form Page}}"
+    Then I should see the button "Submit" in the "static content" region
+
+  @test-blackbox @mapping
+  Scenario: Assert a token resolves inside a non-path argument
+    Given I am at "form_controls.html"
+    Then I should see the button "{{ Submit Button }}" in the "static content" region
+
+  @test-blackbox @mapping
+  Scenario: Assert an unknown mapping key fails the step
+    Given some behat configuration
+    And scenario steps tagged with "@test-blackbox @mapping":
+      """
+      Given I am at "index.html"
+      Then I should see the text "{{ Undefined Key }}"
+      """
+    When I run behat
+    Then it should fail with an exception:
+      """
+      No such mapping: Undefined Key
+      """
+
+  # The scenarios below exercise the same tokens through the Drupal API
+  # driver, proving resolution is driver-agnostic - it works against a real
+  # Drupal site, not only the static blackbox fixtures.
+
+  @test-drupal @api @mapping
+  Scenario: Assert "{{ Key }}" resolves a configured path in the Drupal profile
+    Given I am at "{{ User Login }}"
+    Then I should see the text "Log in"
+
+  @test-drupal @api @mapping
+  Scenario: Assert a token resolves in a table cell and in step text under Drupal
+    Given I am viewing a page with the following fields:
+      | title | {{ Mapped Title }} |
+    Then I should see the text "{{ Mapped Title }}"

--- a/tests/phpunit/src/DrupalExtensionMappingsTest.php
+++ b/tests/phpunit/src/DrupalExtensionMappingsTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Tests;
+
+use Drupal\DrupalExtension\ServiceContainer\DrupalExtension;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Tests the grouped-mappings flatten and uniqueness logic.
+ */
+#[CoversMethod(DrupalExtension::class, 'configure')]
+#[CoversMethod(DrupalExtension::class, 'loadParameters')]
+#[CoversMethod(DrupalExtension::class, 'flattenMappings')]
+class DrupalExtensionMappingsTest extends TestCase {
+
+  /**
+   * Tests that grouped mappings flatten to a single key => value map.
+   *
+   * @param array<string, mixed> $config
+   *   The DrupalExtension configuration (raw, before schema normalisation).
+   * @param array<string, string> $expected
+   *   The expected flattened mapping map.
+   */
+  #[DataProvider('dataProviderMappingsFlatten')]
+  public function testMappingsFlatten(array $config, array $expected): void {
+    $parameters = $this->process($config);
+    $this->assertSame($expected, $parameters['mappings']);
+  }
+
+  /**
+   * Provides data for testMappingsFlatten().
+   */
+  public static function dataProviderMappingsFlatten(): \Iterator {
+    yield 'single group flattens to its entries' => [
+      ['mappings' => ['paths' => ['User Registration' => '/user/register', 'User Login' => '/user/login']]],
+      ['User Registration' => '/user/register', 'User Login' => '/user/login'],
+    ];
+
+    yield 'multiple groups merge into one map' => [
+      ['mappings' => ['paths' => ['Home' => '/'], 'text' => ['Greeting' => 'Hello']]],
+      ['Home' => '/', 'Greeting' => 'Hello'],
+    ];
+
+    yield 'no mappings yields an empty map' => [
+      [],
+      [],
+    ];
+  }
+
+  /**
+   * Tests that the same key in two groups is rejected as ambiguous.
+   */
+  public function testDuplicateKeyAcrossGroupsThrows(): void {
+    $this->expectException(InvalidConfigurationException::class);
+    $this->expectExceptionMessage('Duplicate mapping key "Home" found in groups "paths" and "aliases"');
+    $this->process(['mappings' => ['paths' => ['Home' => '/'], 'aliases' => ['Home' => '/front']]]);
+  }
+
+  /**
+   * Runs config through configure() and loadParameters() and returns params.
+   *
+   * @param array<string, mixed> $config
+   *   The DrupalExtension configuration (raw, before schema normalisation).
+   *
+   * @return array<string, mixed>
+   *   The resulting 'drupal.parameters' container parameter.
+   */
+  protected function process(array $config): array {
+    $extension = new MappingsTestableDrupalExtension();
+
+    $builder = new ArrayNodeDefinition('drupal');
+    $extension->configure($builder);
+    $tree = $builder->getNode(TRUE);
+    $processed = $tree->finalize($tree->normalize($config));
+
+    $container = new ContainerBuilder();
+    $extension->callLoadParameters($container, $processed);
+
+    $parameters = $container->getParameter('drupal.parameters');
+    $this->assertIsArray($parameters);
+
+    return $parameters;
+  }
+
+}
+
+/**
+ * Test-only subclass that exposes the protected 'loadParameters' method.
+ */
+// phpcs:ignore Drupal.Classes.ClassFileName.NoMatch
+class MappingsTestableDrupalExtension extends DrupalExtension {
+
+  /**
+   * Public bridge to the protected loadParameters method.
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+   *   The container builder to populate.
+   * @param array<string, mixed> $config
+   *   The processed configuration array.
+   */
+  public function callLoadParameters(ContainerBuilder $container, array $config): void {
+    $this->loadParameters($container, $config);
+  }
+
+}

--- a/tests/phpunit/src/MappingContextTest.php
+++ b/tests/phpunit/src/MappingContextTest.php
@@ -63,7 +63,7 @@ class MappingContextTest extends TestCase {
    * @param string $expected
    *   The argument after every token has been resolved.
    */
-  #[DataProvider('dataProviderTransformMappings')]
+  #[DataProvider('dataProviderTransformMappingsSubstitutesTokens')]
   public function testTransformMappingsSubstitutesTokens(string $argument, string $expected): void {
     $this->assertSame($expected, $this->context->transformMappings($argument));
   }
@@ -71,11 +71,14 @@ class MappingContextTest extends TestCase {
   /**
    * Provides cases for testTransformMappingsSubstitutesTokens().
    */
-  public static function dataProviderTransformMappings(): \Iterator {
+  public static function dataProviderTransformMappingsSubstitutesTokens(): \Iterator {
     yield 'bare token resolves' => ['{{User Registration}}', '/user/register'];
     yield 'token with inner whitespace resolves the same' => ['{{ User Registration }}', '/user/register'];
     yield 'token embedded in surrounding text' => ['go to {{ User Registration }} now', 'go to /user/register now'];
-    yield 'two distinct tokens both resolve' => ['{{User Login}} then {{User Registration}}', '/user/login then /user/register'];
+    yield 'two distinct tokens both resolve' => [
+      '{{User Login}} then {{User Registration}}',
+      '/user/login then /user/register',
+    ];
     yield 'a repeated token resolves every occurrence' => ['{{Greeting}}, {{Greeting}}!', 'Hello World, Hello World!'];
     yield 'a string without tokens is returned unchanged' => ['plain value', 'plain value'];
   }

--- a/tests/phpunit/src/MappingContextTest.php
+++ b/tests/phpunit/src/MappingContextTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\DrupalExtension\Tests;
+
+use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\TableNode;
+use Drupal\DrupalExtension\Context\MappingContext;
+use Drupal\DrupalExtension\ParametersAwareInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests the MappingContext class.
+ *
+ * The class is exercised standalone - no Behat extension, no Mink session,
+ * no Drupal driver - to prove that none of those subsystems are required
+ * to load and use 'MappingContext'.
+ */
+#[CoversClass(MappingContext::class)]
+class MappingContextTest extends TestCase {
+
+  /**
+   * The context under test, primed with a known mapping table.
+   */
+  protected MappingContext $context;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    $this->context = new MappingContext();
+    $this->context->setParameters([
+      'mappings' => [
+        'User Registration' => '/user/register',
+        'User Login' => '/user/login',
+        'Greeting' => 'Hello World',
+      ],
+    ]);
+  }
+
+  /**
+   * Tests the bare-Behat structural promise.
+   *
+   * 'MappingContext' must implement 'Behat\Behat\Context\Context' directly
+   * with no parent class, so it can be loaded in suites that register
+   * neither Mink nor the Drupal extension.
+   */
+  public function testImplementsBareBehatContextWithoutAncestors(): void {
+    $context = new MappingContext();
+    $this->assertInstanceOf(Context::class, $context);
+    $this->assertInstanceOf(ParametersAwareInterface::class, $context);
+    $this->assertSame([], class_parents($context));
+  }
+
+  /**
+   * Tests '{{ Key }}' substitution inside a scalar argument.
+   *
+   * @param string $argument
+   *   The raw step argument.
+   * @param string $expected
+   *   The argument after every token has been resolved.
+   */
+  #[DataProvider('dataProviderTransformMappings')]
+  public function testTransformMappingsSubstitutesTokens(string $argument, string $expected): void {
+    $this->assertSame($expected, $this->context->transformMappings($argument));
+  }
+
+  /**
+   * Provides cases for testTransformMappingsSubstitutesTokens().
+   */
+  public static function dataProviderTransformMappings(): \Iterator {
+    yield 'bare token resolves' => ['{{User Registration}}', '/user/register'];
+    yield 'token with inner whitespace resolves the same' => ['{{ User Registration }}', '/user/register'];
+    yield 'token embedded in surrounding text' => ['go to {{ User Registration }} now', 'go to /user/register now'];
+    yield 'two distinct tokens both resolve' => ['{{User Login}} then {{User Registration}}', '/user/login then /user/register'];
+    yield 'a repeated token resolves every occurrence' => ['{{Greeting}}, {{Greeting}}!', 'Hello World, Hello World!'];
+    yield 'a string without tokens is returned unchanged' => ['plain value', 'plain value'];
+  }
+
+  /**
+   * Tests that whitespace immediately inside the braces is ignored.
+   */
+  public function testWhitespaceInsideBracesIsIgnored(): void {
+    $this->assertSame(
+      $this->context->transformMappings('{{User Registration}}'),
+      $this->context->transformMappings('{{   User Registration   }}'),
+    );
+  }
+
+  /**
+   * Tests that an unknown key fails the step instead of passing through.
+   */
+  public function testUnknownKeyThrows(): void {
+    $this->expectException(\RuntimeException::class);
+    $this->expectExceptionMessage('No such mapping: Missing Page');
+    $this->context->transformMappings('{{ Missing Page }}');
+  }
+
+  /**
+   * Tests that 'transformMappingsTable()' substitutes tokens in cells only.
+   */
+  public function testTransformTableSubstitutesTokensInCells(): void {
+    $table = new TableNode([
+      ['name', 'path'],
+      ['Registration', '{{ User Registration }}'],
+      ['Login', '{{User Login}}'],
+    ]);
+
+    $rows = $this->context->transformMappingsTable($table)->getRows();
+
+    $this->assertSame(['name', 'path'], $rows[0]);
+    $this->assertSame(['Registration', '/user/register'], $rows[1]);
+    $this->assertSame(['Login', '/user/login'], $rows[2]);
+  }
+
+}


### PR DESCRIPTION
Closes #115

## Summary

Added `MappingContext`, a pure Behat transform context that replaces `{{ Key }}` tokens in any step argument or table cell with values configured under a new `mappings` key in `behat.yml`. Mappings are organised into named groups in the config file, but resolve by their bare key, so groups are structural only - a key must be globally unique across all groups, and a duplicate is rejected at config-load time. An unknown key fails the step immediately rather than silently passing the token through unresolved.

## Changes

**New context - `src/Drupal/DrupalExtension/Context/MappingContext.php`**

Implements `Behat\Behat\Context\Context` directly (no Mink, no Drupal driver), modelled on `RandomContext`. Two `#[Transform]` methods cover scalar arguments and `TableNode` cells. The `{{ }}` delimiter was chosen over `[...]` to avoid collision with Drupal token syntax and Mink form-field array names. Whitespace immediately inside the braces is ignored, so `{{ Key }}` and `{{Key}}` resolve identically.

**Config - `src/Drupal/DrupalExtension/ServiceContainer/DrupalExtension.php`**

Added the `mappings` `ArrayNodeDefinition` node. The new `flattenMappings()` method flattens the grouped config into a single key => value map and throws `InvalidConfigurationException` on a cross-group duplicate key, making the ambiguity an explicit load-time error.

**Accessor - `src/Drupal/DrupalExtension/ParametersTrait.php`**

Added `getMapping(string $name): string`, mirroring `getDrupalText()`. Throws `\RuntimeException` when the key is absent.

**Behat config - `behat.yml`, `behat.dist.yml`**

Registered `MappingContext` in all profiles and added example `mappings` entries used by the integration test suite.

**`BehatCliTrait` fix - `tests/behat/bootstrap/BehatCliTrait.php`**

Narrowed the stub-feature placeholder strip regex from `/\{\{[^\}]+\}\}/` (which ate any `{{ ... }}` occurrence) to `/\{\{[A-Z_]+\}\}/` (which strips only the harness's own `{{SCENARIO_CONTENT}}` / `{{ADDITIONAL_TAGS}}` placeholders), so `{{ Key }}` mapping tokens in subprocess scenarios are preserved.

**Unit tests - `tests/phpunit/src/MappingContextTest.php`, `tests/phpunit/src/DrupalExtensionMappingsTest.php`**

`MappingContextTest` covers scalar and table transforms, whitespace normalisation, unknown-key failure, and the no-ancestor structural promise. `DrupalExtensionMappingsTest` covers grouped-to-flat merging, empty config, and duplicate-key rejection.

**Integration tests - `tests/behat/features/mapping.feature`**

Blackbox scenarios (static HTML fixtures) and Drupal-profile scenarios confirm that tokens resolve in path arguments, non-path arguments, and table cells, and that an unknown key fails as expected.

**Documentation - `docs/configuration.md`, `docs/contexts.md`, `docs/writing-tests.md`**

Added a `## Mappings` reference section to each doc, updated the contexts table, and noted that `MappingContext` and `RandomContext` both operate without a Drupal driver.
