### PR TITLE
[#672] Added email attachment assertion steps to 'MailContext'.

### DIFF
--- a/STEPS.md
+++ b/STEPS.md
@@ -933,6 +933,63 @@ Assert mail to a recipient with a subject has been sent.
 </details>
 
 <details>
+  <summary><code>@Then (a )(an )(e)mail(s) should have been sent with the attachment(s) :attachments</code></summary>
+
+<br/>
+Assert mail with an attachment has been sent during the scenario. 
+<br/><br/>
+
+```gherkin
+  Then an email should have been sent with the attachment "invoice.pdf"
+  Then an email should have been sent with the attachments "invoice.pdf,terms.pdf"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then (a )(an )(e)mail(s) should have been sent to :to with the attachment(s) :attachments</code></summary>
+
+<br/>
+Assert mail to a recipient with an attachment has been sent. 
+<br/><br/>
+
+```gherkin
+  Then an email should have been sent to "user@example.com" with the attachment "invoice.pdf"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then (a )(an )(e)mail(s) should have been sent with the subject :subject and the attachment(s) :attachments</code></summary>
+
+<br/>
+Assert mail with a subject and an attachment has been sent. 
+<br/><br/>
+
+```gherkin
+  Then an email should have been sent with the subject "Invoice" and the attachment "invoice.pdf"
+
+```
+
+</details>
+
+<details>
+  <summary><code>@Then (a )(an )(e)mail(s) should have been sent to :to with the subject :subject and the attachment(s) :attachments</code></summary>
+
+<br/>
+Assert mail to a recipient with a subject and an attachment has been sent. 
+<br/><br/>
+
+```gherkin
+  Then an email should have been sent to "user@example.com" with the subject "Invoice" and the attachments "invoice.pdf,terms.pdf"
+
+```
+
+</details>
+
+<details>
   <summary><code>@Then the following new (e)mail(s) should have been sent:</code></summary>
 
 <br/>

--- a/src/Drupal/DrupalExtension/Context/MailContext.php
+++ b/src/Drupal/DrupalExtension/Context/MailContext.php
@@ -160,6 +160,55 @@ class MailContext extends RawMailContext {
   }
 
   /**
+   * Assert mail with an attachment has been sent during the scenario.
+   *
+   * @code
+   *   Then an email should have been sent with the attachment "invoice.pdf"
+   *   Then an email should have been sent with the attachments "invoice.pdf,terms.pdf"
+   * @endcode
+   */
+  #[Then('(a )(an )(e)mail(s) should have been sent with the attachment(s) :attachments')]
+  public function mailAssertHasBeenSentWithAttachments(string $attachments): void {
+    $this->assertMailWithAttachments('', '', $attachments);
+  }
+
+  /**
+   * Assert mail to a recipient with an attachment has been sent.
+   *
+   * @code
+   *   Then an email should have been sent to "user@example.com" with the attachment "invoice.pdf"
+   * @endcode
+   */
+  #[Then('(a )(an )(e)mail(s) should have been sent to :to with the attachment(s) :attachments')]
+  public function mailAssertHasBeenSentToWithAttachments(string $to, string $attachments): void {
+    $this->assertMailWithAttachments($to, '', $attachments);
+  }
+
+  /**
+   * Assert mail with a subject and an attachment has been sent.
+   *
+   * @code
+   *   Then an email should have been sent with the subject "Invoice" and the attachment "invoice.pdf"
+   * @endcode
+   */
+  #[Then('(a )(an )(e)mail(s) should have been sent with the subject :subject and the attachment(s) :attachments')]
+  public function mailAssertHasBeenSentWithSubjectAndAttachments(string $subject, string $attachments): void {
+    $this->assertMailWithAttachments('', $subject, $attachments);
+  }
+
+  /**
+   * Assert mail to a recipient with a subject and an attachment has been sent.
+   *
+   * @code
+   *   Then an email should have been sent to "user@example.com" with the subject "Invoice" and the attachments "invoice.pdf,terms.pdf"
+   * @endcode
+   */
+  #[Then('(a )(an )(e)mail(s) should have been sent to :to with the subject :subject and the attachment(s) :attachments')]
+  public function mailAssertHasBeenSentToWithSubjectAndAttachments(string $to, string $subject, string $attachments): void {
+    $this->assertMailWithAttachments($to, $subject, $attachments);
+  }
+
+  /**
    * Assert new mail has been sent since the last mail check.
    *
    * @code
@@ -424,6 +473,7 @@ class MailContext extends RawMailContext {
       'subject' => $this->getRandom()->name(20),
       'to' => $this->getRandom()->name(10) . '@anonexample.com',
       'langcode' => '',
+      'attachments' => '',
     ];
 
     foreach ($fields->getRowsHash() as $field => $value) {
@@ -436,7 +486,43 @@ class MailContext extends RawMailContext {
       throw new \RuntimeException(sprintf('The active Drupal driver "%s" does not support sending mail.', $driver::class));
     }
 
-    $driver->mailSend($mail['body'], $mail['subject'], $mail['to'], $mail['langcode']);
+    $driver->mailSend($mail['body'], $mail['subject'], $mail['to'], $mail['langcode'], $this->buildAttachments($mail['attachments']));
+  }
+
+  /**
+   * Parse a comma-separated list of attachment filenames.
+   *
+   * @param string $attachments
+   *   A comma-separated list of attachment filenames.
+   *
+   * @return array<int, string>
+   *   The individual filenames, trimmed and with empty entries removed.
+   */
+  protected function parseAttachmentNames(string $attachments): array {
+    return array_values(array_filter(array_map('trim', explode(',', $attachments)), static fn(string $filename): bool => $filename !== ''));
+  }
+
+  /**
+   * Build mail attachment definitions from a list of filenames.
+   *
+   * @param string $attachments
+   *   A comma-separated list of attachment filenames.
+   *
+   * @return array<int, array<string, string>>
+   *   Attachment definitions following Drupal's mail attachment shape.
+   */
+  protected function buildAttachments(string $attachments): array {
+    $definitions = [];
+
+    foreach ($this->parseAttachmentNames($attachments) as $filename) {
+      $definitions[] = [
+        'filecontent' => $filename,
+        'filename' => $filename,
+        'filemime' => 'text/plain',
+      ];
+    }
+
+    return $definitions;
   }
 
   /**
@@ -455,6 +541,25 @@ class MailContext extends RawMailContext {
     $expected = $expectedMailTable->getHash();
     $actual = array_values($this->getMail(['to' => $to, 'subject' => $subject], TRUE));
     $this->compareMessages($actual, $expected);
+  }
+
+  /**
+   * Assert at least one sent mail matches the filters and carries attachments.
+   *
+   * @param string $to
+   *   Recipient filter, or an empty string to match any recipient.
+   * @param string $subject
+   *   Subject filter, or an empty string to match any subject.
+   * @param string $attachments
+   *   A comma-separated list of attachment filenames that must all be present.
+   */
+  protected function assertMailWithAttachments(string $to, string $subject, string $attachments): void {
+    $filenames = $this->parseAttachmentNames($attachments);
+    $matching = $this->getMail(['to' => $to, 'subject' => $subject], FALSE, NULL, $filenames);
+
+    if (count($matching) === 0) {
+      throw new ExpectationException(sprintf('No mail matching the given criteria was sent with the attachment(s): "%s".', implode('", "', $filenames)), $this->getSession()->getDriver());
+    }
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Context/MailContext.php
+++ b/src/Drupal/DrupalExtension/Context/MailContext.php
@@ -499,7 +499,7 @@ class MailContext extends RawMailContext {
    *   The individual filenames, trimmed and with empty entries removed.
    */
   protected function parseAttachmentNames(string $attachments): array {
-    return array_values(array_filter(array_map('trim', explode(',', $attachments)), static fn(string $filename): bool => $filename !== ''));
+    return array_values(array_filter(array_map(trim(...), explode(',', $attachments)), static fn(string $filename): bool => $filename !== ''));
   }
 
   /**

--- a/src/Drupal/DrupalExtension/Context/MailContext.php
+++ b/src/Drupal/DrupalExtension/Context/MailContext.php
@@ -555,6 +555,11 @@ class MailContext extends RawMailContext {
    */
   protected function assertMailWithAttachments(string $to, string $subject, string $attachments): void {
     $filenames = $this->parseAttachmentNames($attachments);
+
+    if ($filenames === []) {
+      throw new ExpectationException('At least one attachment name must be provided.', $this->getSession()->getDriver());
+    }
+
     $matching = $this->getMail(['to' => $to, 'subject' => $subject], FALSE, NULL, $filenames);
 
     if (count($matching) === 0) {

--- a/src/Drupal/DrupalExtension/Context/RawMailContext.php
+++ b/src/Drupal/DrupalExtension/Context/RawMailContext.php
@@ -55,13 +55,15 @@ class RawMailContext extends RawDrupalContext {
    *   Whether to ignore previously seen mail.
    * @param null|int $index
    *   A particular mail to return, e.g. 0 for first or -1 for last.
+   * @param array<int, string> $attachments
+   *   Filenames that each returned mail must include as attachments.
    *
    * @return array<int, array<string, mixed>>|array<string, mixed>
    *   An array of mail messages keyed by index, or a single mail message
    *   array when '$index' is specified. Each item follows Drupal's
    *   'MailInterface::mail()' shape ('to', 'subject', 'body', etc.).
    */
-  protected function getMail(array $criteria = [], bool $new = FALSE, ?int $index = NULL) {
+  protected function getMail(array $criteria = [], bool $new = FALSE, ?int $index = NULL, array $attachments = []) {
     $messages = $this->getMailManager()->getMail();
     $previous_count = $this->mailMessageCount;
     $this->mailMessageCount = count($messages);
@@ -74,6 +76,11 @@ class RawMailContext extends RawDrupalContext {
     // Filter messages based on $matches; keep only mail where each field
     // mentioned in $filters contains the value specified for that field.
     $messages = array_values(array_filter($messages, fn(array $message): bool => $this->matchMessage($message, $criteria)));
+
+    // Further filter by required attachments, when specified.
+    if ($attachments !== []) {
+      $messages = array_values(array_filter($messages, fn(array $message): bool => $this->messageHasAttachments($message, $attachments)));
+    }
 
     // Return an individual mail if specified by an index.
     if (is_null($index) || count($messages) === 0) {
@@ -102,6 +109,31 @@ class RawMailContext extends RawDrupalContext {
     foreach ($criteria as $field => $value) {
       // Case insensitive.
       if (stripos((string) $message[$field], (string) $value) === FALSE) {
+        return FALSE;
+      }
+    }
+
+    return TRUE;
+  }
+
+  /**
+   * Determine if a mail carries all the given attachments.
+   *
+   * @param array<string, mixed> $message
+   *   The mail message as an associative array of mail fields.
+   * @param array<int, string> $filenames
+   *   Attachment filenames that must all be present on the message.
+   *
+   * @return bool
+   *   Whether the mail message includes every requested attachment.
+   */
+  protected function messageHasAttachments(array $message, array $filenames): bool {
+    $params = $message['params'] ?? [];
+    $attachments = is_array($params) ? ($params['attachments'] ?? []) : [];
+    $attached = is_array($attachments) ? array_column($attachments, 'filename') : [];
+
+    foreach ($filenames as $filename) {
+      if (!in_array($filename, $attached, TRUE)) {
         return FALSE;
       }
     }

--- a/tests/behat/features/mail.feature
+++ b/tests/behat/features/mail.feature
@@ -279,3 +279,58 @@ Feature: MailContext
     Then the following new email should have been sent:
       | body        |
       | second body |
+
+  @test-drupal @api
+  Scenario: Assert "Then an email should have been sent with the attachment :attachments" passes
+    When I send the following email:
+      | to          | fred@example.com |
+      | subject     | Invoice          |
+      | body        | See attached     |
+      | attachments | invoice.pdf      |
+    Then an email should have been sent with the attachment "invoice.pdf"
+    And an email should have been sent to "fred@example.com" with the attachment "invoice.pdf"
+    And an email should have been sent with the subject "Invoice" and the attachment "invoice.pdf"
+    And an email should have been sent to "fred@example.com" with the subject "Invoice" and the attachment "invoice.pdf"
+
+  @test-drupal @api
+  Scenario: Assert "Then an email should have been sent with the attachments :attachments" passes for multiple attachments
+    When I send the following email:
+      | to          | jane@example.com      |
+      | subject     | Documents             |
+      | attachments | invoice.pdf,terms.pdf |
+    Then an email should have been sent with the attachments "invoice.pdf,terms.pdf"
+    And an email should have been sent to "jane@example.com" with the subject "Documents" and the attachments "terms.pdf,invoice.pdf"
+
+  @test-drupal @api
+  Scenario: Assert "Then an email should have been sent with the attachment :attachments" fails when the attachment is missing
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      When I send the following mail:
+        | to          | fred@example.com |
+        | subject     | Invoice          |
+        | attachments | invoice.pdf      |
+      Then an email should have been sent with the attachment "missing.pdf"
+      """
+    When I run behat with drupal profile
+    Then it should fail with an error:
+      """
+      No mail matching the given criteria was sent with the attachment(s): "missing.pdf".
+      """
+
+  @test-drupal @api
+  Scenario: Assert "Then an email should have been sent to :to with the attachment :attachments" fails when the recipient does not match
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      When I send the following mail:
+        | to          | fred@example.com |
+        | subject     | Invoice          |
+        | attachments | invoice.pdf      |
+      Then an email should have been sent to "nobody@example.com" with the attachment "invoice.pdf"
+      """
+    When I run behat with drupal profile
+    Then it should fail with an error:
+      """
+      No mail matching the given criteria was sent with the attachment(s): "invoice.pdf".
+      """

--- a/tests/behat/features/mail.feature
+++ b/tests/behat/features/mail.feature
@@ -334,3 +334,19 @@ Feature: MailContext
       """
       No mail matching the given criteria was sent with the attachment(s): "invoice.pdf".
       """
+
+  @test-drupal @api
+  Scenario: Assert "Then an email should have been sent with the attachment :attachments" fails when no attachment name is given
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api":
+      """
+      When I send the following mail:
+        | to      | fred@example.com |
+        | subject | Invoice          |
+      Then an email should have been sent with the attachment ""
+      """
+    When I run behat with drupal profile
+    Then it should fail with an error:
+      """
+      At least one attachment name must be provided.
+      """

--- a/tests/phpunit/src/RawMailContextTest.php
+++ b/tests/phpunit/src/RawMailContextTest.php
@@ -29,6 +29,11 @@ class RawMailContextTest extends TestCase {
   protected \ReflectionMethod $matchMessage;
 
   /**
+   * Reflection method for messageHasAttachments().
+   */
+  protected \ReflectionMethod $messageHasAttachments;
+
+  /**
    * Reflection method for sortMessages().
    */
   protected \ReflectionMethod $sortMessages;
@@ -56,6 +61,7 @@ class RawMailContextTest extends TestCase {
     $this->context->setMink($mink);
 
     $this->matchMessage = new \ReflectionMethod(RawMailContext::class, 'matchMessage');
+    $this->messageHasAttachments = new \ReflectionMethod(RawMailContext::class, 'messageHasAttachments');
     $this->sortMessages = new \ReflectionMethod(RawMailContext::class, 'sortMessages');
     $this->compareMessages = new \ReflectionMethod(RawMailContext::class, 'compareMessages');
     $this->assertMessageCount = new \ReflectionMethod(RawMailContext::class, 'assertMessageCount');
@@ -108,6 +114,56 @@ class RawMailContextTest extends TestCase {
       FALSE,
       ['to' => 'alice@example.com', 'subject' => 'hello'],
       ['to' => 'alice@example.com', 'subject' => 'goodbye'],
+    ];
+  }
+
+  /**
+   * Tests that messageHasAttachments() detects required attachments.
+   *
+   * @param bool $expected
+   *   The expected result.
+   * @param array<string, mixed> $message
+   *   The mail message data.
+   * @param array<int, string> $filenames
+   *   The attachment filenames that must all be present.
+   */
+  #[DataProvider('dataProviderMessageHasAttachments')]
+  public function testMessageHasAttachments(bool $expected, array $message, array $filenames): void {
+    $result = $this->messageHasAttachments->invoke($this->context, $message, $filenames);
+    $this->assertSame($expected, $result);
+  }
+
+  /**
+   * Data provider for testMessageHasAttachments().
+   */
+  public static function dataProviderMessageHasAttachments(): \Iterator {
+    yield 'empty request matches anything' => [TRUE, ['params' => ['attachments' => []]], []];
+    yield 'no params key' => [FALSE, ['to' => 'alice@example.com'], ['invoice.pdf']];
+    yield 'no attachments key' => [FALSE, ['params' => []], ['invoice.pdf']];
+    yield 'single attachment present' => [
+      TRUE, ['params' => ['attachments' => [['filename' => 'invoice.pdf']]]], ['invoice.pdf'],
+    ];
+    yield 'single attachment missing' => [
+      FALSE, ['params' => ['attachments' => [['filename' => 'invoice.pdf']]]], ['terms.pdf'],
+    ];
+    yield 'multiple attachments all present' => [
+      TRUE,
+      ['params' => ['attachments' => [['filename' => 'invoice.pdf'], ['filename' => 'terms.pdf']]]],
+      ['invoice.pdf', 'terms.pdf'],
+    ];
+    yield 'multiple attachments one missing' => [
+      FALSE,
+      ['params' => ['attachments' => [['filename' => 'invoice.pdf']]]],
+      ['invoice.pdf', 'terms.pdf'],
+    ];
+    yield 'attachment match is case sensitive' => [
+      FALSE, ['params' => ['attachments' => [['filename' => 'Invoice.pdf']]]], ['invoice.pdf'],
+    ];
+    yield 'non-array attachments treated as none' => [
+      FALSE, ['params' => ['attachments' => 'invoice.pdf']], ['invoice.pdf'],
+    ];
+    yield 'attachment entry without filename ignored' => [
+      FALSE, ['params' => ['attachments' => [['filemime' => 'text/plain']]]], ['invoice.pdf'],
     ];
   }
 


### PR DESCRIPTION
Closes #672

## Summary

Adds four `#[Then]` step definitions to `MailContext` for asserting that a sent email carries specific attachment(s), optionally filtered by recipient and/or subject. Extends the `When I send the following (e)mail:` step with an `attachments` table column so tests can send mails with attachments in the first place. Attachment filtering in `RawMailContext::getMail()` is backed by a new `messageHasAttachments()` helper that reads `params['attachments'][*]['filename']`.

## Changes

**`MailContext.php`**
- Added `mailAssertHasBeenSentWithAttachments()`, `mailAssertHasBeenSentToWithAttachments()`, `mailAssertHasBeenSentWithSubjectAndAttachments()`, and `mailAssertHasBeenSentToWithSubjectAndAttachments()` - four `#[Then]` steps covering all combinations of optional `to` and `subject` filters with a required `attachments` argument.
- Added `parseAttachmentNames()` helper that splits a comma-separated attachment string into trimmed, non-empty filenames.
- Added `buildAttachments()` helper that converts parsed filenames into Drupal mail attachment definitions (`filecontent`, `filename`, `filemime`).
- Added `assertMailWithAttachments()` protected method that guards against an empty filename list and delegates to `getMail()` with the new `$attachments` parameter, throwing `ExpectationException` on no match.
- Extended `When I send the following (e)mail:` to accept an `attachments` table column, passing the built attachment array to `driver->mailSend()` as the new fifth argument.

**`RawMailContext.php`**
- Extended `getMail()` with an optional `array $attachments` parameter that, when non-empty, filters the message list through the new `messageHasAttachments()` helper.
- Added `messageHasAttachments()` which checks that every requested filename is present in `$message['params']['attachments'][*]['filename']`, returning `false` for non-array `params` or `attachments` values.

**`tests/behat/features/mail.feature`**
- Added two positive BDD scenarios (single attachment, multiple comma-separated attachments) and three negative scenarios (missing attachment, wrong recipient, empty attachment name) covering all new step phrasings.

**`tests/phpunit/src/RawMailContextTest.php`**
- Added `testMessageHasAttachments()` with a `dataProviderMessageHasAttachments()` data provider covering ten cases: empty request, missing `params` key, missing `attachments` key, single present/missing, multiple all-present/one-missing, case sensitivity, non-array attachments, and attachment entry without `filename`.

**`STEPS.md`**
- Regenerated to document the four new step definitions with usage examples.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added email attachment assertion steps for Behat scenarios, enabling verification that sent emails include specific attachments with optional recipient and subject filtering.

* **Tests**
  * Expanded test coverage for email attachment validation, including single/multiple attachments and error handling scenarios.

* **Documentation**
  * Updated step definitions documentation with new attachment-based email assertion steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->