### PR TITLE
[#734] Added steps to run a failing drush command and assert its output.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -632,6 +632,34 @@ Given I run drush "config:get" "system.site uuid --format=string"
 </details>
 
 <details>
+  <summary><code>@Given I run the failing drush command :command</code></summary>
+
+<br/>
+Run a Drush command that is expected to fail. 
+<br/><br/>
+
+```gherkin
+Given I run the failing drush command "pm:uninstall no_such_module"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Given I run the failing drush command :command :arguments</code></summary>
+
+<br/>
+Run a Drush command with arguments that is expected to fail. 
+<br/><br/>
+
+```gherkin
+Given I run the failing drush command "pm:uninstall" "no_such_module"
+
+```
+
+</details>
+
+<details>
   <summary><code>@When I print the last drush output</code></summary>
 
 <br/>

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "behat/gherkin": "^4.13",
         "behat/mink": "^1.12",
         "behat/mink-browserkit-driver": "^2.1.0",
-        "drupal/drupal-driver": "^3.1",
+        "drupal/drupal-driver": "dev-master as 3.2.0",
         "friends-of-behat/mink-extension": "^2.7.1",
         "lullabot/mink-selenium2-driver": "^1.7.4",
         "symfony/css-selector": "^6.4.3 || ^7",

--- a/src/Drupal/DrupalExtension/Context/DrushContext.php
+++ b/src/Drupal/DrupalExtension/Context/DrushContext.php
@@ -9,6 +9,7 @@ use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
 use Behat\Behat\Context\TranslatableContext;
+use Drupal\Driver\DrushDriver;
 
 /**
  * Provides step definitions for interacting directly with Drush commands.
@@ -75,6 +76,37 @@ class DrushContext extends RawDrupalContext implements TranslatableContext {
   }
 
   /**
+   * Run a Drush command that is expected to fail.
+   *
+   * The command runs without aborting the step on a non-zero exit, capturing
+   * its error output so it can be asserted with the "the drush output should"
+   * steps. The step fails if the command instead succeeds.
+   *
+   * @code
+   * Given I run the failing drush command "pm:uninstall no_such_module"
+   * @endcode
+   */
+  #[Given('I run the failing drush command :command')]
+  public function iRunFailingDrush(string $command): void {
+    $this->runFailingDrush($command);
+  }
+
+  /**
+   * Run a Drush command with arguments that is expected to fail.
+   *
+   * The arguments string is appended to the command verbatim, so it may
+   * contain Drush options (flags) as well as positional arguments.
+   *
+   * @code
+   * Given I run the failing drush command "pm:uninstall" "no_such_module"
+   * @endcode
+   */
+  #[Given('I run the failing drush command :command :arguments')]
+  public function iRunFailingDrushWithArguments(string $command, string $arguments): void {
+    $this->runFailingDrush($command, $arguments);
+  }
+
+  /**
    * Assert the Drush output contains a string.
    *
    * @code
@@ -126,6 +158,36 @@ class DrushContext extends RawDrupalContext implements TranslatableContext {
   #[When('I print the last drush output')]
   public function iPrintLastDrushOutput(): void {
     echo $this->readDrushOutput();
+  }
+
+  /**
+   * Run a Drush command expecting it to fail, capturing its output.
+   *
+   * @param string $command
+   *   The Drush command to run.
+   * @param string|null $arguments
+   *   Optional arguments string appended to the command verbatim.
+   *
+   * @throws \Behat\Mink\Exception\ExpectationException
+   *   When the command exits with a zero (success) status.
+   */
+  protected function runFailingDrush(string $command, ?string $arguments = NULL): void {
+    $driver = $this->getDriver('drush');
+
+    if (!$driver instanceof DrushDriver) {
+      throw new \RuntimeException(sprintf('The active Drupal driver "%s" does not support capturing drush command results.', $driver::class));
+    }
+
+    $args = $arguments === NULL ? [] : [$this->fixStepArgument($arguments)];
+    $result = $driver->drushResult($command, $args);
+
+    // Prefer stdout, falling back to stderr, to match the success-path output.
+    $output = ($result->output === '' || $result->output === '0') ? $result->errorOutput : $result->output;
+    $this->drushOutput = $output;
+
+    if ($result->exitCode === 0) {
+      throw new ExpectationException(sprintf("Expected the drush command '%s' to fail, but it exited 0.\nOutput:\n\n%s", $command, $output), $this->getSession()->getDriver());
+    }
   }
 
   /**

--- a/tests/behat/features/drush.feature
+++ b/tests/behat/features/drush.feature
@@ -20,6 +20,29 @@ Feature: DrushContext
     And the drush output should not contain "system.site"
 
   @test-drupal @api
+  Scenario: Assert "Given I run the failing drush command :command" passes
+    Given I run the failing drush command "pm:uninstall no_such_module"
+    Then the drush output should contain "no_such_module"
+
+  @test-drupal @api
+  Scenario: Assert "Given I run the failing drush command :command :arguments" passes
+    Given I run the failing drush command "pm:uninstall" "no_such_module"
+    Then the drush output should contain "no_such_module"
+
+  @test-drupal @api
+  Scenario: Assert "Given I run the failing drush command :command" fails when the command succeeds
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      Given I run the failing drush command "status"
+      """
+    When I run behat with drupal profile
+    Then it should fail with an error:
+      """
+      Expected the drush command 'status' to fail, but it exited 0.
+      """
+
+  @test-drupal @api
   Scenario: Assert "Then the drush output should contain :output" passes
     Given I run drush "status"
     Then the drush output should contain "Drupal version"


### PR DESCRIPTION
Closes #734

## Summary

Adds two new `DrushContext` step definitions - `Given I run the failing drush command :command` and `Given I run the failing drush command :command :arguments` - for scenarios that need to assert on the output of a Drush command that is expected to exit non-zero. The new steps capture the command's error output into `$drushOutput` so the existing `the drush output should contain/match/not contain` steps can assert on it, and throw a Mink `ExpectationException` if the command unexpectedly exits 0. Three Behat scenarios are added: two positive cases (`pm:uninstall no_such_module` as a single step and as command + arguments) and one negative case verifying that a command which exits 0 causes the step itself to fail.

## Changes

- **`DrushContext`** - adds `iRunFailingDrush()`, `iRunFailingDrushWithArguments()`, and the protected `runFailingDrush()` helper; uses an `instanceof DrushDriver` guard (the canonical pattern in this codebase) to ensure the driver exposes the new `drushResult()` API; prefers stdout over stderr to mirror the success-path behaviour of the existing `runDrush()` steps.
- **`tests/behat/features/drush.feature`** - adds the three scenarios described above, co-located with the existing drush step tests.
- **`STEPS.md`** - regenerated to include the two new step definitions.
- **`composer.json`** - driver dependency temporarily pinned to `dev-master as 3.2.0` (see Dependencies).

## Before / After

```
BEFORE
┌───────────────────────────────────────────────────────────┐
│ Given I run drush "pm:uninstall no_such_module"           │
│                                                           │
│   non-zero exit                                           │
│       │                                                   │
│       └─► RuntimeException thrown ──► scenario aborts    │
│                                                           │
│   No way to reach "Then the drush output should contain"  │
└───────────────────────────────────────────────────────────┘

AFTER
┌───────────────────────────────────────────────────────────┐
│ Given I run the failing drush command "pm:uninstall       │
│       no_such_module"                                     │
│                                                           │
│   non-zero exit (expected)                                │
│       │                                                   │
│       └─► stderr captured into $drushOutput              │
│                                                           │
│   zero exit (unexpected)                                  │
│       │                                                   │
│       └─► ExpectationException: "Expected the drush      │
│           command '...' to fail, but it exited 0."        │
│                                                           │
│ Then the drush output should contain "no_such_module" ✓   │
└───────────────────────────────────────────────────────────┘
```

## Dependencies

Requires the `drushResult()` method added to `drupal/drupal-driver` in [jhedstrom/DrupalDriver#376](https://github.com/jhedstrom/DrupalDriver/pull/376). That API landed on `master` but `v3.2.0` has not been published yet, so `composer.json` temporarily pins the dependency to `dev-master as 3.2.0`. Once `v3.2.0` is released the pin will be replaced with `^3.2`.
