### PR TITLE
[#873] Removed the legacy '<?name>' random token syntax.

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -531,6 +531,34 @@ store name.
 
 # Upgrading from 6.0 to 6.1
 
+## Random token: legacy `<?name>` syntax removed
+
+The `<?name>` random-token syntax, deprecated in 6.0, has been removed.
+Use the typed `[?name:type,args]` form instead. A bare `[?name]` is
+equivalent to the old `<?name>` - a `string` of length 10 - so the common
+case is a one-character-per-token change.
+
+| 6.0 (removed)    | 6.1              |
+| ---------------- | ---------------- |
+| `<?title>`       | `[?title]`       |
+| `<?user>`        | `[?user]`        |
+| `<?random_page>` | `[?random_page]` |
+
+Update every `<?name>` token in your `.feature` files to `[?name]`. The
+typed form also supports explicit generator types and arguments, such as
+`[?slug:machine_name,8]` or `[?age:int,18,65]`; see
+[Writing tests](docs/writing-tests.md#random-data) for the full list of
+built-in types.
+
+If you subclass `RandomContext`, note that its interface surface shrank: it
+no longer implements `ParametersAwareInterface` or `DeprecationInterface`
+and is now a bare `Behat\Behat\Context\Context`. The
+`transformVariablesLegacy()` and `transformTableLegacy()` methods are gone;
+`transformVariables()` / `transformTable()` handle the `[?...]` form. If
+your subclass relied on the inherited `getParameter()` accessor, add
+`use ParametersTrait;` together with `implements ParametersAwareInterface`
+to restore it.
+
 ## `Before/AfterEntityCreate` hooks fan out to every entity create path
 
 In 6.0 the `Before/AfterEntityCreateScope` hooks (registered via the

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -132,12 +132,12 @@ cached value within a scenario:
 | `[?title]`               | `title:string:10`   |
 | `[?title:string]`        | `title:string:10`   |
 | `[?title:string,10]`     | `title:string:10`   |
-| `<?title>` (legacy)      | `title:string:10`   |
 | `[?title:string,8]`      | `title:string:8`    |
 | `[?title:int]`           | `title:int:0,...`   |
 
-So a feature mid-migration from `<?title>` to `[?title]` resolves both
-literals to the same string, letting you swap one usage at a time.
+This lets you reference one generated value from several steps:
+`[?title]`, `[?title:string]`, and `[?title:string,10]` all resolve to
+the same string throughout a scenario.
 
 ### Custom types
 
@@ -162,22 +162,6 @@ class CustomRandomContext extends RandomContext {
 
 Register `CustomRandomContext` in `behat.yml` instead of `RandomContext`,
 then use `[?primary:phone]` in scenarios.
-
-### Legacy `<?token>` syntax
-
-The original `<?token>` form is still accepted but deprecated. Each
-unique legacy literal triggers a one-time `[Deprecation]` notice on
-`STDERR` pointing at the equivalent `[?token]` replacement. Suppress
-notices with the `suppress_deprecations` configuration key or the
-`BEHAT_DRUPALEXTENSION_SUPPRESS_DEPRECATIONS` environment variable -
-see [Configuration](configuration.md).
-
-The legacy form is processed by separate `Transform` methods on
-`RandomContext` (`transformVariablesLegacy()` /
-`transformTableLegacy()`) which exist purely to host the deprecated
-behaviour. They will be removed together once the legacy form is
-dropped, leaving only the modern `transformVariables()` /
-`transformTable()` pair.
 
 ## Mappings
 

--- a/src/Drupal/DrupalExtension/Context/RandomContext.php
+++ b/src/Drupal/DrupalExtension/Context/RandomContext.php
@@ -11,9 +11,6 @@ use Behat\Hook\AfterScenario;
 use Behat\Hook\BeforeScenario;
 use Behat\Transformation\Transform;
 use Drupal\Component\Utility\Random;
-use Drupal\DrupalExtension\DeprecationInterface;
-use Drupal\DrupalExtension\DeprecationTrait;
-use Drupal\DrupalExtension\ParametersAwareInterface;
 
 /**
  * Transforms tokens in step text and tables into random values.
@@ -22,32 +19,19 @@ use Drupal\DrupalExtension\ParametersAwareInterface;
  * driver - so it can be registered in any Behat suite, including ones
  * that load neither 'Drupal\MinkExtension' nor 'Drupal\DrupalExtension'.
  *
- * Two token forms are supported:
- *
- *   '[?<name>:<type>[,<args>]]' - identity, type, and optional type args.
- *   '<?<name>>'                 - legacy, deprecated; equivalent to
- *                                 '[?<name>:string,10]'.
- *
- * The two forms are processed by separate Transform methods - the modern
- * pair handles '[?...]', the '*Legacy' pair handles '<?...>' and emits
- * one '[Deprecation]' notice per unique legacy literal. Splitting the
- * transforms makes the deprecation surface obvious to anyone scanning
- * the class: every method on the legacy side will be removed together.
+ * Tokens take the form '[?<name>:<type>[,<args>]]', carrying an identity,
+ * a generator type, and optional type args.
  *
  * Each unique token (identity + type + args) resolves once per scenario
  * and re-using the same literal returns the same value. The default type
  * is 'string' with length '10', so '[?title]', '[?title:string]', and
- * the legacy '<?title>' all share the same cached value within a
- * scenario, easing incremental migration.
+ * '[?title:string,10]' all share the same cached value within a scenario.
  *
  * See 'docs/writing-tests.md' for the full list of built-in types.
  */
-class RandomContext implements Context, ParametersAwareInterface, DeprecationInterface {
-
-  use DeprecationTrait;
+class RandomContext implements Context {
 
   protected const BRACKET_REGEX = '#(\[\?[a-z0-9_]+(?::[^\]]+)?\])#i';
-  protected const LEGACY_REGEX = '#(\<\?[a-z0-9_]+\>)#i';
 
   /**
    * Token literal as it appears in the feature file -> canonical cache key.
@@ -63,8 +47,8 @@ class RandomContext implements Context, ParametersAwareInterface, DeprecationInt
    * Canonical cache key -> generated value.
    *
    * Canonical key is 'name:type:arg1,arg2,...' with defaults applied,
-   * so '[?title]', '[?title:string]', '[?title:string,10]' and the
-   * legacy '<?title>' collapse to the same key.
+   * so '[?title]', '[?title:string]' and '[?title:string,10]' collapse
+   * to the same key.
    *
    * @var array<string, string|int>
    */
@@ -76,55 +60,22 @@ class RandomContext implements Context, ParametersAwareInterface, DeprecationInt
   protected ?Random $random = NULL;
 
   /**
-   * Substitutes modern '[?...]' tokens inside a step argument.
+   * Substitutes '[?...]' tokens inside a step argument.
    *
    * @return string|array<int, string>|null
    *   The transformed message.
    */
   #[Transform('#(.*\[\?[a-z0-9_]+(?::[^\]]+)?\].*)#i')]
   public function transformVariables(string $message): string|array|null {
-    return $this->substituteWithRegex(self::BRACKET_REGEX, $message);
+    return $this->substitute($message);
   }
 
   /**
-   * Substitutes legacy '<?...>' tokens inside a step argument.
-   *
-   * Deprecated path: emits one '[Deprecation]' notice per unique legacy
-   * literal before substituting. Will be removed together with
-   * 'transformTableLegacy()' once the legacy form is dropped.
-   *
-   * @return string|array<int, string>|null
-   *   The transformed message.
-   */
-  #[Transform('#(.*\<\?[a-z0-9_]+\>.*)#i')]
-  public function transformVariablesLegacy(string $message): string|array|null {
-    $this->emitLegacyDeprecations($message);
-
-    return $this->substituteWithRegex(self::LEGACY_REGEX, $message);
-  }
-
-  /**
-   * Substitutes modern '[?...]' tokens inside table cells.
+   * Substitutes '[?...]' tokens inside table cells.
    */
   #[Transform('table:*')]
   public function transformTable(TableNode $table): TableNode {
-    return $this->substituteTableWithRegex(self::BRACKET_REGEX, $table);
-  }
-
-  /**
-   * Substitutes legacy '<?...>' tokens inside table cells.
-   *
-   * Deprecated path - see 'transformVariablesLegacy()'.
-   */
-  #[Transform('table:*')]
-  public function transformTableLegacy(TableNode $table): TableNode {
-    foreach ($table->getRows() as $row) {
-      foreach ($row as $cell) {
-        $this->emitLegacyDeprecations($cell);
-      }
-    }
-
-    return $this->substituteTableWithRegex(self::LEGACY_REGEX, $table);
+    return $this->substituteTable($table);
   }
 
   /**
@@ -155,10 +106,9 @@ class RandomContext implements Context, ParametersAwareInterface, DeprecationInt
         $haystack .= "\n" . $step_argument[0]->getTableAsString();
       }
 
-      preg_match_all(self::BRACKET_REGEX, $haystack, $modern);
-      preg_match_all(self::LEGACY_REGEX, $haystack, $legacy);
+      preg_match_all(self::BRACKET_REGEX, $haystack, $matches);
 
-      foreach (array_merge($modern[0], $legacy[0]) as $literal) {
+      foreach ($matches[0] as $literal) {
         $this->resolveLiteral($literal);
       }
     }
@@ -174,13 +124,10 @@ class RandomContext implements Context, ParametersAwareInterface, DeprecationInt
   }
 
   /**
-   * Substitutes every '$regex' match in '$message' via 'resolveLiteral()'.
-   *
-   * Modern and legacy paths share the substitution mechanics; only the
-   * regex that selects which literals to substitute differs.
+   * Substitutes every token match in '$message' via 'resolveLiteral()'.
    */
-  protected function substituteWithRegex(string $regex, string $message): string {
-    preg_match_all($regex, $message, $matches);
+  protected function substitute(string $message): string {
+    preg_match_all(self::BRACKET_REGEX, $message, $matches);
 
     if ($matches[0] === []) {
       return $message;
@@ -199,36 +146,15 @@ class RandomContext implements Context, ParametersAwareInterface, DeprecationInt
   }
 
   /**
-   * Applies 'substituteWithRegex()' across every cell in '$table'.
+   * Applies 'substitute()' across every cell in '$table'.
    */
-  protected function substituteTableWithRegex(string $regex, TableNode $table): TableNode {
+  protected function substituteTable(TableNode $table): TableNode {
     $rows = [];
     foreach ($table->getRows() as $row) {
-      $rows[] = array_map(fn (string $v): string => $this->substituteWithRegex($regex, $v), $row);
+      $rows[] = array_map(fn (string $v): string => $this->substitute($v), $row);
     }
 
     return new TableNode($rows);
-  }
-
-  /**
-   * Triggers a one-time deprecation notice per legacy literal in '$message'.
-   *
-   * The trait's process-wide dedup would already collapse repeated calls
-   * with the same message, but we dedup here as well so each unique
-   * literal incurs exactly one 'triggerDeprecation()' call regardless of
-   * how often it appears in a single argument.
-   */
-  protected function emitLegacyDeprecations(string $message): void {
-    preg_match_all(self::LEGACY_REGEX, $message, $matches);
-
-    foreach (array_unique($matches[0]) as $literal) {
-      $name = substr($literal, 2, -1);
-      $this->triggerDeprecation(sprintf(
-        'The "%s" token syntax is deprecated. Use "[?%s]" instead.',
-        $literal,
-        $name,
-      ));
-    }
   }
 
   /**
@@ -237,10 +163,7 @@ class RandomContext implements Context, ParametersAwareInterface, DeprecationInt
    * On first encounter the literal is parsed, normalised to a canonical
    * '(name, type, args)' tuple, the value is generated and stored under
    * the canonical key, and the literal is recorded in the parsing memo
-   * so future lookups are O(1). The legacy '<?...>' form does not
-   * trigger a deprecation here - that lives in 'emitLegacyDeprecations()'
-   * so the deprecation is fired by the legacy Transform methods, not by
-   * the shared resolution path that the modern form also calls.
+   * so future lookups are O(1).
    */
   protected function resolveLiteral(string $literal): string|int {
     if (isset($this->literals[$literal])) {
@@ -262,19 +185,10 @@ class RandomContext implements Context, ParametersAwareInterface, DeprecationInt
   /**
    * Parses a token literal into '[name, type, args]'.
    *
-   * The legacy '<?name>' form is folded into the same '(name, string, [])'
-   * tuple as a bare '[?name]' so the resolver does not need to special-case
-   * it. Deprecation emission is handled separately in the legacy Transform
-   * methods.
-   *
    * @return array{0: string, 1: string, 2: list<string>}
    *   Tuple of name, type, and args.
    */
   protected function parseToken(string $literal): array {
-    if (str_starts_with($literal, '<?')) {
-      return [substr($literal, 2, -1), 'string', []];
-    }
-
     $body = substr($literal, 2, -1);
     $colon = strpos($body, ':');
 

--- a/src/Drupal/DrupalExtension/Context/RandomContext.php
+++ b/src/Drupal/DrupalExtension/Context/RandomContext.php
@@ -151,7 +151,7 @@ class RandomContext implements Context {
   protected function substituteTable(TableNode $table): TableNode {
     $rows = [];
     foreach ($table->getRows() as $row) {
-      $rows[] = array_map(fn (string $v): string => $this->substitute($v), $row);
+      $rows[] = array_map($this->substitute(...), $row);
     }
 
     return new TableNode($rows);

--- a/tests/behat/features/random.feature
+++ b/tests/behat/features/random.feature
@@ -3,73 +3,12 @@ Feature: RandomContext functionality
   I want to generate random values in test scenarios
   So that I can avoid data collisions between test runs
 
-  # This will fail on the second scenario if random transforms are not functional.
+  # The first and second user scenarios together prove that token values are
+  # regenerated per scenario: the second registration only succeeds because the
+  # cache reset between scenarios produced a fresh '[?user]', avoiding a
+  # duplicate-account collision.
   @test-drupal @api @random
-  Scenario: Assert random variable transform passes for first user
-    Given I am at "/user/register"
-    And I fill in "Email address" with "<?user>@example.com"
-    And I fill in "Username" with "<?user>"
-    When I press "Create new account"
-    Then there should be a total of 1 email sent to "<?user>@example.com" with the subject "Account details for <?user>"
-
-  @test-drupal @api @random
-  Scenario: Assert random variable transform passes for second user
-    Given I am at "/user/register"
-    And I fill in "Email address" with "<?user>@example.com"
-    And I fill in "Username" with "<?user>"
-    When I press "Create new account"
-    Then there should be a total of 1 email sent to "<?user>@example.com" with the subject "Account details for <?user>"
-
-  @test-drupal @api @random
-  Scenario: Assert random variable transform in tables passes
-    Given I am viewing a page with the following fields:
-      | title | <?random_page> |
-    Then I should see the text "<?random_page>"
-
-  @test-drupal @api
-  Scenario: Assert random variable transform fails for undefined variable
-    Given some behat configuration
-    And scenario steps tagged with "@test-drupal @api @random":
-      """
-      Given I am on "/"
-      Then I should see the text "<?undefined_var>"
-      """
-    When I run behat with drupal profile
-    Then it should fail
-
-  # The two scenarios below prove that 'RandomContext' can run without the
-  # Drupal API driver. They register against the 'default' (blackbox) profile
-  # and rely on the placeholder transform happening before the assertion.
-
-  @test-blackbox @random
-  Scenario: Assert random variable transform passes in blackbox profile
-    Given some behat configuration
-    And scenario steps tagged with "@test-blackbox @random":
-      """
-      Given I am at "index.html"
-      Then I should not see the text "<?token>"
-      """
-    When I run behat
-    Then it should pass with:
-      """
-      1 scenario (1 passed)
-      """
-
-  @test-blackbox @random
-  Scenario: Assert random variable transform fails when token text expected
-    Given some behat configuration
-    And scenario steps tagged with "@test-blackbox @random":
-      """
-      Given I am at "index.html"
-      Then I should see the text "<?token>"
-      """
-    When I run behat
-    Then it should fail
-
-  # The scenarios below cover the modern '[?<name>:<type>[,<args>]]' form.
-
-  @test-drupal @api @random
-  Scenario: Assert "[?user]" transform passes for user creation
+  Scenario: Assert "[?user]" transform passes for first user
     Given I am at "/user/register"
     And I fill in "Email address" with "[?user]@example.com"
     And I fill in "Username" with "[?user]"
@@ -77,22 +16,39 @@ Feature: RandomContext functionality
     Then there should be a total of 1 email sent to "[?user]@example.com" with the subject "Account details for [?user]"
 
   @test-drupal @api @random
-  Scenario: Assert "[?random_page]" transform passes in tables
+  Scenario: Assert "[?user]" transform passes for second user
+    Given I am at "/user/register"
+    And I fill in "Email address" with "[?user]@example.com"
+    And I fill in "Username" with "[?user]"
+    When I press "Create new account"
+    Then there should be a total of 1 email sent to "[?user]@example.com" with the subject "Account details for [?user]"
+
+  @test-drupal @api @random
+  Scenario: Assert "[?random_page]" transform in tables passes
     Given I am viewing a page with the following fields:
       | title | [?random_page] |
     Then I should see the text "[?random_page]"
-
-  @test-drupal @api @random
-  Scenario: Assert legacy "<?title>" and modern "[?title]" share the same value
-    Given I am viewing a page with the following fields:
-      | title | <?title> |
-    Then I should see the text "[?title]"
 
   @test-drupal @api @random
   Scenario: Assert typed "[?slug:machine_name,8]" produces machine-name shape
     Given I am viewing a page with the following fields:
       | title | prefix-[?slug:machine_name,8]-suffix |
     Then I should see the text "[?slug:machine_name,8]"
+
+  @test-drupal @api
+  Scenario: Assert "[?undefined_var]" transform fails for absent value
+    Given some behat configuration
+    And scenario steps tagged with "@test-drupal @api @random":
+      """
+      Given I am on "/"
+      Then I should see the text "[?undefined_var]"
+      """
+    When I run behat with drupal profile
+    Then it should fail
+
+  # The blackbox scenarios below prove that 'RandomContext' can run without the
+  # Drupal API driver. They register against the 'default' (blackbox) profile
+  # and rely on the placeholder transform happening before the assertion.
 
   @test-blackbox @random
   Scenario: Assert "[?token]" transform passes in blackbox profile
@@ -131,34 +87,4 @@ Feature: RandomContext functionality
     Then it should pass with:
       """
       1 scenario (1 passed)
-      """
-
-  # Legacy '<?token>' deprecation assertions.
-
-  @test-blackbox @random
-  Scenario: Assert legacy "<?token>" triggers a deprecation
-    Given some behat configuration
-    And scenario steps tagged with "@test-blackbox @random":
-      """
-      Given I am at "index.html"
-      Then I should not see the text "<?token>"
-      """
-    When I run behat
-    Then the output should contain:
-      """
-      [Deprecation] The "<?token>" token syntax is deprecated. Use "[?token]" instead.
-      """
-
-  @test-blackbox @random
-  Scenario: Assert modern "[?token]" does not trigger a deprecation
-    Given some behat configuration
-    And scenario steps tagged with "@test-blackbox @random":
-      """
-      Given I am at "index.html"
-      Then I should not see the text "[?token]"
-      """
-    When I run behat
-    Then the output should not contain:
-      """
-      [Deprecation]
       """

--- a/tests/phpunit/src/RandomContextTest.php
+++ b/tests/phpunit/src/RandomContextTest.php
@@ -12,8 +12,6 @@ use Behat\Gherkin\Node\ScenarioNode;
 use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
 use Drupal\DrupalExtension\Context\RandomContext;
-use Drupal\DrupalExtension\DeprecationInterface;
-use Drupal\DrupalExtension\ParametersAwareInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -29,9 +27,9 @@ use PHPUnit\Framework\TestCase;
 class RandomContextTest extends TestCase {
 
   /**
-   * The context under test - a subclass that captures deprecations.
+   * The context under test.
    */
-  protected RecordingRandomContext $context;
+  protected RandomContext $context;
 
   /**
    * Reflection of the protected $values property (canonical key -> value).
@@ -47,13 +45,13 @@ class RandomContextTest extends TestCase {
    * {@inheritdoc}
    */
   protected function setUp(): void {
-    $this->context = new RecordingRandomContext();
+    $this->context = new RandomContext();
     $this->valuesProperty = new \ReflectionProperty(RandomContext::class, 'values');
     $this->literalsProperty = new \ReflectionProperty(RandomContext::class, 'literals');
   }
 
   /**
-   * Tests the bare-Behat structural promise of the rebase.
+   * Tests the bare-Behat structural promise of the class.
    *
    * 'RandomContext' must implement 'Behat\Behat\Context\Context' directly
    * with no parent class, so it can be loaded in suites that do not
@@ -62,16 +60,14 @@ class RandomContextTest extends TestCase {
   public function testImplementsBareBehatContextWithoutAncestors(): void {
     $context = new RandomContext();
     $this->assertInstanceOf(Context::class, $context);
-    $this->assertInstanceOf(ParametersAwareInterface::class, $context);
-    $this->assertInstanceOf(DeprecationInterface::class, $context);
     $this->assertSame([], class_parents($context));
   }
 
   /**
-   * Tests modern '[?...]' substitution via 'transformVariables()'.
+   * Tests '[?...]' substitution via 'transformVariables()'.
    *
    * @param string $message
-   *   The input message containing one or more modern tokens.
+   *   The input message containing one or more tokens.
    * @param string $pattern
    *   Regex the substituted output must match end-to-end.
    * @param int $expected_substitutions
@@ -88,9 +84,7 @@ class RandomContextTest extends TestCase {
   /**
    * Provides cases for testTransformVariablesSubstitutesTokens().
    *
-   * Modern-form inputs only - legacy '<?...>' is covered separately by
-   * 'testTransformVariablesLegacySubstitutesTokens()'. Pattern is anchored
-   * end-to-end so a wrongly-substituted output fails.
+   * Pattern is anchored end-to-end so a wrongly-substituted output fails.
    */
   public static function dataProviderTransformVariablesSubstitutesTokens(): \Iterator {
     yield 'bare token resolves to lowercase 10-char string' => [
@@ -131,59 +125,19 @@ class RandomContextTest extends TestCase {
   }
 
   /**
-   * Tests legacy '<?...>' substitution via 'transformVariablesLegacy()'.
-   *
-   * Asserts both that the substitution works and that exactly one
-   * deprecation message is captured per unique legacy literal.
-   *
-   * @param string $message
-   *   The input message containing legacy tokens.
-   * @param string $pattern
-   *   Regex the substituted output must match end-to-end.
-   * @param int $expected_deprecations
-   *   How many '[Deprecation]' notices should be captured.
-   */
-  #[DataProvider('dataProviderTransformVariablesLegacySubstitutesTokens')]
-  public function testTransformVariablesLegacySubstitutesTokens(string $message, string $pattern, int $expected_deprecations): void {
-    $output = $this->context->transformVariablesLegacy($message);
-    $this->assertIsString($output);
-    $this->assertMatchesRegularExpression($pattern, $output);
-    $this->assertCount($expected_deprecations, $this->context->capturedDeprecations);
-  }
-
-  /**
-   * Provides cases for testTransformVariablesLegacySubstitutesTokens().
-   */
-  public static function dataProviderTransformVariablesLegacySubstitutesTokens(): \Iterator {
-    yield 'single legacy token resolves and emits one deprecation' => [
-      'value: <?token>',
-      '/^value: [a-z0-9]{10}$/',
-      1,
-    ];
-    yield 'two distinct legacy tokens emit two deprecations' => [
-      '<?one> and <?two>',
-      '/^[a-z0-9]{10} and [a-z0-9]{10}$/',
-      2,
-    ];
-  }
-
-  /**
    * Tests that equivalent token forms collapse to the same canonical value.
    *
-   * Default 'string' / length '10' means '[?title]', '[?title:string]',
-   * '[?title:string,10]', and the legacy '<?title>' must all resolve to
-   * the same string within one scenario - this is the back-compat lever
-   * that lets users migrate one literal at a time.
+   * Default 'string' / length '10' means '[?title]', '[?title:string]'
+   * and '[?title:string,10]' all resolve to the same string within one
+   * scenario.
    */
   public function testEquivalentFormsShareTheSameValue(): void {
-    $message = '<?title> [?title] [?title:string] [?title:string,10]';
-    $modern = $this->context->transformVariables($message);
-    $this->assertIsString($modern);
-    $output = $this->context->transformVariablesLegacy($modern);
+    $message = '[?title] [?title:string] [?title:string,10]';
+    $output = $this->context->transformVariables($message);
     $this->assertIsString($output);
 
     $parts = explode(' ', $output);
-    $this->assertCount(4, $parts);
+    $this->assertCount(3, $parts);
     $this->assertSame([$parts[0]], array_unique($parts));
   }
 
@@ -264,9 +218,9 @@ class RandomContextTest extends TestCase {
   }
 
   /**
-   * Tests that 'transformTable()' substitutes modern tokens in cells.
+   * Tests that 'transformTable()' substitutes tokens in cells.
    */
-  public function testTransformTableSubstitutesModernTokensInCells(): void {
+  public function testTransformTableSubstitutesTokensInCells(): void {
     $table = new TableNode([
       ['title', 'value'],
       ['[?one]', '[?two]'],
@@ -279,25 +233,6 @@ class RandomContextTest extends TestCase {
     $this->assertMatchesRegularExpression('/^[a-z0-9]{10}$/', $rows[1][0]);
     $this->assertMatchesRegularExpression('/^[a-z0-9]{10}$/', $rows[1][1]);
     $this->assertNotSame($rows[1][0], $rows[1][1]);
-    $this->assertSame([], $this->context->capturedDeprecations);
-  }
-
-  /**
-   * Tests that 'transformTableLegacy()' substitutes and emits deprecations.
-   */
-  public function testTransformTableLegacySubstitutesAndDeprecates(): void {
-    $table = new TableNode([
-      ['title', 'value'],
-      ['<?one>', '<?two>'],
-    ]);
-
-    $transformed = $this->context->transformTableLegacy($table);
-    $rows = $transformed->getRows();
-
-    $this->assertSame(['title', 'value'], $rows[0]);
-    $this->assertMatchesRegularExpression('/^[a-z0-9]{10}$/', $rows[1][0]);
-    $this->assertMatchesRegularExpression('/^[a-z0-9]{10}$/', $rows[1][1]);
-    $this->assertCount(2, $this->context->capturedDeprecations);
   }
 
   /**
@@ -328,19 +263,15 @@ class RandomContextTest extends TestCase {
    * Provides cases for testBeforeScenarioCollectsTokens().
    */
   public static function dataProviderBeforeScenarioCollectsTokens(): \Iterator {
-    yield 'legacy token in step text' => [
-      ['token:string:10'],
-      [new StepNode('Given', 'a string <?token>', [], 1)],
-    ];
-    yield 'new bare token in step text' => [
+    yield 'bare token in step text' => [
       ['token:string:10'],
       [new StepNode('Given', 'a string [?token]', [], 1)],
     ];
-    yield 'mixed legacy and new with same name share one key' => [
+    yield 'bare and typed same name share one key' => [
       ['token:string:10'],
       [
-        new StepNode('Given', 'first <?token>', [], 1),
-        new StepNode('Then', 'second [?token]', [], 2),
+        new StepNode('Given', 'first [?token]', [], 1),
+        new StepNode('Then', 'second [?token:string,10]', [], 2),
       ],
     ];
     yield 'distinct names produce distinct keys' => [
@@ -354,55 +285,8 @@ class RandomContextTest extends TestCase {
     yield 'tokens in background and scenario are merged' => [
       ['from_background:string:10', 'from_scenario:string:10'],
       [new StepNode('Then', '[?from_scenario]', [], 2)],
-      [new StepNode('Given', '<?from_background>', [], 1)],
+      [new StepNode('Given', '[?from_background]', [], 1)],
     ];
-  }
-
-  /**
-   * Tests that legacy literals trigger one deprecation each.
-   *
-   * The trait's process-wide dedup means each unique message fires only
-   * once, so two uses of '<?token>' produce one notice but '<?one>' plus
-   * '<?two>' produce two. Deprecation is the legacy Transform method's
-   * responsibility - 'resolveLiteral()' must not fire on its own.
-   */
-  public function testLegacyTransformTriggersDeprecation(): void {
-    $this->context->transformVariablesLegacy('<?one> <?two> <?one>');
-    $messages = $this->context->capturedDeprecations;
-
-    $this->assertCount(2, $messages);
-    $this->assertStringContainsString('"<?one>" token syntax is deprecated', $messages[0]);
-    $this->assertStringContainsString('Use "[?one]" instead', $messages[0]);
-    $this->assertStringContainsString('"<?two>" token syntax is deprecated', $messages[1]);
-    $this->assertStringContainsString('Use "[?two]" instead', $messages[1]);
-  }
-
-  /**
-   * Tests that the modern Transform method never emits a deprecation.
-   */
-  public function testModernTransformDoesNotTriggerDeprecation(): void {
-    $this->context->transformVariables('[?one] [?two:int,1,9]');
-
-    $this->assertSame([], $this->context->capturedDeprecations);
-  }
-
-  /**
-   * Tests that scenario pre-resolution does not emit deprecations.
-   *
-   * The 'BeforeScenario' hook warms the cache via 'resolveLiteral()'; if
-   * deprecation lived there, every legacy literal in a feature would fire
-   * a notice before any step ran. The legacy Transform methods are the
-   * single source of deprecation emission.
-   */
-  public function testBeforeScenarioDoesNotTriggerDeprecation(): void {
-    $scope = $this->createScenarioScope([
-      new StepNode('Given', 'a string <?legacy>', [], 1),
-      new StepNode('Then', '[?modern]', [], 2),
-    ]);
-
-    $this->context->beforeScenarioSetVariables($scope);
-
-    $this->assertSame([], $this->context->capturedDeprecations);
   }
 
   /**
@@ -446,32 +330,6 @@ class RandomContextTest extends TestCase {
     $scope->method('getScenario')->willReturn($scenario);
 
     return $scope;
-  }
-
-}
-
-/**
- * Subclass that records deprecations instead of writing to 'STDERR'.
- *
- * 'DeprecationTrait::triggerDeprecation()' writes through 'fwrite(STDERR,
- * ...)' which sidesteps PHP output buffering, so capturing it from a
- * unit test is awkward. Overriding the method is the simplest hook.
- */
-// phpcs:ignore Drupal.Classes.ClassFileName.NoMatch
-class RecordingRandomContext extends RandomContext {
-
-  /**
-   * Deprecation messages captured during the test.
-   *
-   * @var list<string>
-   */
-  public array $capturedDeprecations = [];
-
-  /**
-   * {@inheritdoc}
-   */
-  public function triggerDeprecation(string $message): void {
-    $this->capturedDeprecations[] = $message;
   }
 
 }


### PR DESCRIPTION
Closes #873

## Summary

Removes the `<?name>` legacy random-token syntax from `RandomContext`, deprecated in 6.0.0 and scheduled for removal in 6.1.0. The typed `[?name:type,args]` form is now the only supported syntax. This also eliminates the `[Deprecation]` notices that `random.feature` printed on every CI run.

Because the legacy path was the class's only reason to implement `DeprecationInterface` and `ParametersAwareInterface`, both interfaces (and the `DeprecationTrait` use) have been removed. `RandomContext` is now a bare `Behat\Behat\Context\Context`. The shared `DeprecationTrait`/`DeprecationInterface` helper files are left untouched - they remain in use by the other 6.1 deprecation removals.

## Changes

**`src/Drupal/DrupalExtension/Context/RandomContext.php`** - Removed `LEGACY_REGEX`, `transformVariablesLegacy()`, `transformTableLegacy()`, `emitLegacyDeprecations()`, the `<?` branch in `parseToken()`, and the legacy pre-resolution in `beforeScenarioSetVariables()`. Dropped `ParametersAwareInterface`, `DeprecationInterface`, and `DeprecationTrait`. Renamed `substituteWithRegex()` / `substituteTableWithRegex()` to `substitute()` / `substituteTable()` (redundant regex parameter removed).

**`tests/phpunit/src/RandomContextTest.php`** - Removed the legacy-syntax and deprecation tests and the `RecordingRandomContext` capture subclass. Converted remaining data-provider cases to the `[?...]` form.

**`tests/behat/features/random.feature`** - Migrated every scenario to the `[?...]` form. Dropped legacy-syntax duplicates and deprecation-assertion scenarios while preserving cross-scenario reset, table, typed, blackbox, and undefined-variable coverage.

**`docs/writing-tests.md`** - Removed the legacy cache-equivalence row and the "Legacy `<?token>` syntax" section.

**`UPGRADING.md`** - Added a "6.0 to 6.1" removal entry with a before/after migration table.

## Before / After

```
Token syntax
  before:  [?name:type,args]  +  <?name>  (legacy, deprecated since 6.0)
  after:   [?name:type,args]  only

RandomContext class
  before:  class RandomContext implements Context,
                                        ParametersAwareInterface,
                                        DeprecationInterface {
             use DeprecationTrait;
             protected const LEGACY_REGEX = ...;
             transformVariablesLegacy() / transformTableLegacy()
             emitLegacyDeprecations()
             substituteWithRegex(string $regex, ...) / substituteTableWithRegex(string $regex, ...)
             parseToken(): handles <?name> branch

  after:   class RandomContext implements Context {
             substitute() / substituteTable()
             parseToken(): [?...] form only
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed support for the deprecated `<?name>` random token syntax. All feature files must be updated to use the modern `[?name]` syntax.

* **Documentation**
  * Updated guides and migration documentation with instructions for updating feature files. Includes details on the modern typed token format and available parameter options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->