### PR TITLE
[#536] Added best-practice docs and a tested example for module-shipped Behat contexts.

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -147,6 +147,9 @@ drupal:
         - Drupal\DrupalExtension\Context\MailContext
         - Drupal\DrupalExtension\Context\RandomContext
         - Drupal\DrupalExtension\Context\MappingContext
+        # Example of a context shipped by a module — see "Shipping contexts in
+        # a module" in docs/contexts.md.
+        - Drupal\Tests\behat_test\Behat\Context\ExampleContext
         # Helper contexts for test execution and reporting.
         - FeatureContext
         - BehatCliContext

--- a/composer.json
+++ b/composer.json
@@ -107,6 +107,11 @@
             "Drupal\\MinkExtension": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Drupal\\Tests\\behat_test\\": "tests/behat/fixtures/drupal/modules/behat_test/tests/src/"
+        }
+    },
     "config": {
         "allow-plugins": {
             "composer/installers": true,

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -196,7 +196,7 @@ like any other context.
 Place the classes under the module's `tests/src/` directory - the PSR-4
 root Drupal maps to the `Drupal\Tests\{module}\` namespace:
 
-```
+```text
 mymodule/
 ├── mymodule.info.yml
 ├── src/

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -183,3 +183,106 @@ follow this pattern - none of them inherit from `RawDrupalContext`.
 `Behat\Behat\Context\Context` directly and use no Mink session at all.
 A consumer can register them in any Behat suite, even one that does not
 load `Drupal\MinkExtension`.
+
+## Shipping contexts in a module
+
+A module can ship its own contexts so a project that enables the module
+can reuse its step definitions. The module ships plain context classes;
+the consuming project registers them in `behat.yml` explicitly, exactly
+like any other context.
+
+### Where to put them
+
+Place the classes under the module's `tests/src/` directory - the PSR-4
+root Drupal maps to the `Drupal\Tests\{module}\` namespace:
+
+```
+mymodule/
+├── mymodule.info.yml
+├── src/
+└── tests/
+    └── src/
+        └── Behat/
+            ├── Context/
+            │   └── ExampleContext.php
+            ├── ExampleContextTrait.php
+            └── features/
+                └── example.feature
+```
+
+Context classes go in `tests/src/Behat/Context/`, reusable helper traits
+in `tests/src/Behat/`, and example scenarios in `tests/src/Behat/features/`.
+
+### How to namespace them
+
+Follow Drupal's test namespace convention - a class at
+`tests/src/Behat/Context/ExampleContext.php` is
+`Drupal\Tests\{module}\Behat\Context\ExampleContext`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\mymodule\Behat\Context;
+
+use Behat\Step\When;
+use Drupal\DrupalExtension\Context\RawDrupalContext;
+
+class ExampleContext extends RawDrupalContext {
+
+  #[When('I visit the module custom login page')]
+  public function visitModuleCustomLoginPage(): void {
+    $this->visitPath('/custom-login');
+  }
+
+}
+```
+
+### How to autoload them
+
+Drupal's PHPUnit bootstrap registers the whole `Drupal\Tests\{module}\`
+namespace against the module's `tests/src/` directory, so the class above
+resolves automatically under PHPUnit (Drupal 10.3 and later). A standalone
+`behat` run does not load that bootstrap - it uses Composer's autoloader,
+and Behat's own `autoload` key supports PSR-0 only. Register the namespace
+once in the **project** `composer.json` so Behat can find it:
+
+```json
+"autoload-dev": {
+    "psr-4": {
+        "Drupal\\Tests\\mymodule\\": "web/modules/contrib/mymodule/tests/src/"
+    }
+}
+```
+
+Run `composer dump-autoload` afterwards, then register the context in the
+suite like any other:
+
+```yaml
+default:
+  suites:
+    default:
+      contexts:
+        - Drupal\Tests\mymodule\Behat\Context\ExampleContext
+```
+
+A module that wants to be usable with no project-side wiring can instead
+declare the same `psr-4` mapping in its **own** `composer.json` `autoload`
+block, at the cost of carrying a test namespace in its runtime autoloader.
+
+### What to ship
+
+A module rarely knows the business language of the project that installs
+it, so contexts that activate automatically tend not to fit. Ship building
+blocks the project can opt into instead:
+
+- A **trait** of helper methods, so projects can write their own steps on
+  top of yours.
+- An **example context** the project can register as-is, extend, or copy.
+- **Example scenarios** that prove the integration works.
+
+This extension's own test suite ships a working example: see the
+`behat_test` fixture module's `tests/src/Behat/` directory, autoloaded
+through `composer.json` and registered in the `drupal` profile of
+`behat.yml`.

--- a/tests/behat/features/module_context.feature
+++ b/tests/behat/features/module_context.feature
@@ -1,0 +1,9 @@
+Feature: Shipping contexts in a module
+  As a developer
+  I want a module-provided context to expose working steps
+  So that I can compose its step definitions in my own suite
+
+  @test-drupal @api
+  Scenario: Assert a context shipped by a module provides a working step
+    When I visit the module custom login page
+    Then I should see "Custom log in"

--- a/tests/behat/fixtures/drupal/modules/behat_test/tests/src/Behat/Context/ExampleContext.php
+++ b/tests/behat/fixtures/drupal/modules/behat_test/tests/src/Behat/Context/ExampleContext.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\behat_test\Behat\Context;
+
+use Behat\Step\When;
+use Drupal\DrupalExtension\Context\RawDrupalContext;
+use Drupal\Tests\behat_test\Behat\ExampleContextTrait;
+
+/**
+ * Demonstrates how a module ships its own Behat step definitions.
+ *
+ * Extends RawDrupalContext for the Drupal and Mink session helpers without
+ * inheriting any prebuilt steps, then layers a module-specific step on top of
+ * the shared trait helpers.
+ */
+class ExampleContext extends RawDrupalContext {
+
+  use ExampleContextTrait;
+
+  /**
+   * Visit the custom login form the module exposes.
+   *
+   * @code
+   * When I visit the module custom login page
+   * @endcode
+   */
+  #[When('I visit the module custom login page')]
+  public function visitModuleCustomLoginPage(): void {
+    $this->visitPath($this->getCustomLoginPath());
+  }
+
+}

--- a/tests/behat/fixtures/drupal/modules/behat_test/tests/src/Behat/ExampleContextTrait.php
+++ b/tests/behat/fixtures/drupal/modules/behat_test/tests/src/Behat/ExampleContextTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\behat_test\Behat;
+
+/**
+ * Reusable helpers shared by the module's Behat contexts.
+ *
+ * Keeping helper methods in a trait lets the step definitions stay thin and
+ * lets the same helpers back several contexts without duplication.
+ */
+trait ExampleContextTrait {
+
+  /**
+   * Return the path to the custom login form the module exposes.
+   *
+   * @return string
+   *   The internal path, relative to the site root.
+   */
+  protected function getCustomLoginPath(): string {
+    return '/custom-login';
+  }
+
+}


### PR DESCRIPTION
Closes #536

## Summary

This adds a "Shipping contexts in a module" section to `docs/contexts.md`, answering the three practical questions from the issue: where to place context classes inside a module, how to namespace them (following Drupal's `Drupal\Tests\{module}\` convention), and how to wire up autoloading for standalone Behat runs (PSR-4 in the project `composer.json`, because Behat's own `autoload` key is PSR-0 only). The doc is backed by a working example in the `behat_test` fixture module that is autoloaded through the extension's own `composer.json` and exercised in CI via a `@test-drupal` scenario.

## Changes

**Documentation**

- `docs/contexts.md`: new "Shipping contexts in a module" section covering directory layout (`tests/src/Behat/Context/`), namespacing (`Drupal\Tests\{module}\Behat\Context\`), autoloading (PSR-4 in project `composer.json`), and the recommended shipping pattern (trait + example context + example scenarios).

**Working example in the `behat_test` fixture module**

- `tests/behat/fixtures/drupal/modules/behat_test/tests/src/Behat/Context/ExampleContext.php`: a minimal context extending `RawDrupalContext`, using an attribute-style step and delegating helpers to the trait.
- `tests/behat/fixtures/drupal/modules/behat_test/tests/src/Behat/ExampleContextTrait.php`: shared helper trait (`getCustomLoginPath()`) demonstrating the trait-backed pattern the doc recommends.

**Wiring in the extension's own test setup**

- `composer.json`: `autoload-dev` PSR-4 entry mapping `Drupal\Tests\behat_test\` to the fixture module's `tests/src/` - exactly the step a consumer would take.
- `behat.yml`: `ExampleContext` registered in the `drupal` profile alongside the built-in contexts.
- `tests/behat/features/module_context.feature`: `@test-drupal @api` scenario asserting the module-provided step visits the expected page, run in CI under `--strict`.

## Before / After

```
Before (sub-context auto-discovery removed, no documented replacement):

  mymodule/
  └── src/
      └── (context classes with no agreed location or namespace)

  Consumer: no guidance on where to look or how to autoload.

After (documented convention, backed by a working example):

  mymodule/
  ├── src/
  └── tests/
      └── src/
          └── Behat/
              ├── Context/
              │   └── ExampleContext.php   (Drupal\Tests\mymodule\Behat\Context\)
              └── ExampleContextTrait.php  (Drupal\Tests\mymodule\Behat\)

  Consumer project composer.json:
  "autoload-dev": { "psr-4": { "Drupal\\Tests\\mymodule\\": "...tests/src/" } }

  Consumer behat.yml:
  contexts:
    - Drupal\Tests\mymodule\Behat\Context\ExampleContext
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide on shipping reusable Behat contexts from Drupal modules, including recommended layout, namespace conventions, and how to enable discoverability for standalone Behat runs.

* **Tests**
  * Added an example module Behat context and helper trait, plus a feature/scenario that visits a module custom login page and verifies expected content.
  * Updated Behat configuration to load the new module-provided context for the Drupal profile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->